### PR TITLE
Put git info in a separate config file

### DIFF
--- a/src/Albany_GitVersion.h.in
+++ b/src/Albany_GitVersion.h.in
@@ -1,0 +1,9 @@
+#ifndef ALBANY_GIT_VERSION_H
+#define ALBANY_GIT_VERSION_H
+
+// Trilinos/Albany version details
+#cmakedefine ALBANY_TRILINOS_GIT_COMMIT_ID "${ALBANY_TRILINOS_GIT_COMMIT_ID}"
+#cmakedefine ALBANY_GIT_BRANCH "${ALBANY_GIT_BRANCH}"
+#cmakedefine ALBANY_GIT_COMMIT_ID "${ALBANY_GIT_COMMIT_ID}"
+
+#endif // ALBANY_GIT_VERSION_H

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -8,6 +8,7 @@
 
 #include "Albany_Macros.hpp"
 #include "Albany_ThyraUtils.hpp"
+#include "Albany_GitVersion.h"
 
 // Include the concrete Epetra Comm's, if needed
 #if defined(ALBANY_EPETRA)

--- a/src/Albany_config.h.in
+++ b/src/Albany_config.h.in
@@ -24,11 +24,6 @@
 
 // ========================== General Albany build and capabilities options ============================== //
 
-// Trilinos/Albany version details
-#cmakedefine ALBANY_TRILINOS_GIT_COMMIT_ID "${ALBANY_TRILINOS_GIT_COMMIT_ID}"
-#cmakedefine ALBANY_GIT_BRANCH "${ALBANY_GIT_BRANCH}"
-#cmakedefine ALBANY_GIT_COMMIT_ID "${ALBANY_GIT_COMMIT_ID}"
-
 // Albany compiler details
 #cmakedefine ALBANY_CXX_COMPILER_ID "${ALBANY_CXX_COMPILER_ID}"
 #cmakedefine ALBANY_CXX_COMPILER_VERSION "${ALBANY_CXX_COMPILER_VERSION}"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,9 +5,11 @@
 ##*****************************************************************//
 
 
-# Generate Albany_config.h
+# Generate Albany_config.h and Albany_GitVersion.h
 configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Albany_config.h.in
                 ${CMAKE_CURRENT_BINARY_DIR}/Albany_config.h)
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Albany_GitVersion.h.in
+                ${CMAKE_CURRENT_BINARY_DIR}/Albany_GitVersion.h)
 
 include(CheckCXXSourceCompiles)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,39 +4,10 @@
 ##    in the file "license.txt" in the top-level Albany directory  //
 ##*****************************************************************//
 
-# Configure the file containing Albany configuration macros,
-# and add its folder to the include directories
-# Note: write to a temp file, and only copy into Albany_config.h if
-#       the temp file is different
-macro (CreateAlbanyConfig_h)
-  set (SRC_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Albany_config.h.in)
-  set (CFG_FILE ${CMAKE_CURRENT_BINARY_DIR}/Albany_config.h)
-  set (TMP_FILE ${CMAKE_CURRENT_BINARY_DIR}/Albany_config.h.tmp)
 
-  configure_file (${SRC_FILE} ${TMP_FILE})
-
-  set (OUT_OF_DATE TRUE)
-
-  if (EXISTS ${CFG_FILE})
-    # we rely on FILE macro rather than running diff, since it is
-    # more portable (guaranteed to work regardless of underlying system)
-    file (READ ${CFG_FILE} CFG_FILE_STR)
-    file (READ ${TMP_FILE} TMP_FILE_STR)
-
-    if (${CFG_FILE_STR} STREQUAL ${TMP_FILE_STR})
-      # config file was present and appears unchanged
-      set (OUT_OF_DATE FALSE)
-    endif()
-  endif ()
-
-  if (OUT_OF_DATE)
-    file (RENAME ${TMP_FILE} ${CFG_FILE})
-  else()
-    file (REMOVE ${TMP_FILE})
-  endif()
-endmacro()
-
-CreateAlbanyConfig_h()
+# Generate Albany_config.h
+configure_file (${CMAKE_CURRENT_SOURCE_DIR}/Albany_config.h.in
+                ${CMAKE_CURRENT_BINARY_DIR}/Albany_config.h)
 
 include(CheckCXXSourceCompiles)
 


### PR DESCRIPTION
Premise: this bugged me for a whole afternoon, since I wasn't able to figure out why Albany sometimes was fully rebuilt.

When making a commit during development, the sha of the HEAD commit changes. If, by chance, cmake was triggered (e.g., change in an input file), this changes the Albany_config.h file int he bld dir, which triggers a rebuild of the whole library.

Step to reproduce:

- do minor mod to input file (e.g. test/small/SteadyHeat1D/input.yaml)
- commit micro mod
- run make in build dir

Git info is only used in `Albany_Utils.cpp`. By putting all git version info in a separate `Albany_GitVersion.h.in` file, and including `Albany_GitVersion.h` in `Albany_Utils.cpp`, we allow the rest of Albany to not be rebuilt when re-running CMake after making a commit.

@jewatkins I'm pinging you since I think you added the logic for the GIT info in the albany banner.