### PR TITLE
Add Tpetra path for SDBC to run on device

### DIFF
--- a/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
@@ -17,6 +17,7 @@
 #include "PHAL_SDirichletField.hpp"
 
 #include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_Utils.hpp"
 
 // **********************************************************************
 // Genereric Template Code for Constructor and PostRegistrationSetup
@@ -197,45 +198,80 @@ evaluateFields(typename Traits::EvalData dirichlet_workset)
     }
   }
 
-  const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
-
-  Teuchos::RCP<const Thyra_Vector> x = dirichlet_workset.x;
-  //Teuchos::RCP<Thyra_Vector>       f = dirichlet_workset.f;
-  Teuchos::RCP<Thyra_LinearOp>     J = dirichlet_workset.Jac;
-
-  bool const fill_residual = f != Teuchos::null;
-
-  auto f_view = fill_residual ? Albany::getNonconstLocalData(f) : Teuchos::null;
-  Teuchos::Array<ST> entries;
-  Teuchos::Array<LO> indices;
-  Teuchos::Array<ST> value(1);
-  value[0] = dirichlet_workset.j_coeff;;
-
   this->set_row_and_col_is_dbc(dirichlet_workset);
 
-  auto     col_is_dbc_data = Albany::getLocalData(col_is_dbc_.getConst());
-  auto     range_spmd_vs   = Albany::getSpmdVectorSpace(J->range());
-  const LO num_local_rows  = range_spmd_vs->localSubDim();
-
-  for (LO local_row = 0; local_row < num_local_rows; ++local_row) {
-    Albany::getLocalRowValues(J, local_row, indices, entries);
-    auto row_is_dbc = col_is_dbc_data[local_row] > 0;
-    if (row_is_dbc && fill_residual == true) {
-      int lunk = nsNodes[local_row][this->offset];
-      f_view[lunk] = 0.0;
+  const bool is_tpetra = Albany::build_type() == Albany::BuildType::Tpetra;
+  bool const fill_residual = f != Teuchos::null;
+  if (is_tpetra)
+  {
+    Tpetra_Vector::dual_view_type::t_dev fView;
+    if (fill_residual)
+    {
+      printf("Fill residual...\n");
+      auto tf = Albany::getTpetraVector(f);
+      fView = tf->getLocalViewDevice(Tpetra::Access::ReadWrite);
     }
 
-    const LO num_row_entries = entries.size();
+    auto tCol2DBC = Albany::getTpetraVector(col_is_dbc_);
+    auto col2DBCView = tCol2DBC->getLocalViewDevice(Tpetra::Access::ReadOnly);
+    auto col2DBC = Kokkos::subview(col2DBCView, Kokkos::ALL(), 0);
 
-    for (LO row_entry = 0; row_entry < num_row_entries; ++row_entry) {
-      auto local_col         = indices[row_entry];
-      auto is_diagonal_entry = local_col == local_row;
-      if ( is_diagonal_entry) { continue; }
+    auto tJac = Albany::getTpetraMatrix(dirichlet_workset.Jac);
+    auto lJac = tJac->getLocalMatrixDevice();
+    auto numLRows = lJac.numRows();
 
-      auto col_is_dbc = col_is_dbc_data[local_col] > 0;
-      if (row_is_dbc || col_is_dbc) { entries[row_entry] = 0.0; }
+    using range_policy = Kokkos::RangePolicy<PHX::Device::execution_space>;
+    Kokkos::parallel_for(
+      "SDirichletField<Jacobian>::evaluateFields",
+      range_policy(0, numLRows), KOKKOS_LAMBDA(const int lrow) {
+        const bool isRowDBC = col2DBC(lrow) > 0;
+        if (fill_residual == true && isRowDBC)
+          fView(lrow, 0) = 0.0;
+
+        auto lJacRow = lJac.row(lrow);
+        auto numCols = lJacRow.length;
+        for (LO i = 0; i < numCols; ++i) {
+          auto lcol = lJacRow.colidx(i);
+          const bool isDiagEntry = lcol == lrow;
+          if (isDiagEntry) continue;
+
+          const bool isColDBC = col2DBC(lcol) > 0;
+          if (isRowDBC || isColDBC)
+            lJacRow.value(i) = 0.0;
+        }
+      });
+  }
+  else {
+    Teuchos::RCP<Thyra_LinearOp>     J = dirichlet_workset.Jac;
+    auto f_view = fill_residual ? Albany::getNonconstLocalData(f) : Teuchos::null;
+    Teuchos::Array<ST> entries;
+    Teuchos::Array<LO> indices;
+
+    auto     col_is_dbc_data = Albany::getLocalData(col_is_dbc_.getConst());
+    auto     range_spmd_vs   = Albany::getSpmdVectorSpace(J->range());
+    const LO num_local_rows  = range_spmd_vs->localSubDim();
+    const std::vector<std::vector<int> >& nsNodes = dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
+
+    for (LO local_row = 0; local_row < num_local_rows; ++local_row) {
+      Albany::getLocalRowValues(J, local_row, indices, entries);
+      auto row_is_dbc = col_is_dbc_data[local_row] > 0;
+      if (row_is_dbc && fill_residual == true) {
+        int lunk = nsNodes[local_row][this->offset];
+        f_view[lunk] = 0.0;
+      }
+
+      const LO num_row_entries = entries.size();
+
+      for (LO row_entry = 0; row_entry < num_row_entries; ++row_entry) {
+        auto local_col         = indices[row_entry];
+        auto is_diagonal_entry = local_col == local_row;
+        if ( is_diagonal_entry) { continue; }
+
+        auto col_is_dbc = col_is_dbc_data[local_col] > 0;
+        if (row_is_dbc || col_is_dbc) { entries[row_entry] = 0.0; }
+      }
+      Albany::setLocalRowValues(J, local_row, indices(), entries());
     }
-    Albany::setLocalRowValues(J, local_row, indices(), entries());
   }
 }
 

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch.yaml
@@ -17,8 +17,8 @@ ANONYMOUS:
         Regularization Type: Given Value
         Regularization Value: 1.0e-05
     Dirichlet BCs:
-      DBC on NS extruded_boundary_node_set_3 for DOF U0 prescribe Field: velocity
-      DBC on NS extruded_boundary_node_set_3 for DOF U1 prescribe Field: velocity
+      SDBC on NS extruded_boundary_node_set_3 for DOF U0 prescribe Field: velocity
+      SDBC on NS extruded_boundary_node_set_3 for DOF U1 prescribe Field: velocity
     LandIce BCs:
       Number: 2
       BC 0:


### PR DESCRIPTION
This adds a path to run SDBC on device. It improves CPU/GPU performance significantly (although the runtime on CPU was small to begin with) by avoiding a local matrix fill on each row and only filling when needed.

I tested this on Humboldt1km-10km and obtained the same results (both CPU/GPU compared to old code). I'm not sure if this evaluator is tested in any regression tests. I also think I found a bug (will comment below) but I'm not sure if it's ever used (still looking for a test that runs that part of the code).