### PR TITLE
Add the Hessian reconstruction for scalar parameters

### DIFF
--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -670,14 +670,14 @@ public:
       const Teuchos::RCP<Thyra_MultiVector>&  Hv_g_pp);
 
   /**
-   * \brief evaluateResponseDistParamHessian_pp function
+   * \brief evaluateResponseHessian_pp function
    *
    * This function is used to compute the Hessian \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_i}(g)\f$ of the <tt>response[response_index]</tt> 
-   * (i.e. the response_index-th response) where \f$g\f$ is the response and \f$\boldsymbol{p}_i\f$ is a distributed parameter.
+   * (i.e. the response_index-th response) where \f$g\f$ is the response and \f$\boldsymbol{p}_i\f$ is a parameter.
    *
    * \param response_index [in] Response index of the response which the Hessian is computed.
    *
-   * \param parameter_index [in] Parameter index of the distributed parameter.
+   * \param parameter_index [in] Parameter index of the parameter.
    *
    * \param current_time [in] Current time at which the Hessian is computed for transient simulations.
    *
@@ -689,12 +689,12 @@ public:
    *
    * \param param_array [in] Array of the parameters vectors.
    *
-   * \param dist_param_name [in] Name of the distributed parameter.
+   * \param param_name [in] Name of the parameter.
    *
    * \param H [out] the output of the computation: \f$\boldsymbol{H}_{\boldsymbol{p}_i\boldsymbol{p}_i}(g)\f$.
    */
   void
-  evaluateResponseDistParamHessian_pp(
+  evaluateResponseHessian_pp(
       int                                     response_index,
       int                                     parameter_index,
       const double                            current_time,
@@ -702,7 +702,7 @@ public:
       const Teuchos::RCP<const Thyra_Vector>& xdot,
       const Teuchos::RCP<const Thyra_Vector>& xdotdot,
       const Teuchos::Array<ParamVec>&         param_array,
-      const std::string&                      dist_param_name,
+      const std::string&                      param_name,
       const Teuchos::RCP<Thyra_LinearOp>&     H);
 
   /**

--- a/src/responses/Albany_WeightedMisfitResponseFunction.hpp
+++ b/src/responses/Albany_WeightedMisfitResponseFunction.hpp
@@ -150,6 +150,8 @@ namespace Albany
 
     Teuchos::RCP<Thyra_Vector> g_;
     int n_parameters;
+    int total_dimension;
+    Teuchos::RCP<Teuchos::SerialDenseVector<int, int>> dimensions;
     Teuchos::RCP<Teuchos::SerialDenseVector<int, double>> theta_0;
     Teuchos::RCP<Teuchos::SerialDenseMatrix<int, double>> C;
     Teuchos::RCP<Teuchos::SerialDenseMatrix<int, double>> invC;

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -4,7 +4,18 @@
 namespace Albany
 {
     /**
-     * \brief createHessianLinearOp function
+     * \brief createDenseHessianLinearOp function
+     *
+     * This function computes the Thyra::LinearOp associated to
+     * the Hessian w.r.t a parameter vector.
+     *
+     * \param p_vs [in] Thyra::VectorSpace which specifies the entries of the current parameter vector.
+     */
+    Teuchos::RCP<Thyra_LinearOp> createDenseHessianLinearOp(
+        Teuchos::RCP<const Thyra_VectorSpace> p_vs);
+
+    /**
+     * \brief createSparseHessianLinearOp function
      *
      * This function computes the Thyra::LinearOp associated to
      * the Hessian w.r.t a distributed parameter.
@@ -15,7 +26,7 @@ namespace Albany
      *
      * \param wsElDofs [in] Vector of IDArray associated to the mesh used.
      */
-    Teuchos::RCP<Thyra_LinearOp> createHessianLinearOp(
+    Teuchos::RCP<Thyra_LinearOp> createSparseHessianLinearOp(
         Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
         Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
         const std::vector<IDArray> wsElDofs);

--- a/tests/small/SteadyHeatConstrainedOpt2D/CMakeLists.txt
+++ b/tests/small/SteadyHeatConstrainedOpt2D/CMakeLists.txt
@@ -126,3 +126,18 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_scalar_and_dist_paramT.yaml
 # Create the test with this name and standard executable
 add_test(${testName}_Tpetra ${Albany.exe} input_scalar_and_dist_paramT.yaml)
 set_tests_properties(${testName}_Tpetra PROPERTIES LABELS "Basic;Tpetra;Forward")
+
+####################################
+### Hessian Mixed Scalar Distributed Params tests ###
+####################################
+
+if (ALBANY_ROL)
+  set(testName ${testNameRoot}_Scalar_And_Dist_Param_Hessian)
+
+  # Copy Input file from source to binary dir
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_scalar_and_dist_param_hessianT.yaml
+                ${CMAKE_CURRENT_BINARY_DIR}/input_scalar_and_dist_param_hessianT.yaml COPYONLY)
+  # Create the test with this name and standard executable
+  add_test(${testName}_Tpetra ${AlbanyAnalysis.exe} input_scalar_and_dist_param_hessianT.yaml)
+  set_tests_properties(${testName}_Tpetra PROPERTIES LABELS "Basic;Tpetra;Analysis")
+endif()

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -37,7 +37,7 @@ ANONYMOUS:
       Response 0:
         Use AD for Hessian-vector products (default): true
         Reconstruct H_pp: true
-        Replace H_pp by I parameter 1: true
+        Replace H_pp with Identity for Parameter 1: true
       Write Hessian MatrixMarket: false 
     Response Functions:
       Number Of Responses: 1

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -1,0 +1,360 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Problem: 
+    Name: Heat 2D
+    Compute Sensitivities: true
+    Dirichlet BCs: 
+      SDBC on NS NodeSet0 for DOF T: 1.00000000000000000e+00
+      SDBC on NS NodeSet1 for DOF T: 0.00000000000000000e+00
+      SDBC on NS NodeSet2 for DOF T: -1.00000000000000000e+00
+      SDBC on NS NodeSet3 for DOF T: 0.00000000000000000e+00
+    Parameters:
+      Number Of Parameters: 2
+      Parameter 0:
+        Dimension: 2
+        Type: Vector
+        Scalar 0:
+          Name: "Amplitude 0"
+          Lower Bound: 4.00000000000000022e-01
+          Upper Bound: 5.00000000000000000e+00
+        Scalar 1:
+          Name: "Radius 0"
+          Lower Bound: 4.00000000000000022e-01
+          Upper Bound: 5.00000000000000000e+00
+      Parameter 1:
+        Type: Distributed
+        Name: thermal_conductivity
+        Lower Bound: 4.00000000000000022e-01
+        Upper Bound: 5.00000000000000000e+00
+        Initial Uniform Value: 1.00000000000000000e+00
+        Mesh Part: ''
+    Hessian:
+      Use AD for Hessian-vector products (default): false
+      Residual:
+        Use AD for Hessian-vector products (default): true
+      Response 0:
+        Use AD for Hessian-vector products (default): true
+        Reconstruct H_pp: true
+        Replace H_pp by I parameter 1: true
+      Write Hessian MatrixMarket: false 
+    Response Functions:
+      Number Of Responses: 1
+      Response 0:
+        Type: Sum Of Responses
+        Number Of Responses: 3
+        Response 0:
+          Name: Squared L2 Difference Source ST Target PST
+          Field Rank: Scalar
+          Source Field Name: Temperature
+          Target Value: 0.0
+        Response 1:
+          Name: Squared L2 Difference Source ST Target PST
+          Field Rank: Scalar
+          Scaling: 1.49999999999999994e-01
+          Source Field Name: ThermalConductivity
+          Target Value: 0.0
+        Response 2:
+          Name: Weighted Misfit
+          Number Of Parameters: 1
+          Mean: [1., 1.]
+          Covariance Matrix: [[1., 0.], [0., 1.]]
+    Source Functions: 
+      Point:
+        Number: 1
+        Center 0: [0.5, 0.5]
+        Time Wavelet:
+          Type: Monotone
+        Spatial:
+          Type: Gaussian
+          Amplitude: 10.0e+00
+          Radius: 0.5
+  Discretization: 
+    1D Elements: 40
+    2D Elements: 40
+    Method: STK2D
+    Exodus Output File Name: steady2d_scalar_and_dist_param.exo
+    Cubature Degree: 9
+  Regression For Response 0:
+    Test Value:  3.714619372618e-01
+    Relative Tolerance: 1.00000000000000002e-03
+    Sensitivity For Parameter 0:
+      Test Values: [9.561048021617e-03, -3.169063814956e-01]
+    Sensitivity For Parameter 1:
+      Test Value: 8.044261077318e-03
+  Piro: 
+    Sensitivity Method: Adjoint
+    Enable Explicit Matrix Transpose: true
+    Analysis: 
+      Analysis Package: ROL
+      ROL: 
+        Number Of Parameters: 2
+        Check Gradient: true
+        Gradient Tolerance: 1.0e-04
+        Step Tolerance: 1.0e-04
+        Print Output: true
+        Parameter Initial Guess Type: Uniform Vector
+        Uniform Parameter Guess: 1.0e+00
+        Min And Max Of Random Parameter Guess: [-1.0e+00, 2.0e+00]
+        Bound Constrained: true
+
+        Step Method: "Line Search"
+        bound_eps: 1.0e-01
+        Max Iterations: 10
+       
+
+        Full Space: false
+        Use NOX Solver: true
+ 
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 0
+              Remove Mean Of The Right-hand Side: false
+              Block Diagonal Solver:
+                Block 0:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
+                Block 1:
+                  Linear Solver Type: Belos
+                  Linear Solver Types:
+                    Belos:
+                      Solver Type: Block GMRES
+                      Solver Types:
+                        Block GMRES:
+                          Maximum Iterations: 200
+                          Convergence Tolerance: 1e-7
+                          Num Blocks: 200
+                          Output Frequency: 20
+                          Output Style: 1
+                          Verbosity: 33
+                      VerboseObject:
+                        Verbosity Level: medium
+                  Preconditioner Type: Ifpack2
+                  Preconditioner Types:
+                    Ifpack2:
+                      Overlap: 0
+                      Prec Type: Amesos2
+                      Ifpack2 Settings: 
+                        Amesos2: {}
+                        Amesos2 solver name: klu
+
+        ROL Options: 
+        # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
+          SimOpt:
+            Solve:
+              Absolute Residual Tolerance:   1.0e-5
+              Relative Residual Tolerance:   1.0e-0
+              Iteration Limit:               20
+              Sufficient Decrease Tolerance: 1.e-4
+              Step Tolerance:                1.e-8
+              Backtracking Factor:           0.5
+              Output Iteration History:      false
+              Zero Initial Guess:            false
+              Solver Type:                   0    
+          
+          Status Test: 
+            Gradient Tolerance: 1.0e-4
+            Constraint Tolerance: 1.0e-5
+            Step Tolerance: 1.0e-10
+            Iteration Limit: 10
+
+          General: 
+            Variable Objective Function: false
+            Scale for Epsilon Active Sets: 1.00000000000000000e+00
+            Inexact Objective Function: false
+            Inexact Gradient: false
+            Inexact Hessian-Times-A-Vector: false
+            Projected Gradient Criticality Measure: false
+            Secant: 
+              Type: Limited-Memory BFGS
+              Use as Preconditioner: false
+              Use as Hessian: true
+              Maximum Storage: 50
+              Barzilai-Borwein Type: 1
+            Krylov: 
+              Type: Conjugate Gradients
+              Absolute Tolerance: 1.00000000000000005e-04
+              Relative Tolerance: 1.00000000000000002e-02
+              Iteration Limit: 100
+
+          Step:
+            Type: "Augmented Lagrangian" #"Moreau-Yosida Penalty" 
+            Line Search: 
+              Function Evaluation Limit: 60
+              Sufficient Decrease Tolerance: 9.99999999999999945e-21
+              Initial Step Size: 1.00000000000000000e+00
+              User Defined Initial Step Size: false
+              Accept Linesearch Minimizer: false
+              Accept Last Alpha: false
+              Descent Method: 
+                Type: Quasi-Newton
+                Nonlinear CG Type: Hestenes-Stiefel
+              Curvature Condition: 
+                Type: Strong Wolfe Conditions
+                General Parameter: 9.00000000000000022e-01
+                Generalized Wolfe Parameter: 5.99999999999999978e-01
+              Line-Search Method: 
+                Type: Cubic Interpolation
+                Backtracking Rate: 5.00000000000000000e-01
+                Bracketing Tolerance: 1.00000000000000002e-08
+                Path-Based Target Level: 
+                  Target Relaxation Parameter: 1.00000000000000000e+00
+                  Upper Bound on Path Length: 1.00000000000000000e+00
+            Trust Region: 
+              Subproblem Solver: Truncated CG
+              Initial Radius: 1.00000000000000000e+01
+              Maximum Radius: 5.00000000000000000e+03
+              Step Acceptance Threshold: 5.00000000000000028e-02
+              Radius Shrinking Threshold: 5.00000000000000028e-02
+              Radius Growing Threshold: 9.00000000000000022e-01
+              Radius Shrinking Rate (Negative rho): 6.25000000000000000e-02
+              Radius Shrinking Rate (Positive rho): 2.50000000000000000e-01
+              Radius Growing Rate: 2.50000000000000000e+00
+              Safeguard Size: 1.00000000000000000e+08
+              Inexact: 
+                Value: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Exponent: 9.00000000000000022e-01
+                  Forcing Sequence Initial Value: 1.00000000000000000e+00
+                  Forcing Sequence Update Frequency: 10
+                  Forcing Sequence Reduction Factor: 1.00000000000000006e-01
+                Gradient: 
+                  Tolerance Scaling: 1.00000000000000006e-01
+                  Relative Tolerance: 2.00000000000000000e+00
+
+            Moreau-Yosida Penalty:
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Initial Penalty Parameter: 1.0e+2
+              Penalty Parameter Growth Factor: 1.0
+
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Subproblem:
+                Optimality Tolerance: 1.e-4
+                Feasibility Tolerance: 1.e-5
+                Print History: true
+                Iteration Limit: 1
+
+            # ===========  COMPOSITE STEP  =========== -->
+            Composite Step:
+              Output Level: 2
+              #Initial Radius: 1.0e+2
+              Use Constraint Hessian: false
+              
+              # ===========  OPTIMALITY SYSTEM SOLVER  =========== -->
+              Optimality System Solver:
+                Nominal Relative Tolerance: 2.0e-1
+                Fix Tolerance: true
+      
+              # ===========  TANGENTIAL SUBPROBLEM SOLVER  =========== -->
+              Tangential Subproblem Solver:
+                Iteration Limit: 100
+                Relative Tolerance: 1.0e-2
+
+            # ===========  AUGMENTED LAGRANGIAN  =========== 
+            Augmented Lagrangian:
+              Level of Hessian Approximation: 0
+              #  ===========  PROBLEM SCALING =========== 
+              Use Default Problem Scaling: false
+              Objective Scaling: 1.e+01
+              Constraint Scaling: 1.e+0
+              # ===========  PENALTY PARAMETER UPDATE  =========== 
+              Use Default Initial Penalty Parameter: true
+              Initial Penalty Parameter: 1.e+1
+              Penalty Parameter Growth Factor: 1.e+1
+              Minimum Penalty Parameter Reciprocal: 0.1
+              # ===========  OPTIMALITY TOLERANCE UPDATE  =========== 
+              Initial Optimality Tolerance: 1.0
+              Optimality Tolerance Update Exponent: 1.0
+              Optimality Tolerance Decrease Exponent: 1.0
+              # ==========  FEASIBILITY TOLERANCE UPDATE  =========== 
+              Initial Feasibility Tolerance: 1.0
+              Feasibility Tolerance Update Exponent: 0.1
+              Feasibility Tolerance Decrease Exponent: 0.9
+              # ===========  SUBPROBLEM SOLVER  =========== 
+              Print Intermediate Optimization History: false
+              Subproblem Step Type: "Trust Region"
+              Subproblem Iteration Limit: 50
+
+    LOCA: 
+      Bifurcation: { }
+      Constraints: { }
+      Predictor: 
+        First Step Predictor: { }
+        Last Step Predictor: { }
+      Step Size: { }
+      Stepper: 
+        Eigensolver: { }
+    NOX: 
+      Direction: 
+        Method: Newton
+        Newton: 
+          Forcing Term Method: Constant
+          Rescue Bad Newton Solve: true
+          Stratimikos Linear Solver: 
+            NOX Stratimikos Options: { }
+            Stratimikos: 
+              Linear Solver Type: AztecOO
+              Linear Solver Types: 
+                AztecOO: 
+                  Forward Solve: 
+                    AztecOO Settings: 
+                      Aztec Solver: GMRES
+                      Convergence Test: r0
+                      Size of Krylov Subspace: 200
+                      Output Frequency: 10
+                    Max Iterations: 200
+                    Tolerance: 1.0e-07
+                Belos: 
+                  Solver Type: Block GMRES
+                  Solver Types: 
+                    Block GMRES: 
+                      Convergence Tolerance: 9.99999999999999955e-08
+                      Output Frequency: 10
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 100
+                      Block Size: 1
+                      Num Blocks: 50
+                      Flexible Gmres: false
+              Preconditioner Type: Ifpack2
+              Preconditioner Types: 
+                Ifpack2: 
+                  Overlap: 1
+                  Prec Type: RILUK
+                  Ifpack2 Settings: 
+                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: iluk level-of-fill': 0
+      Line Search: 
+        Full Step: 
+          Full Step: 1.00000000000000000e+00
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing: 
+        Output Information: 103
+        Output Precision: 3
+      Solver Options: 
+        Status Test Check Type: Minimal
+...


### PR DESCRIPTION
This PR adds the reconstruction of the Hessian of response function for scalar parameters.

All the tests passed and the branch builds warning free.

The weighted misfit function has been updated to be able to use vector of scalar parameters.

An option has been added to be able to replace the Hessian of a response w.r.t a parameter by the identity matrix.

@mperego @bartgol 