### PR TITLE
Enabling simultaneous inversion of bed topography and surface height

### DIFF
--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -1245,6 +1245,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
         sacado_param_vec,
         f_out, W_op_out, dt);
     if(transposeJacobian) {
+      TEUCHOS_FUNC_TIME_MONITOR("Albany Transpose Jacobian");
       Albany::transpose(W_op_out);
     }
 

--- a/src/LandIce/evaluators/LandIce_UpdateZCoordinate.cpp
+++ b/src/LandIce/evaluators/LandIce_UpdateZCoordinate.cpp
@@ -11,4 +11,5 @@
 
 PHAL_INSTANTIATE_TEMPLATE_CLASS(LandIce::UpdateZCoordinateMovingTop)
 PHAL_INSTANTIATE_TEMPLATE_CLASS(LandIce::UpdateZCoordinateMovingBed)
+PHAL_INSTANTIATE_TEMPLATE_CLASS(LandIce::UpdateZCoordinateGivenTopAndBedSurfaces)
 

--- a/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
+++ b/src/LandIce/evaluators/LandIce_UpdateZCoordinate.hpp
@@ -30,7 +30,7 @@ public:
                              const Teuchos::RCP<Albany::Layouts>& dl);
 
   void postRegistrationSetup(typename Traits::SetupData /* d */,
-                             PHX::FieldManager<Traits>& /* vm */) {}
+                             PHX::FieldManager<Traits>& /* vm */);
 
   void evaluateFields(typename Traits::EvalData d);
 
@@ -64,7 +64,7 @@ public:
                              const Teuchos::RCP<Albany::Layouts>& dl);
 
   void postRegistrationSetup(typename Traits::SetupData /* d */,
-                             PHX::FieldManager<Traits>& /* vm */) {}
+                             PHX::FieldManager<Traits>& /* vm */);
 
   void evaluateFields(typename Traits::EvalData d);
 
@@ -86,6 +86,46 @@ private:
   PHX::MDField<ScalarOutT, Cell, Node>       topSurfaceOut;
   PHX::MDField<ScalarOutT, Cell, Node>       bedTopoOut;
 
+  double minH, rho_i, rho_w;
+  unsigned int numDims, numNodes;
+};
+
+
+template<typename EvalT, typename Traits>
+class UpdateZCoordinateGivenTopAndBedSurfaces : public PHX::EvaluatorWithBaseImpl<Traits>,
+                                   public PHX::EvaluatorDerived<EvalT, Traits>
+{
+public:
+
+  UpdateZCoordinateGivenTopAndBedSurfaces(const Teuchos::ParameterList& p,
+                             const Teuchos::RCP<Albany::Layouts>& dl);
+
+  void postRegistrationSetup(typename Traits::SetupData /* d */,
+                             PHX::FieldManager<Traits>& /* vm */);
+
+  void evaluateFields(typename Traits::EvalData d);
+
+private:
+
+  using MeshScalarT = typename EvalT::MeshScalarT;
+
+  // Input:
+  PHX::MDField<const MeshScalarT, Cell, Node,Dim> coordVecIn;
+  PHX::MDField<const MeshScalarT, Cell, Node>     topSurfIn;
+  PHX::MDField<const MeshScalarT, Cell, Node>     bedTopoIn;
+
+  // Output:
+  PHX::MDField<MeshScalarT, Cell, Node>  H;
+  PHX::MDField<MeshScalarT, Cell, Node, Dim>  coordVecOut;
+
+  // InOut:
+  // output if isBedSurfParam == true
+  PHX::MDField<MeshScalarT, Cell, Node>        bedTopo;
+
+  // output if isBedSurfParam == false
+  PHX::MDField<MeshScalarT, Cell, Node>        topSurf;
+
+  bool isTopSurfParam, isBedTopoParam;
   double minH, rho_i, rho_w;
   unsigned int numDims, numNodes;
 };

--- a/src/LandIce/problems/LandIce_StokesFO.cpp
+++ b/src/LandIce/problems/LandIce_StokesFO.cpp
@@ -221,6 +221,7 @@ void StokesFO::setupEvaluatorRequests () {
     auto dof_name_auxiliary = "L2 Projected Boundary Laplacian";
 
     ss_build_interp_ev[ssName][dof_name_auxiliary][IReq::CELL_TO_SIDE] = true;
+    ss_build_interp_ev[ssName][dof_name_auxiliary][IReq::QP_VAL] = true;
     ss_build_interp_ev[ssName][field_name][IReq::GRAD_QP_VAL] = true;
   }
 }

--- a/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOThermoCoupled.hpp
@@ -135,19 +135,13 @@ constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   // Geometry
   // If the mesh depends on parameters AND the thickness is a parameter,
   // after gathering the coordinates, we modify the z coordinate of the mesh.
-  if (Albany::mesh_depends_on_parameters() && is_dist_param[ice_thickness_name]) {
+  bool require_old_coords=false;
+  if (Albany::mesh_depends_on_parameters() && (is_dist_param[ice_thickness_name])) {
+    require_old_coords=true;
     if(adjustBedTopo && !adjustSurfaceHeight) {
-      //----- Gather Coordinate Vector (ad hoc parameters)
-      p = Teuchos::rcp(new Teuchos::ParameterList("Gather Coordinate Vector"));
-
-      // Output:: Coordindate Vector at vertices
-      p->set<std::string>("Coordinate Vector Name", "Coord Vec Old");
-
-      ev = Teuchos::rcp(new PHAL::GatherCoordinateVector<EvalT,PHAL::AlbanyTraits>(*p,dl));
-      fm0.template registerEvaluator<EvalT>(ev);
-
       //------ Update Z Coordinate
       p = Teuchos::rcp(new Teuchos::ParameterList("Update Z Coordinate"));
+
       p->set<std::string>("Old Coords Name",  "Coord Vec Old");
       p->set<std::string>("New Coords Name",  Albany::coord_vec_name);
       p->set<std::string>("Thickness Name",   ice_thickness_name);
@@ -159,20 +153,12 @@ constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
       p->set<std::string>("Updated Bed Topography Name", bed_topography_name);
       p->set<Teuchos::ParameterList*>("Physical Parameter List", &params->sublist("LandIce Physical Parameters"));
 
-      ev = Teuchos::rcp(new UpdateZCoordinateMovingBed<EvalT,PHAL::AlbanyTraits>(*p, dl));
+      ev = Teuchos::rcp(new LandIce::UpdateZCoordinateMovingBed<EvalT,PHAL::AlbanyTraits>(*p, dl));
       fm0.template registerEvaluator<EvalT>(ev);
     } else if(adjustSurfaceHeight && !adjustBedTopo) {
-      //----- Gather Coordinate Vector (ad hoc parameters)
-      p = Teuchos::rcp(new Teuchos::ParameterList("Gather Coordinate Vector"));
-
-      // Output:: Coordindate Vector at vertices
-      p->set<std::string>("Coordinate Vector Name", "Coord Vec Old");
-
-      ev = Teuchos::rcp(new PHAL::GatherCoordinateVector<EvalT,PHAL::AlbanyTraits>(*p,dl));
-      fm0.template registerEvaluator<EvalT>(ev);
-
       //------ Update Z Coordinate
       p = Teuchos::rcp(new Teuchos::ParameterList("Update Z Coordinate"));
+
       p->set<std::string>("Old Coords Name",  "Coord Vec Old");
       p->set<std::string>("New Coords Name",  Albany::coord_vec_name);
       p->set<std::string>("Thickness Name",   ice_thickness_name);
@@ -180,13 +166,46 @@ constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
       p->set<std::string>("Bed Topography Name", bed_topography_name);
       p->set<Teuchos::ParameterList*>("Physical Parameter List", &params->sublist("LandIce Physical Parameters"));
 
-      ev = Teuchos::rcp(new UpdateZCoordinateMovingTop<EvalT,PHAL::AlbanyTraits>(*p, dl));
+      ev = Teuchos::rcp(new LandIce::UpdateZCoordinateMovingTop<EvalT,PHAL::AlbanyTraits>(*p, dl));
       fm0.template registerEvaluator<EvalT>(ev);
     } else {
           TEUCHOS_TEST_FOR_EXCEPTION(adjustBedTopo == adjustSurfaceHeight, std::logic_error, "Error! When the ice thickness is a parameter,\n "
               "either 'Adjust Bed Topography to Account for Thickness Changes' or\n"
               " 'Adjust Surface Height to Account for Thickness Changes' needs to be true.\n");
     }
+  }
+
+  // If the mesh depends on parameters AND the bed topography or the surface height are parameters,
+  // after gathering the coordinates, we modify the z coordinate of the mesh.
+  else if (Albany::mesh_depends_on_parameters() && (is_dist_param[surface_height_param_name]||is_dist_param[bed_topography_param_name])) {
+    //------ Update Z Coordinate
+    require_old_coords=true;
+    p = Teuchos::rcp(new Teuchos::ParameterList("Update Z Coordinate"));
+
+    p->set<std::string>("Old Coords Name",  "Coord Vec Old");
+    p->set<std::string>("New Coords Name",  Albany::coord_vec_name);
+    p->set<std::string>("Thickness Name",   ice_thickness_name);
+    p->set<std::string>("Top Surface Name", surface_height_name);
+    if(is_dist_param[surface_height_param_name])
+      p->set<std::string>("Top Surface Parameter Name", surface_height_param_name);
+    if(is_dist_param[bed_topography_param_name])
+      p->set<std::string>("Bed Topography Parameter Name", bed_topography_param_name);
+    p->set<std::string>("Bed Topography Name", bed_topography_name);
+    p->set<Teuchos::ParameterList*>("Physical Parameter List", &params->sublist("LandIce Physical Parameters"));
+
+    ev = Teuchos::rcp(new LandIce::UpdateZCoordinateGivenTopAndBedSurfaces<EvalT,PHAL::AlbanyTraits>(*p, dl));
+    fm0.template registerEvaluator<EvalT>(ev);
+  }
+
+  if(require_old_coords) {
+    //----- Gather Coordinate Vector (ad hoc parameters)
+    p = Teuchos::rcp(new Teuchos::ParameterList("Gather Coordinate Vector"));
+
+    // Output:: Coordindate Vector at vertices
+    p->set<std::string>("Coordinate Vector Name", "Coord Vec Old");
+
+    ev = Teuchos::rcp(new PHAL::GatherCoordinateVector<EvalT,PHAL::AlbanyTraits>(*p,dl));
+    fm0.template registerEvaluator<EvalT>(ev);
   } else {
     //----- Gather Coordinate Vector (general parameters)
     ev = evalUtils.constructGatherCoordinateVectorEvaluator();

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide.hpp
@@ -14,7 +14,7 @@ namespace PHAL {
  * \brief Response Description
  */
 template<typename EvalT, typename Traits, typename SourceScalarT, typename TargetScalarT>
-class ResponseSquaredL2DifferenceSideBase : public PHAL::SeparableScatterScalarResponse<EvalT,Traits>
+class ResponseSquaredL2DifferenceSideBase : public PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT,Traits>
 {
 public:
 
@@ -45,12 +45,13 @@ private:
   int fieldDim;
   std::vector<PHX::Device::size_type> dims;
 
-  bool target_value;
+  bool target_value, rmsScaling, extrudedParams;
   TargetScalarT target_value_val;
   RealType scaling;
 
   PHX::MDField<const SourceScalarT> sourceField;
   PHX::MDField<const TargetScalarT> targetField;
+  PHX::MDField<const RealType> rootMeanSquareField;
 
   PHX::MDField<const MeshScalarT,Side,QuadPoint,Dim,Dim>   metric;
   PHX::MDField<const MeshScalarT,Side,QuadPoint>   w_measure;
@@ -59,11 +60,12 @@ private:
   std::vector<ScalarT> diff_1;
   std::vector<std::vector<ScalarT>> diff_2;
 
+  Teuchos::RCP<const CellTopologyData> cell_topo;
 };
 
 //-- SourceScalarT = ScalarT
 template<typename EvalT, typename Traits>
-using ResponseSquaredL2DifferenceSideSST_TST  = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ScalarT,typename EvalT::ScalarT>;
+using ResponseSquaredL2DifferenceSideSST_TST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ScalarT,typename EvalT::ScalarT>;
 
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSST_TMST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ScalarT,typename EvalT::MeshScalarT>;
@@ -71,9 +73,12 @@ using ResponseSquaredL2DifferenceSideSST_TMST = ResponseSquaredL2DifferenceSideB
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSST_TPST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ScalarT,typename EvalT::ParamScalarT>;
 
+template<typename EvalT, typename Traits>
+using ResponseSquaredL2DifferenceSideSST_TRT = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ScalarT,RealType>;
+
 //-- SourceScalarT = ParamScalarT
 template<typename EvalT, typename Traits>
-using ResponseSquaredL2DifferenceSideSPST_TST  = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ParamScalarT,typename EvalT::ScalarT>;
+using ResponseSquaredL2DifferenceSideSPST_TST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ParamScalarT,typename EvalT::ScalarT>;
 
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSPST_TMST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ParamScalarT,typename EvalT::MeshScalarT>;
@@ -81,15 +86,21 @@ using ResponseSquaredL2DifferenceSideSPST_TMST = ResponseSquaredL2DifferenceSide
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSPST_TPST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ParamScalarT,typename EvalT::ParamScalarT>;
 
+template<typename EvalT, typename Traits>
+using ResponseSquaredL2DifferenceSideSPST_TRT = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::ParamScalarT,RealType>;
+
 //-- SourceScalarT = MeshScalarT
 template<typename EvalT, typename Traits>
-using ResponseSquaredL2DifferenceSideSMST_TST  = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::MeshScalarT,typename EvalT::ScalarT>;
+using ResponseSquaredL2DifferenceSideSMST_TST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::MeshScalarT,typename EvalT::ScalarT>;
 
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSMST_TMST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::MeshScalarT,typename EvalT::MeshScalarT>;
 
 template<typename EvalT, typename Traits>
 using ResponseSquaredL2DifferenceSideSMST_TPST = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::MeshScalarT,typename EvalT::ParamScalarT>;
+
+template<typename EvalT, typename Traits>
+using ResponseSquaredL2DifferenceSideSMST_TRT = ResponseSquaredL2DifferenceSideBase<EvalT,Traits,typename EvalT::MeshScalarT,RealType>;
 
 } // Namespace PHAL
 

--- a/src/problems/Albany_EvaluatorUtils.hpp
+++ b/src/problems/Albany_EvaluatorUtils.hpp
@@ -367,13 +367,8 @@ namespace Albany {
     virtual constructDOFGradInterpolationSideEvaluator(
       const std::string& dof_name,
       const std::string& sideSetName,
+      const std::string& dof_grad_name,
       const bool planar = false) const = 0;
-
-    Teuchos::RCP< PHX::Evaluator<Traits> >
-    virtual constructDOFGradInterpolationSideEvaluator(
-      const std::string& dof_name,
-      const std::string& sideSetName,
-      const std::string& dof_grad_name) const = 0;
 
     //! Interpolation functions for gradient of vector quantities defined on a side set
     Teuchos::RCP< PHX::Evaluator<Traits> >
@@ -772,16 +767,11 @@ namespace Albany {
 
     //! Interpolation functions for gradient of quantities defined on a side set
     Teuchos::RCP< PHX::Evaluator<Traits> >
-    constructDOFGradInterpolationSideEvaluator(
-      const std::string& dof_names,
-      const std::string& sideSetName,
-      const bool planar = false) const;
-
-    Teuchos::RCP< PHX::Evaluator<Traits> >
     virtual constructDOFGradInterpolationSideEvaluator(
       const std::string& dof_name,
       const std::string& sideSetName,
-      const std::string& dof_grad_name) const;
+      const std::string& dof_grad_name,
+      const bool planar = false) const;
 
     //! Interpolation functions for gradient of vector quantities defined on a side set
     Teuchos::RCP< PHX::Evaluator<Traits> >

--- a/src/problems/Albany_EvaluatorUtils_Def.hpp
+++ b/src/problems/Albany_EvaluatorUtils_Def.hpp
@@ -774,37 +774,8 @@ Teuchos::RCP< PHX::Evaluator<Traits> >
 EvaluatorUtilsImpl<EvalT,Traits,ScalarType>::constructDOFGradInterpolationSideEvaluator(
        const std::string& dof_name,
        const std::string& sideSetName,
+       const std::string& dof_grad_name,
        const bool planar) const
-{
-    TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideSetName)==dl->side_layouts.end(), std::runtime_error,
-                                "Error! The layout structure for side set " << sideSetName << " was not found.\n");
-
-    using Teuchos::RCP;
-    using Teuchos::rcp;
-    using Teuchos::ParameterList;
-
-    std::string sideSetName_ = planar ? sideSetName + "_planar" : sideSetName;
-    std::string gradientSuffixName = planar ? " Planar Gradient" : " Gradient";
-
-    RCP<ParameterList> p = rcp(new ParameterList("DOF Grad Interpolation Side "+dof_name));
-
-    // Input
-    p->set<std::string>("Variable Name", dof_name);
-    p->set<std::string>("Gradient BF Name", "Grad BF_"+sideSetName_);
-    p->set<std::string> ("Side Set Name",sideSetName);
-
-    // Output (assumes same Name as input)
-    p->set<std::string>("Gradient Variable Name", dof_name+gradientSuffixName);
-
-    return rcp(new PHAL::DOFGradInterpolationSideBase<EvalT,Traits,ScalarType>(*p,dl->side_layouts.at(sideSetName)));
-}
-
-template<typename EvalT, typename Traits, typename ScalarType>
-Teuchos::RCP< PHX::Evaluator<Traits> >
-EvaluatorUtilsImpl<EvalT,Traits,ScalarType>::constructDOFGradInterpolationSideEvaluator(
-       const std::string& dof_name,
-       const std::string& sideSetName,
-       const std::string& dof_grad_name) const
 {
     TEUCHOS_TEST_FOR_EXCEPTION (dl->side_layouts.find(sideSetName)==dl->side_layouts.end(), std::runtime_error,
         "Error! The layout structure for side set " << sideSetName << " was not found.\n");
@@ -814,10 +785,11 @@ EvaluatorUtilsImpl<EvalT,Traits,ScalarType>::constructDOFGradInterpolationSideEv
     using Teuchos::ParameterList;
 
     RCP<ParameterList> p = rcp(new ParameterList("DOF Grad Interpolation Side "+dof_name));
+    std::string sideSetName_ = planar ? sideSetName + "_planar" : sideSetName;
 
     // Input
     p->set<std::string>("Variable Name", dof_name);
-    p->set<std::string>("Gradient BF Name", "Grad BF_"+sideSetName);
+    p->set<std::string>("Gradient BF Name", "Grad BF_"+sideSetName_);
     p->set<std::string> ("Side Set Name",sideSetName);
 
     // Output (assumes same Name as input)

--- a/src/problems/Albany_ResponseUtilities_Def.hpp
+++ b/src/problems/Albany_ResponseUtilities_Def.hpp
@@ -74,7 +74,7 @@ ResponseUtilities<EvalT,Traits>::constructResponses(
   }
   else if (responseName == "Squared L2 Difference Source MST Target PST")
   {
-    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSMST_TPST<EvalT,Traits>(*p,dl));
+    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSMST_TPST<EvalT,Traits>(*p,dl));
   }
   else if (responseName == "Squared L2 Difference Side Source ST Target ST")
   {
@@ -88,6 +88,10 @@ ResponseUtilities<EvalT,Traits>::constructResponses(
   {
     res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSST_TPST<EvalT,Traits>(*p,dl));
   }
+  else if (responseName == "Squared L2 Difference Side Source ST Target RT")
+  {
+    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSST_TRT<EvalT,Traits>(*p,dl));
+  }
   else if (responseName == "Squared L2 Difference Side Source PST Target ST")
   {
     res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSPST_TST<EvalT,Traits>(*p,dl));
@@ -100,6 +104,10 @@ ResponseUtilities<EvalT,Traits>::constructResponses(
   {
     res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSPST_TPST<EvalT,Traits>(*p,dl));
   }
+  else if (responseName == "Squared L2 Difference Side Source PST Target RT")
+  {
+    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSPST_TRT<EvalT,Traits>(*p,dl));
+  }
   else if (responseName == "Squared L2 Difference Side Source MST Target ST")
   {
     res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSMST_TST<EvalT,Traits>(*p,dl));
@@ -110,7 +118,11 @@ ResponseUtilities<EvalT,Traits>::constructResponses(
   }
   else if (responseName == "Squared L2 Difference Side Source MST Target PST")
   {
-    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSMST_TPST<EvalT,Traits>(*p,dl));
+    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSMST_TPST<EvalT,Traits>(*p,dl));
+  }
+  else if (responseName == "Squared L2 Difference Side Source MST Target RT")
+  {
+    res_ev = rcp(new PHAL::ResponseSquaredL2DifferenceSideSMST_TRT<EvalT,Traits>(*p,dl));
   }
   else if (responseName == "PHAL Field Integral")
   {

--- a/src/problems/Albany_SideLaplacianProblem.hpp
+++ b/src/problems/Albany_SideLaplacianProblem.hpp
@@ -269,7 +269,8 @@ SideLaplacian::constructEvaluators3D (PHX::FieldManager<PHAL::AlbanyTraits>& fm0
   fm0.template registerEvaluator<EvalT> (ev);
 
   // Solution Gradient Side
-  ev = evalUtils.constructDOFGradInterpolationSideEvaluator(dof_names[0],sideSetName);
+  std::string grad_side_name = dof_names[0] + "_gradient_" + sideSetName;
+  ev = evalUtils.constructDOFGradInterpolationSideEvaluator(dof_names[0],sideSetName,grad_side_name);
   fm0.template registerEvaluator<EvalT> (ev);
 
   // -------- Restriction of Solution to Side Field -------- /
@@ -291,7 +292,7 @@ SideLaplacian::constructEvaluators3D (PHX::FieldManager<PHAL::AlbanyTraits>& fm0
   p->set<std::string> ("Gradient BF Variable Name", Albany::grad_bf_name + "_" + sideSetName);
   p->set<std::string> ("Solution Variable Name", dof_names[0]);
   p->set<std::string> ("Solution QP Variable Name", dof_names[0]);
-  p->set<std::string> ("Solution Gradient QP Variable Name", dof_names[0] + " Gradient");
+  p->set<std::string> ("Solution Gradient QP Variable Name", grad_side_name);
   p->set<std::string> ("Side Set Name",sideSetName);
   p->set<bool> ("Side Equation", true);
   p->set<Teuchos::RCP<shards::CellTopology> >("Cell Type",cellType);

--- a/src/responses/Albany_ResponseFactory.cpp
+++ b/src/responses/Albany_ResponseFactory.cpp
@@ -119,12 +119,15 @@ createResponseFunction(
      name == "Squared L2 Difference Side Source ST Target ST" ||
      name == "Squared L2 Difference Side Source ST Target MST" ||
      name == "Squared L2 Difference Side Source ST Target PST" ||
+     name == "Squared L2 Difference Side Source ST Target RT" ||
      name == "Squared L2 Difference Side Source PST Target ST" ||
      name == "Squared L2 Difference Side Source PST Target MST" ||
      name == "Squared L2 Difference Side Source PST Target PST" ||
+     name == "Squared L2 Difference Side Source PST Target RT" ||
      name == "Squared L2 Difference Side Source MST Target ST" ||
      name == "Squared L2 Difference Side Source MST Target MST" ||
      name == "Squared L2 Difference Side Source MST Target PST" ||
+     name == "Squared L2 Difference Side Source MST Target RT" ||
      name == "Surface Velocity Mismatch" ||
      name == "Surface Mass Balance Mismatch" ||
      name == "Grounding Line Flux" ||

--- a/tests/small/LandIce/FO_GIS/CMakeLists.txt
+++ b/tests/small/LandIce/FO_GIS/CMakeLists.txt
@@ -362,6 +362,11 @@ if (ALBANY_MESH_DEPENDS_ON_PARAMETERS)
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_thicknessT.yaml)
     add_test(${testName}_Tpetra ${Albany.exe} input_fo_gis_adjoint_sensitivity_thicknessT.yaml)
     set_tests_properties(${testName}_Tpetra PROPERTIES LABELS "LandIce;Tpetra;Forward")
+    
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_adjoint_sensitivity_bed_and_topT.yaml
+                   ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_bed_and_topT.yaml)
+    add_test(${testName}_MoveSurfHeightAndBed ${Albany.exe} input_fo_gis_adjoint_sensitivity_bed_and_topT.yaml)
+    set_tests_properties(${testName}_MoveSurfHeightAndBed PROPERTIES LABELS "LandIce;Tpetra;Forward")
 
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml)

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
@@ -5,6 +5,7 @@ ANONYMOUS:
   Debug Output:
     Write Solution to MatrixMarket: 0
   Problem:
+    Use MDField Memoization: true
     Phalanx Graph Visualization Detail: 1
     Solution Method: Steady
     Name: LandIce Stokes First Order 3D
@@ -36,12 +37,37 @@ ANONYMOUS:
         Type: Scalar Response
         Name: Grounding Line Flux
       Response 0:
-        Name: Surface Mass Balance Mismatch
-        SMB Coefficient: 1.0e+00
-        Regularization Coefficient: 1.0e+00
-        Scaling Coefficient: 5.8824e-07
-        Type: Scalar Response
-        H Coefficient: 1.0e+00
+        Type: Sum Of Responses
+        Number Of Responses: 3
+        Response 0:
+          Scaling: 5.8824e-07
+          Name: Squared L2 Difference Side Source ST Target RT
+          Source Field Name: flux_divergence_basalside
+          Response Depends On Solution Column: true
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Is Side Set Planar: true
+          Root Mean Square Error Field Name: apparent_mass_balance_RMS_basalside
+          Target Field Name: apparent_mass_balance_basalside
+        Response 1:
+          Scaling: 5.8824e-07
+          Name: Squared L2 Difference Side Source PST Target RT
+          Source Field Name: ice_thickness_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Is Side Set Planar: true
+          Response Depends On Extruded Parameters: true
+          Root Mean Square Error Field Name: observed_ice_thickness_RMS_basalside
+          Target Field Name: observed_ice_thickness_basalside
+        Response 2:
+          Scaling: 5.8824e-07
+          Name: Squared L2 Difference Side Source PST Target RT
+          Source Field Name: ice_thickness_gradient_basalside
+          Response Depends On Extruded Parameters: true
+          Side Set Name: basalside
+          Field Rank: Gradient
+          Is Side Set Planar: true
+          Target Value: 0.0
     Parameters:
       Number Of Parameters: 1
       Parameter 0:
@@ -66,6 +92,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
+    Workset Size: -1
     Method: Extruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
@@ -283,13 +310,15 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:
-    Absolute Tolerance: 1.e-05
+    Absolute Tolerance: 1.e-06
+    Relative Tolerance: 1.e-06
+    Test Value: 3.907995515271e+01
     Sensitivity For Parameter 0:
       Test Value: 2.381305924869e+02
-    Test Value: 3.907995515271e+01
-    Relative Tolerance: 1.e-05
   Regression For Response 1:
-    Absolute Tolerance: 1.e-05
+    Absolute Tolerance: 1.e-06
+    Relative Tolerance: 1.e-06
     Test Value: 1.523621754658e+12
-    Relative Tolerance: 1.e-05
+    Sensitivity For Parameter 0:
+      Test Value: 2.005848338672e+13
 ...


### PR DESCRIPTION
This PR enables simultaneous inversion of bed topography and surface height

It also improves the handling of planar fileds such as thickness, surface height and bed topography, and of responses on planar sidesets

Other minor fixes.