### PR TITLE
Added parallel orthogonalization method for PyAlbany MultiVectors

### DIFF
--- a/PyAlbany/python/Utils.py
+++ b/PyAlbany/python/Utils.py
@@ -13,14 +13,18 @@ except:
 import numpy as np
 from numpy import linalg as LA
 import sys
-from numpy import linalg as LA
-import sys
 
 def norm(distributedVector, comm):
     """@brief Computes the norm-2 of a distributed vector using Python and Teuchos MPI communicator."""
-    localSNorm = (LA.norm(distributedVector))**2
+    localSNorm = np.inner(distributedVector, distributedVector)
     norm = np.sqrt(comm.reduceAll(Teuchos.REDUCE_SUM, localSNorm))
     return norm
+
+def inner(distributedVector1, distributedVector2, comm):
+    """@brief Computes the l2 inner product of two distributed vectors using Python and Teuchos MPI communicator."""
+    localInnerProduct = np.inner(distributedVector1, distributedVector2)
+    innerProduct = comm.reduceAll(Teuchos.REDUCE_SUM, localInnerProduct)
+    return innerProduct
 
 def createDefaultParallelEnv(comm = Teuchos.DefaultComm.getComm(), n_threads=-1,n_numa=-1,device_id=-1):
     """@brief Creates a default parallel environment.

--- a/PyAlbany/python/Utils.py
+++ b/PyAlbany/python/Utils.py
@@ -16,8 +16,7 @@ import sys
 
 def norm(distributedVector, comm):
     """@brief Computes the norm-2 of a distributed vector using Python and Teuchos MPI communicator."""
-    localSNorm = np.inner(distributedVector, distributedVector)
-    norm = np.sqrt(comm.reduceAll(Teuchos.REDUCE_SUM, localSNorm))
+    norm = inner(distributedVector, distributedVector, comm)
     return norm
 
 def inner(distributedVector1, distributedVector2, comm):

--- a/PyAlbany/python/Utils.py
+++ b/PyAlbany/python/Utils.py
@@ -16,7 +16,7 @@ import sys
 
 def norm(distributedVector, comm):
     """@brief Computes the norm-2 of a distributed vector using Python and Teuchos MPI communicator."""
-    norm = inner(distributedVector, distributedVector, comm)
+    norm = np.sqrt(inner(distributedVector, distributedVector, comm))
     return norm
 
 def inner(distributedVector1, distributedVector2, comm):

--- a/PyAlbany/src/Albany_Interface.hpp
+++ b/PyAlbany/src/Albany_Interface.hpp
@@ -26,25 +26,10 @@
 
 #include "Albany_CumulativeScalarResponseFunction.hpp"
 
-#include "BelosConfigDefs.hpp"
-#include "BelosOutputManager.hpp"
-
-#include "Teuchos_CommandLineProcessor.hpp"
-#include "Teuchos_ParameterList.hpp"
-#include "Teuchos_StandardCatchMacros.hpp"
-#include <Teuchos_StackedTimer.hpp>
-
 #include "BelosTpetraAdapter.hpp"
 #include "BelosTpetraOperator.hpp"
-#include "Tpetra_Core.hpp"
-#include "Tpetra_CrsMatrix.hpp"
-#include <MatrixMarket_Tpetra.hpp>
 #include "BelosOrthoManagerFactory.hpp"
 #include "BelosOrthoManager.hpp"
-
-using Teuchos::RCP;
-using Teuchos::rcp;
-using Teuchos::Array;
 
 namespace PyAlbany
 {
@@ -73,7 +58,8 @@ namespace PyAlbany
    * The function returns an RCP to the gathered multivector.
    */
     Teuchos::RCP<PyTrilinosMultiVector> gatherMVector(Teuchos::RCP<PyTrilinosMultiVector> inVector, Teuchos::RCP<PyTrilinosMap> distributedMap);
-
+    
+    
     /**
    * \brief PyParallelEnv class
    * 
@@ -81,7 +67,7 @@ namespace PyAlbany
    * a Teuchos communicator and the Kokkos arguments.
    * 
    * The constructor of this object calls Kokkos::initialize and its destructors calls finalize_all.
-   * 
+    
    */
     class PyParallelEnv
     {
@@ -96,7 +82,7 @@ namespace PyAlbany
             std::cout << "~PyParallelEnv()\n";
         }
     };
-   
+
     /**
     * \brief orthogTpMVecs function
     *
@@ -104,7 +90,7 @@ namespace PyAlbany
     *
     */ 
     void orthogTpMVecs(Teuchos::RCP<PyAlbany::PyTrilinosMultiVector> inputVecs, int blkSize);
-   
+
     /**
    * \brief getParameterList function
    * 
@@ -374,54 +360,6 @@ Teuchos::RCP<PyAlbany::PyTrilinosMultiVector> PyAlbany::gatherMVector(Teuchos::R
     return outVector;
 }
 
-void PyAlbany::orthogTpMVecs(Teuchos::RCP<PyAlbany::PyTrilinosMultiVector> inputVecs, int blkSize)
-{
-  typedef double                            ScalarType;
-  typedef int                               OT;
-  typedef typename Teuchos::SerialDenseMatrix<OT,ScalarType> MAT;
-  typedef Tpetra::MultiVector<ScalarType>   MV;
-  typedef Kokkos::DefaultExecutionSpace     EXSP;
-  typedef Tpetra::Operator<ScalarType>             OP;
-  typedef Belos::OperatorTraits<ScalarType,MV,OP> OPT;
-  int numVecs = inputVecs->getNumVectors();
-  int numRows = inputVecs->getGlobalLength();
-  std::string orthogType("ICGS");
-
-  RCP<MAT> B = rcp(new MAT(blkSize, blkSize)); //Matrix for coeffs of X
-  Array<RCP<MAT>> C; 
-
-  Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
-  Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
-
-  //Default OutputManager is std::cout.
-  Teuchos::RCP<Belos::OutputManager<ScalarType> > myOutputMgr = Teuchos::rcp( new Belos::OutputManager<ScalarType>() );
-  const Teuchos::RCP<Belos::OrthoManager<ScalarType,MV>> orthoMgr = factory.makeOrthoManager (orthogType, Teuchos::null, myOutputMgr, "Tpetra OrthoMgr", paramsOrtho); 
-  
-  int numLoops = numVecs/blkSize;
-  int remainder = numVecs % blkSize;
-
-  RCP<MV> vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(0,blkSize-1));
-  orthoMgr->normalize(*vecBlock, B);
-  std::vector<RCP<const MV>> pastVecArray;
-  pastVecArray.push_back(vecBlock);
-  Teuchos::ArrayView<RCP<const MV>> pastVecArrayView; 
-
-  for(int k=1; k<numLoops; k++){
-    pastVecArrayView = arrayViewFromVector(pastVecArray);
-    vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(k*blkSize,k*blkSize + blkSize - 1));
-    C.append(rcp(new MAT(blkSize, blkSize)));
-    int rank = orthoMgr->projectAndNormalize(*vecBlock, C, B, pastVecArrayView);
-    pastVecArray.push_back(vecBlock);
-  }
-  if( remainder > 0){
-    pastVecArrayView = arrayViewFromVector(pastVecArray);
-    vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(numVecs-remainder, numVecs-1));
-    B = rcp(new MAT(remainder, remainder));
-    C.append(rcp(new MAT(remainder, remainder)));
-    int rank = orthoMgr->projectAndNormalize(*vecBlock, C, B, pastVecArrayView);
-  }
-}
-
 Teuchos::RCP<Teuchos::ParameterList> PyAlbany::getParameterList(std::string inputFile, Teuchos::RCP<PyAlbany::PyParallelEnv> pyParallelEnv)
 {
     Teuchos::RCP<Teuchos::ParameterList> params = Teuchos::createParameterList("Albany Parameters");
@@ -440,4 +378,53 @@ Teuchos::RCP<Teuchos::ParameterList> PyAlbany::getParameterList(std::string inpu
     }
 
     return params;
+}
+
+
+void PyAlbany::orthogTpMVecs(Teuchos::RCP<PyAlbany::PyTrilinosMultiVector> inputVecs, int blkSize)
+{
+  typedef double                            ScalarType;
+  typedef int                               OT;
+  typedef typename Teuchos::SerialDenseMatrix<OT,ScalarType> MAT;
+  typedef Tpetra::MultiVector<ScalarType>   MV;
+  typedef Kokkos::DefaultExecutionSpace     EXSP;
+  typedef Tpetra::Operator<ScalarType>             OP;
+  typedef Belos::OperatorTraits<ScalarType,MV,OP> OPT;
+  int numVecs = inputVecs->getNumVectors();
+  int numRows = inputVecs->getGlobalLength();
+  std::string orthogType("ICGS");
+
+  Teuchos::RCP<MAT> B = Teuchos::rcp(new MAT(blkSize, blkSize)); //Matrix for coeffs of X
+  Teuchos::Array<Teuchos::RCP<MAT>> C; 
+
+  Belos::OrthoManagerFactory<ScalarType, MV, OP> factory;
+  Teuchos::RCP<Teuchos::ParameterList> paramsOrtho;   // can be null
+
+  //Default OutputManager is std::cout.
+  Teuchos::RCP<Belos::OutputManager<ScalarType> > myOutputMgr = Teuchos::rcp( new Belos::OutputManager<ScalarType>() );
+  const Teuchos::RCP<Belos::OrthoManager<ScalarType,MV>> orthoMgr = factory.makeOrthoManager (orthogType, Teuchos::null, myOutputMgr, "Tpetra OrthoMgr", paramsOrtho); 
+  
+  int numLoops = numVecs/blkSize;
+  int remainder = numVecs % blkSize;
+
+  Teuchos::RCP<MV> vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(0,blkSize-1));
+  orthoMgr->normalize(*vecBlock, B);
+  std::vector<Teuchos::RCP<const MV>> pastVecArray;
+  pastVecArray.push_back(vecBlock);
+  Teuchos::ArrayView<Teuchos::RCP<const MV>> pastVecArrayView; 
+
+  for(int k=1; k<numLoops; k++){
+    pastVecArrayView = arrayViewFromVector(pastVecArray);
+    vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(k*blkSize,k*blkSize + blkSize - 1));
+    C.append(rcp(new MAT(blkSize, blkSize)));
+    int rank = orthoMgr->projectAndNormalize(*vecBlock, C, B, pastVecArrayView);
+    pastVecArray.push_back(vecBlock);
+  }
+  if( remainder > 0){
+    pastVecArrayView = arrayViewFromVector(pastVecArray);
+    vecBlock = inputVecs->subViewNonConst(Teuchos::Range1D(numVecs-remainder, numVecs-1));
+    B = Teuchos::rcp(new MAT(remainder, remainder));
+    C.append(Teuchos::rcp(new MAT(remainder, remainder)));
+    int rank = orthoMgr->projectAndNormalize(*vecBlock, C, B, pastVecArrayView);
+  }
 }

--- a/PyAlbany/tests/small/SteadyHeat/CMakeLists.txt
+++ b/PyAlbany/tests/small/SteadyHeat/CMakeLists.txt
@@ -55,3 +55,15 @@ IF(ALBANY_MPI)
     set_tests_properties(PyAlbany_SteadyHeat_StateMap_MPI
         PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
 ENDIF()
+
+add_test(PyAlbany_SteadyHeat_Orthogonalization ${SERIAL_CALL} "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/steadyHeat_orthog.py")
+
+set_tests_properties(PyAlbany_SteadyHeat_Orthogonalization
+    PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+
+IF(ALBANY_MPI)
+    add_test(PyAlbany_SteadyHeat_Orthogonalization_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/steadyHeat_orthog.py")
+
+    set_tests_properties(PyAlbany_SteadyHeat_Orthogonalization_MPI
+        PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")
+ENDIF()

--- a/PyAlbany/tests/small/SteadyHeat/steadyHeat_orthog.py
+++ b/PyAlbany/tests/small/SteadyHeat/steadyHeat_orthog.py
@@ -1,0 +1,61 @@
+from PyTrilinos import Tpetra
+from PyTrilinos import Teuchos
+
+import unittest
+import numpy as np
+try:
+    from PyAlbany import Utils
+except:
+    import Utils
+try:
+    from PyAlbany import wpyalbany as wpa
+except:
+    import wpyalbany as wpa
+import os
+
+class TestSteadyHeat(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.comm = Teuchos.DefaultComm.getComm()
+        cls.parallelEnv = Utils.createDefaultParallelEnv(cls.comm)
+
+    def test_all(self):
+        cls = self.__class__
+        rank = cls.comm.getRank()
+
+        file_dir = os.path.dirname(__file__)
+
+        # Create an Albany problem:
+        filename = 'input_conductivity_dist_paramT.yaml'
+        problem = Utils.createAlbanyProblem(file_dir+'/'+filename, cls.parallelEnv)
+
+        n_vecs = 4
+        parameter_map = problem.getParameterMap(0)
+        num_elems     = parameter_map.getNodeNumElements()
+        
+        # generate vectors with random entries
+        omega = Tpetra.MultiVector(parameter_map, n_vecs, dtype="d")
+        for i in range(n_vecs):
+            omega[i,:] = np.random.randn(num_elems)
+        
+        # call the orthonormalization method
+        wpa.orthogTpMVecs(omega, 2)
+        
+        # check that the vectors are now orthonormal
+        tol = 1.e-12
+        for i in range(n_vecs):
+            for j in range(i+1):
+                omegaiTomegaj = Utils.inner(omega[i,:], omega[j,:], cls.comm)
+                if rank == 0:
+                    if i == j:
+                        self.assertTrue(abs(omegaiTomegaj - 1.0) < tol)
+                    else:
+                        self.assertTrue(abs(omegaiTomegaj-0.0) < tol)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.parallelEnv = None
+        cls.comm = None
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added a orthogTpMVecs method that can be accessed from the Python interface of Albany, so that one can orthogonalize distributed MultiVector's.
Tests have been added to test the orthogonalization method.
Utils has been updated that now provides an inner product method for distributed vectors.
Credit should be given to Jennifer A. Loe for providing the majority of the source code as an example.