### PR TITLE
Add non Gaussian random variables

### DIFF
--- a/PyAlbany/examples/extremeEvent/.gitignore
+++ b/PyAlbany/examples/extremeEvent/.gitignore
@@ -2,3 +2,4 @@
 *.out
 *.jpeg
 *.txt
+phalanx*

--- a/PyAlbany/examples/extremeEvent/thermal_steady_2.py
+++ b/PyAlbany/examples/extremeEvent/thermal_steady_2.py
@@ -19,9 +19,9 @@ except:
 
 
 def evaluate_responses(X, Y, problem, recompute=False):
-    if not recompute and os.path.isfile('Z1.txt'):
-        Z1 = np.loadtxt('Z1.txt')
-        Z2 = np.loadtxt('Z2.txt')
+    if not recompute and os.path.isfile('Z1_2.txt'):
+        Z1 = np.loadtxt('Z1_2.txt')
+        Z2 = np.loadtxt('Z2_2.txt')
     else:
         comm = MPI.COMM_WORLD
         myGlobalRank = comm.rank
@@ -45,8 +45,8 @@ def evaluate_responses(X, Y, problem, recompute=False):
                 Z1[j, i] = problem.getCumulativeResponseContribution(0, 0)
                 Z2[j, i] = problem.getCumulativeResponseContribution(0, 1)
 
-        np.savetxt('Z1.txt', Z1)
-        np.savetxt('Z2.txt', Z2)
+        np.savetxt('Z1_2.txt', Z1)
+        np.savetxt('Z2_2.txt', Z2)
     return Z1, Z2
 
 
@@ -57,7 +57,7 @@ def main(parallelEnv):
     # Create an Albany problem:
 
     n_params = 2
-    filename = "thermal_steady.yaml"
+    filename = "thermal_steady_2.yaml"
 
     parameter = Utils.createParameterList(
         filename, parallelEnv
@@ -80,10 +80,10 @@ def main(parallelEnv):
 
     theta_star, I_star, F_star, P_star = ee.evaluateThetaStar(l, problem, n_params)
 
-    np.savetxt('theta_star_steady.txt', theta_star)
-    np.savetxt('I_star_steady.txt', I_star)
-    np.savetxt('P_star_steady.txt', P_star)
-    np.savetxt('F_star_steady.txt', F_star)
+    np.savetxt('theta_star_steady_2.txt', theta_star)
+    np.savetxt('I_star_steady_2.txt', I_star)
+    np.savetxt('P_star_steady_2.txt', P_star)
+    np.savetxt('F_star_steady_2.txt', F_star)
 
     # ----------------------------------------------
     #
@@ -93,7 +93,7 @@ def main(parallelEnv):
 
     N_samples = 100
 
-    mean = np.array([0., 0.])
+    mean = np.array([1., 1.])
     cov = np.array([[1., 0.], [0., 1.]])
 
     samples = np.random.multivariate_normal(mean, cov, N_samples)
@@ -105,9 +105,9 @@ def main(parallelEnv):
     P_mixed = ee.mixedImportanceSamplingEstimator(mean, cov, theta_star, F_star, P_star, samples, problem, angle_1, angle_2)
     P_SO = ee.secondOrderEstimator(mean, cov, l, theta_star, I_star, F_star, P_star, problem)
 
-    np.savetxt('P_steady_IS.txt', P_IS)
-    np.savetxt('P_steady_mixed.txt', P_mixed)
-    np.savetxt('P_steady_SO.txt', P_SO)
+    np.savetxt('P_steady_IS_2.txt', P_IS)
+    np.savetxt('P_steady_mixed_2.txt', P_mixed)
+    np.savetxt('P_steady_SO_2.txt', P_SO)
 
     problem.reportTimers()
 
@@ -117,8 +117,8 @@ def main(parallelEnv):
     #
     # ----------------------------------------------
     if n_params == 2:
-        X = np.arange(0, 6, 0.2)
-        Y = np.arange(0, 6, 0.25)
+        X = np.arange(1, 7, 0.2)
+        Y = np.arange(1, 7, 0.25)
 
         Z1, Z2 = evaluate_responses(X, Y, problem, True)
 
@@ -132,29 +132,29 @@ def main(parallelEnv):
             plt.semilogy(F_star, P_mixed, 'r*--')
             plt.semilogy(F_star, P_SO, 'g*-')
 
-            plt.savefig('extreme_steady.jpeg', dpi=800)
+            plt.savefig('extreme_steady_2.jpeg', dpi=800)
             plt.close()
 
             if n_params == 2:
                 plt.figure()
                 plt.plot(theta_star[:, 0], theta_star[:, 1], '*-')
-                #plt.contour(X, Y, Z1, levels=I_star, colors='g')
-                #plt.contour(X, Y, Z2, levels=F_star, colors='r')
-                plt.savefig('theta_star.jpeg', dpi=800)
+                plt.contour(X, Y, Z1, levels=I_star, colors='g')
+                plt.contour(X, Y, Z2, levels=F_star, colors='r')
+                plt.savefig('theta_star_2.jpeg', dpi=800)
                 plt.close()
 
                 fig = plt.figure()
                 ax = fig.gca(projection='3d')
                 ax.plot_surface(X, Y, Z1)
 
-                plt.savefig('Z1.jpeg', dpi=800)
+                plt.savefig('Z1_2.jpeg', dpi=800)
                 plt.close()
 
                 fig = plt.figure()
                 ax = fig.gca(projection='3d')
                 ax.plot_surface(X, Y, Z2)
 
-                plt.savefig('Z2.jpeg', dpi=800)
+                plt.savefig('Z2_2.jpeg', dpi=800)
                 plt.close()
 
 

--- a/PyAlbany/examples/extremeEvent/thermal_steady_2.yaml
+++ b/PyAlbany/examples/extremeEvent/thermal_steady_2.yaml
@@ -3,7 +3,6 @@
 ANONYMOUS:
   Build Type: Tpetra
   Problem:
-    Phalanx Graph Visualization Detail: 1
     Name: Thermal 2D
     Solution Method: Steady
     Compute Sensitivities: true
@@ -20,27 +19,13 @@ ANONYMOUS:
         Dimension: 2
         Type: Vector
         Scalar 0:
-          Name: Theta 0
-          Lower Bound: -1.e+10
-          Upper Bound: 1.e+10
+          Name: DBC on NS NodeSet1 for DOF T
+          Lower Bound: -5.00000000000000000e+04
+          Upper Bound: 5.00000000000000000e+04
         Scalar 1:
-          Name: Theta 1
-          Lower Bound: -1.e+10
-          Upper Bound: 1.e+10
-    Random Parameters:
-      Number Of Parameters: 2
-      Parameter 0:
-        Name: DBC on NS NodeSet1 for DOF T
-        Distribution: 
-          Name: Normal
-          Loc: 1.
-        Standard Normal Parameter: Theta 0
-      Parameter 1:
-        Name: DBC on NS NodeSet0 for DOF T
-        Distribution: 
-          Name: Normal
-          Loc: 1.
-        Standard Normal Parameter: Theta 1
+          Name: DBC on NS NodeSet0 for DOF T
+          Lower Bound: -5.00000000000000000e+04
+          Upper Bound: 5.00000000000000000e+04
     Response Functions: 
       Number Of Responses: 1
       Response 0:
@@ -49,7 +34,7 @@ ANONYMOUS:
         Response 0:
           Name: Weighted Misfit
           Number Of Parameters: 1
-          Mean: [0., 0.]
+          Mean: [1., 1.]
           Covariance Matrix: [[1., 0.], [0., 1.]]
         Response 1:
           Type: Scalar Response

--- a/PyAlbany/python/Distributions.py
+++ b/PyAlbany/python/Distributions.py
@@ -1,8 +1,5 @@
 import numpy as np
-from scipy.optimize import minimize
-from numpy.linalg import inv
 from scipy.special import erfinv
-from scipy.special import erf
 import scipy.stats
 
 
@@ -161,7 +158,7 @@ class multivariatDistribution(distribution):
         return s
 
 
-def mapping(x, distribution1, distribution2):
+def mapping_v(x, distribution1, distribution2):
     if distribution1.n_dimensions != distribution2.n_dimensions:
         raise NameError("mapping: The two distributions are not compatible")
     return distribution2.ppf(distribution1.cdf(x))
@@ -179,3 +176,14 @@ def mapping_dx_dx(x, distribution1, distribution2):
             "mapping_dx_dx: The two distributions are not compatible")
     return distribution2.ppf_dx_dx(distribution1.cdf(x)) * distribution1.cdf_dx(x)**2 + distribution2.ppf_dx(distribution1.cdf(x)) * distribution1.cdf_dx_dx(x)
 
+
+class mapping:
+    def __init__(self, standard, other):
+        self.standard = standard
+        self.other = other
+
+    def toNormal(self, x):
+        return mapping_v(x, self.other, self.standard)
+
+    def fromNormal(self, x):
+        return mapping_v(x, self.standard, self.other)

--- a/PyAlbany/src/Albany_Interface.cpp
+++ b/PyAlbany/src/Albany_Interface.cpp
@@ -38,6 +38,8 @@
 
 #include "Albany_ObserverImpl.hpp"
 
+#include "ROL_Types.hpp"
+
 #if defined(ALBANY_CHECK_FPE) || defined(ALBANY_STRONG_FPE_CHECK) || defined(ALBANY_FLUSH_DENORMALS)
 #include <xmmintrin.h>
 #endif
@@ -559,7 +561,7 @@ bool PyProblem::performAnalysis()
 
     stackedTimer->stop("PyAlbany: performAnalysis");
     stackedTimer->stopBaseTimer();
-    bool error = (status != 0);
+    bool error = (status != ROL::EXITSTATUS_CONVERGED && status != ROL::EXITSTATUS_STEPTOL);
     return error;
 }
 

--- a/PyAlbany/src/Albany_Interface.hpp
+++ b/PyAlbany/src/Albany_Interface.hpp
@@ -31,6 +31,7 @@
 #include "BelosOrthoManagerFactory.hpp"
 #include "BelosOrthoManager.hpp"
 
+#include <Teuchos_TwoDArray.hpp>
 namespace PyAlbany
 {
     /**
@@ -313,8 +314,23 @@ namespace PyAlbany
             else
                 csrf->updateWeight(j, weigth);
         }
-    };
 
+        void getCovarianceMatrix(double* C, int n, int m)
+        {
+            auto responseParams = albanyApp->getAppPL()->sublist("Problem").sublist("Responses").sublist("Response 0").sublist("Response 0");
+            int total_dimension = n;
+
+            Teuchos::TwoDArray<double> C_data(total_dimension, total_dimension, 0);
+            if (responseParams.isParameter("Covariance Matrix"))
+                C_data = responseParams.get<Teuchos::TwoDArray<double>>("Covariance Matrix");
+            else
+                for (int i=0; i<total_dimension; i++)
+                    C_data(i,i) = 1.;
+            for (int i=0; i<n; i++)
+                for (int j=0; j<m; j++)
+                    C[i * n + j] = C_data(i,j);
+        }
+    };
 } // namespace PyAlbany
 
 Teuchos::RCP<PyAlbany::PyTrilinosMap> PyAlbany::getRankZeroMap(Teuchos::RCP<PyAlbany::PyTrilinosMap> distributedMap)

--- a/PyAlbany/swig/albany.i
+++ b/PyAlbany/swig/albany.i
@@ -14,7 +14,14 @@
 #include <typeinfo>
 
 #include <Albany_PyAlbanyTypes.hpp>
+#define SWIG_FILE_WITH_INIT
 #include <Albany_Interface.hpp>
+%}
+// ----------- Numpy -----------
+%include "numpy.i"
+
+%init %{
+    import_array();
 %}
 
 // ----------- PyTrilinos ------------
@@ -37,4 +44,5 @@ using std::string;
 %teuchos_rcp(PyAlbany::PyProblem)
 
 %include "Albany_PyAlbanyTypes.hpp"
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2) {(double* C, int n, int m)}
 %include "Albany_Interface.hpp"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,6 +148,7 @@ list (APPEND SOURCES
   utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
   utility/Albany_ThyraUtils.cpp
   utility/Albany_TpetraThyraUtils.cpp
+  utility/Albany_UnivariateDistribution.hpp
   utility/VariableMonitor.cpp
   utility/StaticAllocator.cpp
   )
@@ -561,7 +562,6 @@ list (APPEND HEADERS
   evaluators/utility/PHAL_RandomPhysicalParameter.hpp
   evaluators/utility/PHAL_Source.hpp
   evaluators/utility/PHAL_Source_Def.hpp
-  evaluators/utility/PHAL_UnivariateDistribution.hpp
   evaluators/utility/PHAL_Field_Source.hpp
   evaluators/utility/PHAL_Field_Source_Def.hpp
   )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -558,8 +558,10 @@ list (APPEND HEADERS
   evaluators/utility/PHAL_MapToPhysicalFrameSide.hpp
   evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
   evaluators/utility/PHAL_MapToPhysicalFrame_Def.hpp
+  evaluators/utility/PHAL_RandomPhysicalParameter.hpp
   evaluators/utility/PHAL_Source.hpp
   evaluators/utility/PHAL_Source_Def.hpp
+  evaluators/utility/PHAL_UnivariateDistribution.hpp
   evaluators/utility/PHAL_Field_Source.hpp
   evaluators/utility/PHAL_Field_Source_Def.hpp
   )

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -17,6 +17,8 @@
 
 #include <string.hpp> // for 'upper_case' (comes from src/utility; not to be confused with <string>)
 
+#include "Albany_Utils.hpp"
+
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN
 
@@ -265,6 +267,17 @@ BasalFrictionCoefficient (const Teuchos::ParameterList& p,
     } else if (beta_type == BETA_TYPE::POWER_LAW) {
       auto paramLib = p.get<Teuchos::RCP<ParamLib> >("Parameter Library");
       is_power_parameter = paramLib->isParameter("Power Exponent");
+      Teuchos::ParameterList rparams = *p.get<Teuchos::ParameterList*>("Random Parameters");
+      if (!is_power_parameter && rparams.isParameter("Number Of Parameters")) {
+        int nrparams = rparams.get<int>("Number Of Parameters");
+        for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
+          auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+          if (rparams_i.get<std::string>("Name") == "Power Exponent") {
+            is_power_parameter = true;
+            break;
+          }
+        }
+      }
       if (is_power_parameter) {
         u_norm = PHX::MDField<const VelocityST>(p.get<std::string> ("Sliding Velocity Variable Name"), layout);
         this->addDependentField (u_norm);

--- a/src/LandIce/problems/LandIce_ParamEnum.hpp
+++ b/src/LandIce/problems/LandIce_ParamEnum.hpp
@@ -19,7 +19,9 @@ enum class ParamEnum
   Mu,
   Power,
   Homotopy,
-  GLHomotopy
+  GLHomotopy,
+  Theta_0,
+  Theta_1
 };
 
 namespace ParamEnumName
@@ -30,6 +32,8 @@ namespace ParamEnumName
   static const std::string Power           = "Power Exponent";
   static const std::string HomotopyParam   = "Homotopy Parameter";
   static const std::string GLHomotopyParam = "Glen's Law Homotopy Parameter";
+  static const std::string theta_0         = "Theta 0"; 
+  static const std::string theta_1         = "Theta 1";
 } // ParamEnum
 
 } // Namespace LandIce

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -993,35 +993,33 @@ constructVelocityEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   fm0.template registerEvaluator<EvalT>(ptr_theta_1);
 
   auto rparams = params->sublist("Random Parameters");
-  if (rparams.isParameter("Number Of Parameters")) {
-    int nrparams = rparams.get<int>("Number Of Parameters");
-    for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
-      auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+  int nrparams = rparams.get("Number Of Parameters",0);
+  for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
+    auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
 
-      p = rcp(new Teuchos::ParameterList("Theta 1"));
-      p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-      const std::string param_name = rparams_i.get<std::string>("Name");
-      p->set<std::string>("Parameter Name", param_name); //output name
-      const std::string rparam_name = rparams_i.get<std::string>("Standard Normal Parameter");
-      p->set<std::string>("Random Parameter Name", rparam_name); //input name
-      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-      p->set<const Teuchos::ParameterList*>("Distribution", &rparams_i.sublist("Distribution"));
-      Teuchos::RCP<PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>> ptr_rparam;
-      ptr_rparam = Teuchos::rcp(new PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>(*p,dl));
-      fm0.template registerEvaluator<EvalT>(ptr_rparam);
-    }
+    p = rcp(new Teuchos::ParameterList("Theta 1"));
+    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+    const std::string param_name = rparams_i.get<std::string>("Name");
+    p->set<std::string>("Parameter Name", param_name); //output name
+    const std::string rparam_name = rparams_i.get<std::string>("Standard Normal Parameter");
+    p->set<std::string>("Random Parameter Name", rparam_name); //input name
+    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+    p->set<const Teuchos::ParameterList*>("Distribution", &rparams_i.sublist("Distribution"));
+    Teuchos::RCP<PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>> ptr_rparam;
+    ptr_rparam = Teuchos::rcp(new PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>(*p,dl));
+    fm0.template registerEvaluator<EvalT>(ptr_rparam);
   }
 
   //--- Shared Parameter for Continuation: Glen's Law Homotopy Parameter ---//
-  p = Teuchos::rcp(new Teuchos::ParameterList("Homotopy Parameter"));
-
   param_name = ParamEnumName::GLHomotopyParam;
-  p->set<std::string>("Parameter Name", param_name);
-  p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-  p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-  p->set<double>("Default Nominal Value", params->sublist("LandIce Viscosity").get<double>(param_name,-1.0));
 
-  if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+  if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+    p = Teuchos::rcp(new Teuchos::ParameterList("Homotopy Parameter"));
+    p->set<std::string>("Parameter Name", param_name);
+    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+    p->set<double>("Default Nominal Value", params->sublist("LandIce Viscosity").get<double>(param_name,-1.0));
+    
     Teuchos::RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::GLHomotopy>> ptr_gl_homotopy;
     ptr_gl_homotopy = Teuchos::rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::GLHomotopy>(*p,dl));
     fm0.template registerEvaluator<EvalT>(ptr_gl_homotopy);
@@ -1334,19 +1332,19 @@ void StokesFOBase::constructBasalBCEvaluators (PHX::FieldManager<PHAL::AlbanyTra
       }
 
       //--- Shared Parameter for basal friction coefficient: alpha ---//
-      p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: alpha"));
-
       param_name = "Hydraulic-Over-Hydrostatic Potential Ratio";
-      p->set<std::string>("Parameter Name", param_name);
-      p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
 
-      //TODO Why is this parameter looked for in the Basal Friction List?
-      double nominalValue = pl->sublist("Basal Friction Coefficient").isParameter(param_name) ?
-                               pl->sublist("Basal Friction Coefficient").get<double>(param_name) : -1.0;
-      p->set<double>("Default Nominal Value", nominalValue);
+      if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+        p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: alpha"));
+        p->set<std::string>("Parameter Name", param_name);
+        p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+        p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
 
-      if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+        //TODO Why is this parameter looked for in the Basal Friction List?
+        double nominalValue = pl->sublist("Basal Friction Coefficient").isParameter(param_name) ?
+                                pl->sublist("Basal Friction Coefficient").get<double>(param_name) : -1.0;
+        p->set<double>("Default Nominal Value", nominalValue);
+
         Teuchos::RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Alpha>> ptr_alpha;
         ptr_alpha = Teuchos::rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Alpha>(*p,dl));
         fm0.template registerEvaluator<EvalT>(ptr_alpha);
@@ -1354,48 +1352,48 @@ void StokesFOBase::constructBasalBCEvaluators (PHX::FieldManager<PHAL::AlbanyTra
     }
 
     //--- Shared Parameter for basal friction coefficient: lambda ---//
-    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: lambda"));
-
     param_name = "Bed Roughness";
-    p->set<std::string>("Parameter Name", param_name);
-    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-    p->set<double>("Default Nominal Value", pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
 
-    if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+    if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+      p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: lambda"));
+      p->set<std::string>("Parameter Name", param_name);
+      p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+      p->set<double>("Default Nominal Value", pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
+
       Teuchos::RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Lambda>> ptr_lambda;
       ptr_lambda = Teuchos::rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Lambda>(*p,dl));
       fm0.template registerEvaluator<EvalT>(ptr_lambda);
     }
 
     //--- Shared Parameter for basal friction coefficient: muPowerLaw ---//
-    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: mu"));
-
     param_name = ParamEnumName::Mu;
-    p->set<std::string>("Parameter Name", param_name);
-    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-    p->set<double>("Default Nominal Value", pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
 
-    if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+    if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+      p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: mu"));
+      p->set<std::string>("Parameter Name", param_name);
+      p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+      p->set<double>("Default Nominal Value", pl->sublist("Basal Friction Coefficient").get<double>(param_name,-1.0));
+
       Teuchos::RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>> ptr_mu;
       ptr_mu = Teuchos::rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Mu>(*p,dl));
       fm0.template registerEvaluator<EvalT>(ptr_mu);
     }
 
     //--- Shared Parameter for basal friction coefficient: power ---//
-    p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: power"));
-
     param_name = "Power Exponent";
-    p->set<std::string>("Parameter Name", param_name);
-    p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
-    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-    Teuchos::ParameterList beta_list = pl->sublist("Basal Friction Coefficient");
-    const auto type = util::upper_case(beta_list.get<std::string>("Type"));
-    double default_val = (type == "FIELD") ? 1.0 : beta_list.get<double>(param_name, -1.0);
-    p->set<double>("Default Nominal Value", default_val);
 
-    if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+    if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+      p = Teuchos::rcp(new Teuchos::ParameterList("Basal Friction Coefficient: power"));
+      p->set<std::string>("Parameter Name", param_name);
+      p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);
+      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+      Teuchos::ParameterList beta_list = pl->sublist("Basal Friction Coefficient");
+      const auto type = util::upper_case(beta_list.get<std::string>("Type"));
+      double default_val = (type == "FIELD") ? 1.0 : beta_list.get<double>(param_name, -1.0);
+      p->set<double>("Default Nominal Value", default_val);
+
       Teuchos::RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Power>> ptr_power;
       ptr_power = Teuchos::rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,ParamEnum,ParamEnum::Power>(*p,dl));
       fm0.template registerEvaluator<EvalT>(ptr_power);

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -993,7 +993,7 @@ constructVelocityEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   fm0.template registerEvaluator<EvalT>(ptr_theta_1);
 
   auto rparams = params->sublist("Random Parameters");
-  int nrparams = rparams.get("Number Of Parameters",0);
+  int nrparams = rparams.get<int>("Number Of Parameters");
   for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
     auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
 

--- a/src/evaluators/bc/PHAL_Dirichlet.hpp
+++ b/src/evaluators/bc/PHAL_Dirichlet.hpp
@@ -16,7 +16,7 @@
 
 #include "Sacado_ParameterAccessor.hpp"
 #include "PHAL_AlbanyTraits.hpp"
-#include "PHAL_UnivariateDistribution.hpp"
+#include "Albany_UnivariateDistribution.hpp"
 
 #include "PHAL_Dimension.hpp"
 

--- a/src/evaluators/bc/PHAL_Dirichlet.hpp
+++ b/src/evaluators/bc/PHAL_Dirichlet.hpp
@@ -16,6 +16,9 @@
 
 #include "Sacado_ParameterAccessor.hpp"
 #include "PHAL_AlbanyTraits.hpp"
+#include "PHAL_UnivariateDistribution.hpp"
+
+#include "PHAL_Dimension.hpp"
 
 namespace PHAL {
 /** \brief Gathers solution values from the Newton solution vector into
@@ -58,6 +61,9 @@ protected:
   const int offset;
   ScalarT value;
   std::string nodeSetID;
+  bool isRandom;
+  Teuchos::RCP<Albany::UnivariatDistribution> distribution;
+  PHX::MDField<ScalarT,Dim>   theta_as_field;
 };
 
 // **************************************************************

--- a/src/evaluators/utility/PHAL_IsAvailable.hpp
+++ b/src/evaluators/utility/PHAL_IsAvailable.hpp
@@ -4,31 +4,24 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef PHAL_IS_PARAM_AVAILABLE_HPP
-#define PHAL_IS_PARAM_AVAILABLE_HPP
+#ifndef PHAL_IS_FIELD_EVALUATED_HPP
+#define PHAL_IS_FIELD_EVALUATED_HPP
 
 namespace PHAL
 {
 
-enum class FieldScalarType : int {
-  Real        = 0,
-  MeshScalar  = 1,
-  ParamScalar = 2,
-  Scalar      = 3
-};
-
-template<typename EvalT>
+template<typename ScalarT>
 Teuchos::RCP<PHX::FieldTag>
 createTag(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& dl)
 {
-  return Teuchos::rcp(new PHX::Tag<typename EvalT::ScalarT>(name,dl));
+  return Teuchos::rcp(new PHX::Tag<ScalarT>(name,dl));
 }
 
 template<typename EvalT>
-bool is_param_available (const PHX::FieldManager<PHAL::AlbanyTraits>& fm,
+bool is_field_evaluated (const PHX::FieldManager<PHAL::AlbanyTraits>& fm,
                    const std::string& name,
                    const Teuchos::RCP<PHX::DataLayout>& dl) {
-  auto tag = createTag<EvalT>(name,dl);
+  auto tag = createTag<typename EvalT::ScalarT>(name,dl);
 
   const auto& dag = fm.getDagManager<EvalT>();
 
@@ -43,4 +36,4 @@ bool is_param_available (const PHX::FieldManager<PHAL::AlbanyTraits>& fm,
 
 } // namespace PHAL
 
-#endif // PHAL_IS_PARAM_AVAILABLE_HPP
+#endif // PHAL_IS_FIELD_EVALUATED_HPP

--- a/src/evaluators/utility/PHAL_IsAvailable.hpp
+++ b/src/evaluators/utility/PHAL_IsAvailable.hpp
@@ -1,0 +1,46 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef PHAL_IS_PARAM_AVAILABLE_HPP
+#define PHAL_IS_PARAM_AVAILABLE_HPP
+
+namespace PHAL
+{
+
+enum class FieldScalarType : int {
+  Real        = 0,
+  MeshScalar  = 1,
+  ParamScalar = 2,
+  Scalar      = 3
+};
+
+template<typename EvalT>
+Teuchos::RCP<PHX::FieldTag>
+createTag(const std::string& name, const Teuchos::RCP<PHX::DataLayout>& dl)
+{
+  return Teuchos::rcp(new PHX::Tag<typename EvalT::ScalarT>(name,dl));
+}
+
+template<typename EvalT>
+bool is_param_available (const PHX::FieldManager<PHAL::AlbanyTraits>& fm,
+                   const std::string& name,
+                   const Teuchos::RCP<PHX::DataLayout>& dl) {
+  auto tag = createTag<EvalT>(name,dl);
+
+  const auto& dag = fm.getDagManager<EvalT>();
+
+  const auto& field_to_eval = dag.queryRegisteredFields();
+  auto search = std::find_if(field_to_eval.begin(),
+                             field_to_eval.end(),
+                             [&] (const auto& tag_identifier)
+                             {return (tag->identifier() == tag_identifier.first);});
+
+  return search!=field_to_eval.end();
+}
+
+} // namespace PHAL
+
+#endif // PHAL_IS_PARAM_AVAILABLE_HPP

--- a/src/evaluators/utility/PHAL_RandomPhysicalParameter.hpp
+++ b/src/evaluators/utility/PHAL_RandomPhysicalParameter.hpp
@@ -1,0 +1,260 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef PHAL_RANDOMPHYSICALPARAMETER_HPP
+#define PHAL_RANDOMPHYSICALPARAMETER_HPP
+
+#include "Phalanx_Evaluator_Derived.hpp"
+#include "Phalanx_Evaluator_WithBaseImpl.hpp"
+#include "Phalanx_MDField.hpp"
+#include "Phalanx_config.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#include "PHAL_AlbanyTraits.hpp"
+#include "PHAL_SharedParameter.hpp"
+#include "PHAL_UnivariateDistribution.hpp"
+
+namespace PHAL {
+///
+/// RandomPhysicalParameterBase
+///
+template<typename EvalT, typename Traits>
+class RandomPhysicalParameterBase : 
+  public PHX::EvaluatorWithBaseImpl<Traits>,
+  public PHX::EvaluatorDerived<EvalT, Traits>
+{
+ public:
+  typedef typename EvalT::ScalarT   ScalarT;
+  //typedef ParamNameEnum             EnumType;
+
+  RandomPhysicalParameterBase (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl)
+  {
+    std::string param_name   = p.get<std::string>("Parameter Name");
+    std::string theta_name   = p.get<std::string>("Random Parameter Name");
+    param_as_field = PHX::MDField<ScalarT,Dim>(param_name,dl->shared_param);
+    theta_as_field = PHX::MDField<ScalarT,Dim>(theta_name, dl->shared_param);
+
+    // Never actually evaluated, but creates the evaluation tag
+    this->addEvaluatedField(param_as_field);
+    this->addDependentField(theta_as_field);
+    this->setName("Random Parameter " + param_name + PHX::print<EvalT>());
+
+    const Teuchos::ParameterList* distributionList = p.get<const Teuchos::ParameterList*>("Distribution");
+
+    if (distributionList->get<std::string>("Name") == "Normal")
+      distribution = Teuchos::rcp<Albany::UnivariatDistribution>(new Albany::NormalDistribution(*distributionList));
+    if (distributionList->get<std::string>("Name") == "LogNormal")
+      distribution = Teuchos::rcp<Albany::UnivariatDistribution>(new Albany::LogNormalDistribution(*distributionList));
+    if (distributionList->get<std::string>("Name") == "Uniform")
+      distribution = Teuchos::rcp<Albany::UnivariatDistribution>(new Albany::UniformDistribution(*distributionList));
+  }
+
+  void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+  {
+    this->utils.setFieldData(param_as_field,fm);
+    d.fill_field_dependencies(this->dependentFields(),this->evaluatedFields(),false);
+  }
+
+protected:
+  PHX::MDField<ScalarT,Dim>   param_as_field;
+  PHX::MDField<ScalarT,Dim>   theta_as_field;
+  Teuchos::RCP<Albany::UnivariatDistribution> distribution;
+};
+
+template<typename EvalT, typename Traits> class RandomPhysicalParameter;
+
+// **************************************************************
+// **************************************************************
+// * Specializations
+// **************************************************************
+// **************************************************************
+
+
+// **************************************************************
+// Residual
+// **************************************************************
+template<typename Traits>
+class RandomPhysicalParameter<PHAL::AlbanyTraits::Residual,Traits>
+  : public RandomPhysicalParameterBase<PHAL::AlbanyTraits::Residual, Traits>  {
+
+  public:
+    typedef typename PHAL::AlbanyTraits::Residual::ScalarT   ScalarT;
+
+    RandomPhysicalParameter (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Residual, Traits>(p, dl)
+     {
+     }
+
+    void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+    {
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Residual, Traits>::
+        postRegistrationSetup(d, fm);
+    }
+
+    void evaluateFields(typename Traits::EvalData d)
+    {
+      this->param_as_field(0) = this->distribution->fromNormalMapping(this->theta_as_field(0));
+
+      std::cout << " RandomPhysicalParameter<PHAL::AlbanyTraits::Residual>::evaluateFields() "
+        << this->param_as_field(0) << " theta " << this->theta_as_field(0) << std::endl;
+    }
+};
+
+// **************************************************************
+// Jacobian
+// **************************************************************
+template<typename Traits>
+class RandomPhysicalParameter<PHAL::AlbanyTraits::Jacobian,Traits>
+  : public RandomPhysicalParameterBase<PHAL::AlbanyTraits::Jacobian, Traits>  {
+
+  public:
+    typedef typename PHAL::AlbanyTraits::Jacobian::ScalarT   ScalarT;
+
+    RandomPhysicalParameter (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Jacobian, Traits>(p, dl)
+     {
+     }
+
+    void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+    {
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Jacobian, Traits>::
+        postRegistrationSetup(d, fm);
+    }
+
+    void evaluateFields(typename Traits::EvalData d)
+    {
+      double theta_val = this->theta_as_field(0).val();
+      this->param_as_field(0).val() = this->distribution->fromNormalMapping(theta_val);
+
+      std::cout << " RandomPhysicalParameter<PHAL::AlbanyTraits::Jacobian>::evaluateFields() "
+        << this->param_as_field(0) << " theta " << this->theta_as_field(0) << std::endl;
+    }
+};
+
+// **************************************************************
+// Tangent
+// **************************************************************
+template<typename Traits>
+class RandomPhysicalParameter<PHAL::AlbanyTraits::Tangent,Traits>
+  : public RandomPhysicalParameterBase<PHAL::AlbanyTraits::Tangent, Traits>  {
+
+  public:
+    typedef typename PHAL::AlbanyTraits::Tangent::ScalarT   ScalarT;
+
+    RandomPhysicalParameter (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Tangent, Traits>(p, dl)
+     {
+     }
+
+    void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+    {
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::Tangent, Traits>::
+        postRegistrationSetup(d, fm);
+    }
+
+    void evaluateFields(typename Traits::EvalData d)
+    {
+      double theta_val = this->theta_as_field(0).val();
+      this->param_as_field(0).val() = this->distribution->fromNormalMapping(theta_val);
+      double v_dx = this->distribution->fromNormalMapping_dx(theta_val);
+
+      int size = this->theta_as_field(0).size();
+
+      for (int i = 0; i < size; ++i)
+        this->param_as_field(0).fastAccessDx(i) = this->theta_as_field(0).fastAccessDx(i) * v_dx;
+
+      std::cout << " RandomPhysicalParameter<PHAL::AlbanyTraits::Tangent>::evaluateFields() "
+        << this->param_as_field(0) << " theta " << this->theta_as_field(0) << std::endl;
+    }
+};
+
+// **************************************************************
+// DistParamDeriv
+// **************************************************************
+template<typename Traits>
+class RandomPhysicalParameter<PHAL::AlbanyTraits::DistParamDeriv,Traits>
+  : public RandomPhysicalParameterBase<PHAL::AlbanyTraits::DistParamDeriv, Traits>  {
+
+  public:
+    typedef typename PHAL::AlbanyTraits::DistParamDeriv::ScalarT   ScalarT;
+
+    RandomPhysicalParameter (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::DistParamDeriv, Traits>(p, dl)
+     {
+     }
+
+    void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+    {
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::DistParamDeriv, Traits>::
+        postRegistrationSetup(d, fm);
+    }
+
+    void evaluateFields(typename Traits::EvalData d)
+    {
+      double theta_val = this->theta_as_field(0).val();
+      this->param_as_field(0).val() = this->distribution->fromNormalMapping(theta_val);
+      double v_dx = this->distribution->fromNormalMapping_dx(theta_val);
+
+      int size = this->theta_as_field(0).size();
+
+      for (int i = 0; i < size; ++i)
+        this->param_as_field(0).fastAccessDx(i) = this->theta_as_field(0).fastAccessDx(i) * v_dx;
+
+      std::cout << " RandomPhysicalParameter<PHAL::AlbanyTraits::DistParamDeriv>::evaluateFields() "
+        << this->param_as_field(0) << " theta " << this->theta_as_field(0) << std::endl;
+    }
+};
+
+// **************************************************************
+// HessianVec
+// **************************************************************
+template<typename Traits>
+class RandomPhysicalParameter<PHAL::AlbanyTraits::HessianVec,Traits>
+  : public RandomPhysicalParameterBase<PHAL::AlbanyTraits::HessianVec, Traits>  {
+
+  public:
+    typedef typename PHAL::AlbanyTraits::HessianVec::ScalarT   ScalarT;
+ 
+    RandomPhysicalParameter (const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::Layouts>& dl) :
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::HessianVec, Traits>(p, dl)
+     {
+     }
+
+    void postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& fm)
+    {
+      RandomPhysicalParameterBase<PHAL::AlbanyTraits::HessianVec, Traits>::
+        postRegistrationSetup(d, fm);
+    }
+
+    void evaluateFields(typename Traits::EvalData d)
+    {
+      double theta_val = this->theta_as_field(0).val().val();
+      this->param_as_field(0).val().val() = this->distribution->fromNormalMapping(theta_val);
+      double v_dx = this->distribution->fromNormalMapping_dx(theta_val);
+      double v_dx_dx = this->distribution->fromNormalMapping_dx_dx(theta_val);
+
+      int size_1 = this->theta_as_field(0).size();
+      int size_2 = this->theta_as_field(0).val().size();
+
+      for (int i_1 = 0; i_1 < size_1; ++i_1) {
+        this->param_as_field(0).fastAccessDx(i_1).val() = this->theta_as_field(0).fastAccessDx(i_1).val() * v_dx;
+        for (int i_2 = 0; i_2 < size_2; ++i_2)
+          this->param_as_field(0).fastAccessDx(i_1).fastAccessDx(i_2) = this->theta_as_field(0).fastAccessDx(i_1).fastAccessDx(i_2) * v_dx 
+                                                                        + this->theta_as_field(0).fastAccessDx(i_1).val() * v_dx_dx;
+      }
+
+      for (int i_2 = 0; i_2 < size_2; ++i_2)
+        this->param_as_field(0).val().fastAccessDx(i_2) = this->theta_as_field(0).val().fastAccessDx(i_2) * v_dx;
+      
+
+      std::cout << " RandomPhysicalParameter<PHAL::AlbanyTraits::HessianVec>::evaluateFields() "
+        << this->param_as_field(0) << " theta " << this->theta_as_field(0) << std::endl;
+    }
+};
+
+}  // Namespace PHAL
+
+#endif  // PHAL_READSTATEFIELD_HPP

--- a/src/evaluators/utility/PHAL_RandomPhysicalParameter.hpp
+++ b/src/evaluators/utility/PHAL_RandomPhysicalParameter.hpp
@@ -15,7 +15,7 @@
 
 #include "PHAL_AlbanyTraits.hpp"
 #include "PHAL_SharedParameter.hpp"
-#include "PHAL_UnivariateDistribution.hpp"
+#include "Albany_UnivariateDistribution.hpp"
 
 namespace PHAL {
 ///

--- a/src/evaluators/utility/PHAL_UnivariateDistribution.hpp
+++ b/src/evaluators/utility/PHAL_UnivariateDistribution.hpp
@@ -1,0 +1,300 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_UNIVARIATEDISTRIBUTION_HPP
+#define ALBANY_UNIVARIATEDISTRIBUTION_HPP
+
+#include <boost/math/special_functions/erf.hpp>
+
+namespace Albany
+{
+
+  class UnivariatDistribution
+  {
+    public:
+      UnivariatDistribution()
+      {
+        // Nothing to be done here
+      }
+      UnivariatDistribution(const Teuchos::ParameterList &distributionParams)
+      {
+        // Nothing to be done here
+      }
+      virtual double cdf(const double x) = 0;
+      virtual double cdf_dx(const double x) = 0;
+      virtual double cdf_dx_dx(const double x) = 0;
+
+      virtual double ppf(const double x) = 0;
+      virtual double ppf_dx(const double x) = 0;
+      virtual double ppf_dx_dx(const double x) = 0;
+
+      virtual double toNormalMapping(const double x) = 0;
+      virtual double toNormalMapping_dx(const double x) = 0;
+      virtual double toNormalMapping_dx_dx(const double x) = 0;
+      virtual double fromNormalMapping(const double x) = 0;
+      virtual double fromNormalMapping_dx(const double x) = 0;
+      virtual double fromNormalMapping_dx_dx(const double x) = 0;
+  };
+
+  class NormalDistribution : public virtual UnivariatDistribution
+  {
+    public:
+      NormalDistribution() {
+        mu = 0.;
+        sigma = 1.;
+      }
+      NormalDistribution(const Teuchos::ParameterList &distributionParams) {
+        mu = 0.;
+        sigma = 1.;
+        if (distributionParams.isParameter("Loc"))
+          mu = distributionParams.get<double>("Loc");
+        if (distributionParams.isParameter("Scale"))
+          sigma = distributionParams.get<double>("Scale");
+      }
+      NormalDistribution(double mu_, double sigma_) {
+        mu = mu_;
+        sigma = sigma_;
+      }
+    
+      double cdf(const double x) {
+        return 0.5*(1+erf((x-mu)/(sigma*sqrt(2.))));
+      }
+
+      double cdf_dx(const double x) {
+        return exp(-pow(x-mu,2)/(2*pow(sigma,2)))/(sqrt(2*M_PI)*sigma);
+      }
+
+      double cdf_dx_dx(const double x) {
+        return -exp(-pow(x-mu,2)/(2*pow(sigma,2)))*(x-mu)/(sqrt(2*M_PI)*pow(sigma,3));
+      }
+      
+      double ppf(const double x) {
+        return mu + sigma * sqrt(2) * boost::math::erf_inv(2*x-1);
+      }
+
+      double ppf_dx(const double x) {
+        return sqrt(2*M_PI) * sigma * exp(pow(boost::math::erf_inv(-1+2*x),2));
+      }
+
+      double ppf_dx_dx(const double x) {
+        return 2*sqrt(2)*M_PI * sigma * exp(2*pow(boost::math::erf_inv(-1+2*x),2))*boost::math::erf_inv(2*x-1);
+      }
+
+      double ppf(const double x, const double v) {
+        return mu + sigma * v;
+      }
+
+      double ppf_dx(const double x, const double v) {
+        return sqrt(2*M_PI) * sigma * exp(pow(v/sqrt(2),2));
+      }
+
+      double ppf_dx_dx(const double x, const double v) {
+        return 2*sqrt(2)*M_PI * sigma * exp(2*pow(v/sqrt(2),2))*v/sqrt(2);
+      }
+
+      double toNormalMapping(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf(this->cdf(x));        
+      }
+
+      double toNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx(this->cdf(x)) * this->cdf_dx(x);
+      }
+
+      double toNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx_dx(this->cdf(x)) * pow(this->cdf_dx(x), 2) + standard.ppf_dx(this->cdf(x)) * this->cdf_dx_dx(x);
+      }
+
+      double fromNormalMapping(const double x) {
+        NormalDistribution standard(0, 1);
+        return this->ppf(standard.cdf(x), x);
+      }
+
+      double fromNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return this->ppf_dx(standard.cdf(x), x) * standard.cdf_dx(x);
+      }
+
+      double fromNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return this->ppf_dx_dx(standard.cdf(x), x) * pow(standard.cdf_dx(x), 2) + this->ppf_dx(this->cdf(x), x) * standard.cdf_dx_dx(x);
+      }
+  
+    private:
+      double sigma, mu;
+  };
+
+  class LogNormalDistribution : public virtual UnivariatDistribution
+  {
+    public:
+      LogNormalDistribution(const Teuchos::ParameterList &distributionParams) {
+        mu = 0.;
+        sigma = 1.;
+        if (distributionParams.isParameter("Scale"))
+          sigma = distributionParams.get<double>("Scale");
+      }
+      LogNormalDistribution(double sigma_) {
+        mu = 0.;
+        sigma = sigma_;
+      }
+    
+      double cdf(const double x) {
+        return 0.5*(1+erf(pow(log(x)-mu, 2)/(sigma*sqrt(2.))));
+      }
+
+      double cdf_dx(const double x) {
+        return exp(-pow(log(x)-mu,2)/(2*pow(sigma,2)))/(sqrt(2*M_PI)*sigma*x);
+      }
+
+      double cdf_dx_dx(const double x) {
+        return -exp(-pow(log(x)-mu,2)/(2*pow(sigma,2)))/(sqrt(2*M_PI)*sigma*pow(x,2)) - 2 * ((log(x)-mu)*exp(-pow(log(x)-mu,2)/(2*pow(sigma,2))))/(2*sqrt(2*M_PI)*pow(sigma,3)*pow(x,2));
+      }
+      
+      double ppf(const double x) {
+        return exp(mu + sqrt(2) * sigma * boost::math::erf_inv(2*x-1));
+      }
+
+      double ppf_dx(const double x) {
+        return sqrt(2*M_PI)*sigma*exp(sqrt(2)*sigma*boost::math::erf_inv(2*x-1)+pow(boost::math::erf_inv(2*x-1),2)+mu);
+      }
+
+      double ppf_dx_dx(const double x) {
+        return sqrt(2)*M_PI*sigma*(2*boost::math::erf_inv(2*x-1)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*boost::math::erf_inv(2*x-1)+2*pow(boost::math::erf_inv(2*x-1),2)+mu);
+      }
+
+      double ppf(const double x, const double v) {
+        return exp(mu + sqrt(2) * sigma * v/sqrt(2));
+      }
+
+      double ppf_dx(const double x, const double v) {
+        return sqrt(2*M_PI)*sigma*exp(sqrt(2)*sigma*v/sqrt(2)+pow(v/sqrt(2),2)+mu);
+      }
+
+      double ppf_dx_dx(const double x, const double v) {
+        return sqrt(2)*M_PI*sigma*(2*v/sqrt(2)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*v/sqrt(2)+2*pow(v/sqrt(2),2)+mu);
+      }
+
+      double toNormalMapping(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf(this->cdf(x));        
+      }
+
+      double toNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx(this->cdf(x)) * this->cdf_dx(x);
+      }
+
+      double toNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx_dx(this->cdf(x)) * pow(this->cdf_dx(x), 2) + standard.ppf_dx(this->cdf(x)) * this->cdf_dx_dx(x);
+      }
+
+      double fromNormalMapping(const double x) {
+        NormalDistribution standard(0, 1);
+        if (sigma == 1)
+          return exp(x);
+        return this->ppf(standard.cdf(x), x);        
+      }
+
+      double fromNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        if (sigma == 1)
+          return exp(x);
+        return this->ppf_dx(standard.cdf(x), x) * standard.cdf_dx(x);
+      }
+
+      double fromNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        if (sigma == 1)
+          return exp(x);
+        return this->ppf_dx_dx(standard.cdf(x), x) * pow(standard.cdf_dx(x), 2) + this->ppf_dx(this->cdf(x), x) * standard.cdf_dx_dx(x);
+      }
+  
+    private:
+      double mu, sigma;
+  };
+  
+  class UniformDistribution : public virtual UnivariatDistribution
+  {
+    public:
+      UniformDistribution(const Teuchos::ParameterList &distributionParams) {
+        a = 0.;
+        if (distributionParams.isParameter("Loc"))
+          a = distributionParams.get<double>("Loc");
+        b = a;
+        if (distributionParams.isParameter("Scale"))
+          b += distributionParams.get<double>("Scale");
+        else
+          b += 1.;
+      }
+      UniformDistribution(double a_, double b_) {
+        a = a_;
+        b = b_;
+      }
+    
+      double cdf(const double x) {
+        return (x-a)/(b-a);
+      }
+
+      double cdf_dx(const double x) {
+        return 1./(b-a);
+      }
+
+      double cdf_dx_dx(const double x) {
+        return 0;
+      }
+      
+      double ppf(const double x) {
+        return (b-a) * x + a;
+      }
+
+      double ppf_dx(const double x) {
+        return (b-a);
+      }
+
+      double ppf_dx_dx(const double x) {
+        return 0;
+      }
+
+      double toNormalMapping(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf(this->cdf(x));        
+      }
+
+      double toNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx(this->cdf(x)) * this->cdf_dx(x);
+      }
+
+      double toNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return standard.ppf_dx_dx(this->cdf(x)) * pow(this->cdf_dx(x), 2) + standard.ppf_dx(this->cdf(x)) * this->cdf_dx_dx(x);
+      }
+
+      double fromNormalMapping(const double x) {
+        NormalDistribution standard(0, 1); //static in the class
+        return this->ppf(standard.cdf(x));        
+      }
+
+      double fromNormalMapping_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return this->ppf_dx(standard.cdf(x)) * standard.cdf_dx(x);
+      }
+
+      double fromNormalMapping_dx_dx(const double x) {
+        NormalDistribution standard(0, 1);
+        return this->ppf_dx_dx(standard.cdf(x)) * pow(standard.cdf_dx(x), 2) + this->ppf_dx(this->cdf(x)) * standard.cdf_dx_dx(x);
+      }
+      
+    private:
+      double a, b;
+  };
+
+} // namespace Albany
+
+#endif // ALBANY_UNIVARIATEDISTRIBUTION_HPP

--- a/src/problems/Albany_AbstractProblem.cpp
+++ b/src/problems/Albany_AbstractProblem.cpp
@@ -130,6 +130,7 @@ Albany::AbstractProblem::getGenericProblemParams(std::string listname) const
   validPL->sublist("Absorption", false, "");
   validPL->sublist("Response Functions", false, "");
   validPL->sublist("Parameters", false, "");
+  validPL->sublist("Random Parameters", false, "");
   validPL->sublist("Teko", false, "");
   validPL->sublist("Hessian", false, "");
   validPL->sublist("XFEM", false, "");

--- a/src/problems/Albany_ParamEnum.hpp
+++ b/src/problems/Albany_ParamEnum.hpp
@@ -10,7 +10,9 @@ enum class ParamEnum
 {
   Kappa_x      = 0, //For thermal problem
   Kappa_y      = 1, //For thermal problem
-  Kappa_z      = 2  //For thermal problem
+  Kappa_z      = 2, //For thermal problem
+  Theta_0      = 3,
+  Theta_1      = 4
 };
 
 namespace ParamEnumName
@@ -18,6 +20,8 @@ namespace ParamEnumName
   static const std::string kappa_x       = "kappa_x Parameter"; //For thermal problem
   static const std::string kappa_y       = "kappa_y Parameter"; //For thermal problem
   static const std::string kappa_z       = "kappa_z Parameter"; //For thermal problem
+  static const std::string theta_0       = "Theta 0"; 
+  static const std::string theta_1       = "Theta 1";
 } // ParamEnum
 
 } // Namespace Albany

--- a/src/problems/Albany_ThermalProblem.hpp
+++ b/src/problems/Albany_ThermalProblem.hpp
@@ -270,39 +270,42 @@ Albany::ThermalProblem::constructEvaluators(
 
   if (!conductivityIsDistParam) {  
     //Shared parameter for sensitivity analysis: kappa_x
-    RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_x"));
-    p->set< RCP<ParamLib> >("Parameter Library", paramLib);
     const std::string param_name = "kappa_x Parameter";
-    p->set<std::string>("Parameter Name", param_name);
-    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-    p->set<double>("Default Nominal Value", kappa[0]);
-    if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+
+    if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+      RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_x"));
+      p->set< RCP<ParamLib> >("Parameter Library", paramLib);
+      p->set<std::string>("Parameter Name", param_name);
+      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+      p->set<double>("Default Nominal Value", kappa[0]);
       RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>> ptr_kappa_x;
       ptr_kappa_x = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>(*p,dl));
       fm0.template registerEvaluator<EvalT>(ptr_kappa_x);
     }
 
     if (numDim > 1) {  //Shared parameter for sensitivity analysis: kappa_y
-      RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_y"));
-      p->set< RCP<ParamLib> >("Parameter Library", paramLib);
       const std::string param_name = "kappa_y Parameter";
-      p->set<std::string>("Parameter Name", param_name);
-      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-      p->set<double>("Default Nominal Value", kappa[1]);
-      if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+
+      if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+        RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_y"));
+        p->set< RCP<ParamLib> >("Parameter Library", paramLib);
+        p->set<std::string>("Parameter Name", param_name);
+        p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+        p->set<double>("Default Nominal Value", kappa[1]);
         RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>> ptr_kappa_y;
         ptr_kappa_y = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>(*p,dl));
         fm0.template registerEvaluator<EvalT>(ptr_kappa_y);
       }
     }
     if (numDim > 2) {  //Shared parameter for sensitivity analysis: kappa_z
-      RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_z"));
-      p->set< RCP<ParamLib> >("Parameter Library", paramLib);
       const std::string param_name = "kappa_z Parameter";
-      p->set<std::string>("Parameter Name", param_name);
-      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
-      p->set<double>("Default Nominal Value", kappa[2]);
-      if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+
+      if(!PHAL::is_field_evaluated<EvalT>(fm0, param_name, dl->shared_param)) {
+        RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_z"));
+        p->set< RCP<ParamLib> >("Parameter Library", paramLib);        
+        p->set<std::string>("Parameter Name", param_name);
+        p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+        p->set<double>("Default Nominal Value", kappa[2]);
         RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>> ptr_kappa_z;
         ptr_kappa_z = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>(*p,dl));
         fm0.template registerEvaluator<EvalT>(ptr_kappa_z);

--- a/src/problems/Albany_ThermalProblem.hpp
+++ b/src/problems/Albany_ThermalProblem.hpp
@@ -18,6 +18,11 @@
 
 #include "PHAL_ConvertFieldType.hpp"
 #include "Albany_MaterialDatabase.hpp"
+
+#include "PHAL_RandomPhysicalParameter.hpp"
+
+#include "PHAL_IsAvailable.hpp"
+
 namespace Albany {
 
   /*!
@@ -218,6 +223,51 @@ Albany::ThermalProblem::constructEvaluators(
         evalUtils.constructDOFGradInterpolationEvaluator(dof_names[i]));
   }
 
+
+  {
+    RCP<ParameterList> p = rcp(new ParameterList("Theta 0"));
+    p->set< RCP<ParamLib> >("Parameter Library", paramLib);
+    const std::string param_name = "Theta 0";
+    p->set<std::string>("Parameter Name", param_name);
+    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+    p->set<double>("Default Nominal Value", 0.);
+    RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Theta_0>> ptr_theta_0;
+    ptr_theta_0 = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Theta_0>(*p,dl));
+    fm0.template registerEvaluator<EvalT>(ptr_theta_0);
+  }
+  {
+    RCP<ParameterList> p = rcp(new ParameterList("Theta 1"));
+    p->set< RCP<ParamLib> >("Parameter Library", paramLib);
+    const std::string param_name = "Theta 1";
+    p->set<std::string>("Parameter Name", param_name);
+    p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+    p->set<double>("Default Nominal Value", 0.);
+    RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Theta_1>> ptr_theta_1;
+    ptr_theta_1 = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Theta_1>(*p,dl));
+    fm0.template registerEvaluator<EvalT>(ptr_theta_1);
+  }
+  auto rparams = params->sublist("Random Parameters");
+  if (rparams.isParameter("Number Of Parameters"))
+  {
+    int nrparams = rparams.get<int>("Number Of Parameters");
+    for (int i_rparams=0; i_rparams<nrparams; ++i_rparams)
+    {
+      auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+
+      RCP<ParameterList> p = rcp(new ParameterList("Theta 1"));
+      p->set< RCP<ParamLib> >("Parameter Library", paramLib);
+      const std::string param_name = rparams_i.get<std::string>("Name");
+      p->set<std::string>("Parameter Name", param_name); //output name
+      const std::string rparam_name = rparams_i.get<std::string>("Standard Normal Parameter");
+      p->set<std::string>("Random Parameter Name", rparam_name); //input name
+      p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
+      p->set<const Teuchos::ParameterList*>("Distribution", &rparams_i.sublist("Distribution"));
+      RCP<PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>> ptr_rparam;
+      ptr_rparam = rcp(new PHAL::RandomPhysicalParameter<EvalT,PHAL::AlbanyTraits>(*p,dl));
+      fm0.template registerEvaluator<EvalT>(ptr_rparam);
+    }
+  }
+
   if (!conductivityIsDistParam) {  
     //Shared parameter for sensitivity analysis: kappa_x
     RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_x"));
@@ -226,9 +276,11 @@ Albany::ThermalProblem::constructEvaluators(
     p->set<std::string>("Parameter Name", param_name);
     p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
     p->set<double>("Default Nominal Value", kappa[0]);
-    RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>> ptr_kappa_x;
-    ptr_kappa_x = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>(*p,dl));
-    fm0.template registerEvaluator<EvalT>(ptr_kappa_x);
+    if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+      RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>> ptr_kappa_x;
+      ptr_kappa_x = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_x>(*p,dl));
+      fm0.template registerEvaluator<EvalT>(ptr_kappa_x);
+    }
 
     if (numDim > 1) {  //Shared parameter for sensitivity analysis: kappa_y
       RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_y"));
@@ -237,9 +289,11 @@ Albany::ThermalProblem::constructEvaluators(
       p->set<std::string>("Parameter Name", param_name);
       p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
       p->set<double>("Default Nominal Value", kappa[1]);
-      RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>> ptr_kappa_y;
-      ptr_kappa_y = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>(*p,dl));
-      fm0.template registerEvaluator<EvalT>(ptr_kappa_y);
+      if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+        RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>> ptr_kappa_y;
+        ptr_kappa_y = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_y>(*p,dl));
+        fm0.template registerEvaluator<EvalT>(ptr_kappa_y);
+      }
     }
     if (numDim > 2) {  //Shared parameter for sensitivity analysis: kappa_z
       RCP<ParameterList> p = rcp(new ParameterList("Thermal Conductivity: kappa_z"));
@@ -248,9 +302,11 @@ Albany::ThermalProblem::constructEvaluators(
       p->set<std::string>("Parameter Name", param_name);
       p->set<const Teuchos::ParameterList*>("Parameters List", &params->sublist("Parameters"));
       p->set<double>("Default Nominal Value", kappa[2]);
-      RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>> ptr_kappa_z;
-      ptr_kappa_z = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>(*p,dl));
-      fm0.template registerEvaluator<EvalT>(ptr_kappa_z);
+      if(!PHAL::is_param_available<EvalT>(fm0, param_name, dl->shared_param)) {
+        RCP<PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>> ptr_kappa_z;
+        ptr_kappa_z = rcp(new PHAL::SharedParameter<EvalT,PHAL::AlbanyTraits,Albany::ParamEnum,Albany::ParamEnum::Kappa_z>(*p,dl));
+        fm0.template registerEvaluator<EvalT>(ptr_kappa_z);
+      }
     }
   }
   else //conductivityIsDistParam

--- a/src/utility/Albany_UnivariateDistribution.hpp
+++ b/src/utility/Albany_UnivariateDistribution.hpp
@@ -4,8 +4,8 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef ALBANY_UNIVARIATEDISTRIBUTION_HPP
-#define ALBANY_UNIVARIATEDISTRIBUTION_HPP
+#ifndef ALBANY_UNIVARIATE_DISTRIBUTION_HPP
+#define ALBANY_UNIVARIATE_DISTRIBUTION_HPP
 
 #include <boost/math/special_functions/erf.hpp>
 
@@ -297,4 +297,4 @@ namespace Albany
 
 } // namespace Albany
 
-#endif // ALBANY_UNIVARIATEDISTRIBUTION_HPP
+#endif // ALBANY_UNIVARIATE_DISTRIBUTION_HPP


### PR DESCRIPTION
This PR adds the `RandomPhysicalParameter`, a need type of parameter deduced from a Gaussian random variable and a mapping between the two.

This is used in the extreme event computation to have non-Gaussian random variables.

The tests passed on my workstation.

@mperego 