### PR TITLE
Remove atomic from Kokkos::Serial execution

### DIFF
--- a/src/LandIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
@@ -10,6 +10,7 @@
 
 #include "Albany_DiscretizationUtils.hpp"
 #include "LandIce_StokesFOBasalResid.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 //uncomment the following line if you want debug output to be printed to screen
 // #define OUTPUT_TO_SCREEN
@@ -120,7 +121,7 @@ operator() (const StokesFOBasalResid_Tag&, const int& sideSet_idx) const {
       local_res[1] += (beta(sideSet_idx,qp)*(u0*bx*by + u1*(1.0+by*by)))*BF(sideSet_idx,node,qp)*w_measure(sideSet_idx,qp);
     }
     for (unsigned int dim=0; dim<vecDimFO; ++dim)
-      Kokkos::atomic_add(&residual(cell,sideNodes(side,node),dim), local_res[dim]);
+      KU::atomic_add<ExecutionSpace>(&residual(cell,sideNodes(side,node),dim), local_res[dim]);
   }
 
 }

--- a/src/LandIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
@@ -162,7 +162,7 @@ operator() (const GivenImmersedRatio_Tag&, const int& sideSet_idx) const {
       // NOTE: we are RELYING on the fact that the lateral side is vertical, so that u*n = ux*nx+uy*ny.
       const OutputScalarT w_normal_stress_bf = w_normal_stress * BF(sideSet_idx,node,qp);
       for (unsigned int dim=0; dim<vecDimFO; ++dim) {
-        Kokkos::atomic_add(&residual(cell,sideNode,dim), w_normal_stress_bf * normals(sideSet_idx,qp,dim));
+        KU::atomic_add<ExecutionSpace>(&residual(cell,sideNode,dim), w_normal_stress_bf * normals(sideSet_idx,qp,dim));
       }
     }
   }
@@ -208,7 +208,7 @@ operator() (const ComputedImmersedRatio_Tag&, const int& sideSet_idx) const {
       // NOTE: we are RELYING on the fact that the lateral side is vertical, so that u*n = ux*nx+uy*ny.
       const OutputScalarT w_normal_stress_bf = w_normal_stress * BF(sideSet_idx,node,qp);
       for (unsigned int dim=0; dim<vecDimFO; ++dim) {
-        Kokkos::atomic_add(&residual(cell,sideNode,dim), w_normal_stress_bf * normals(sideSet_idx,qp,dim));
+        KU::atomic_add<ExecutionSpace>(&residual(cell,sideNode,dim), w_normal_stress_bf * normals(sideSet_idx,qp,dim));
       }
     }
   }

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -212,7 +212,7 @@ private:
   using Base::val_kokkos;
 
   typedef typename PHX::Device::execution_space ExecutionSpace;
-  static constexpr bool is_atomic = KU::IsAtomic<ExecutionSpace>::value;
+  static constexpr bool is_atomic = KU::NeedsAtomic<ExecutionSpace>::value;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterResRank0_Tag> PHAL_ScatterResRank0_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterJacRank0_Adjoint_Tag> PHAL_ScatterJacRank0_Adjoint_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterJacRank0_Tag> PHAL_ScatterJacRank0_Policy;

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -18,6 +18,7 @@
 #include "Albany_KokkosTypes.hpp"
 #include "Albany_Layouts.hpp"
 #include "Albany_DiscretizationUtils.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 #include "Teuchos_ParameterList.hpp"
 
@@ -211,6 +212,7 @@ private:
   using Base::val_kokkos;
 
   typedef typename PHX::Device::execution_space ExecutionSpace;
+  static constexpr bool is_atomic = KU::IsAtomic<ExecutionSpace>::value;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterResRank0_Tag> PHAL_ScatterResRank0_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterJacRank0_Adjoint_Tag> PHAL_ScatterJacRank0_Adjoint_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, PHAL_ScatterJacRank0_Tag> PHAL_ScatterJacRank0_Policy;

--- a/src/utility/Albany_KokkosUtils.hpp
+++ b/src/utility/Albany_KokkosUtils.hpp
@@ -10,16 +10,8 @@
 namespace KU
 {
 
+// Check device memory
 #ifdef KOKKOS_ENABLE_CUDA
-
-template <typename T>
-KOKKOS_INLINE_FUNCTION
-const T& max (const T& a, const T& b) { return a > b ? a : b; }
-
-template <typename T>
-KOKKOS_INLINE_FUNCTION
-const T& min (const T& a, const T& b) { return a < b ? a : b; }
-
 inline bool
 IsNearDeviceMemoryLimit()
 {
@@ -28,24 +20,82 @@ IsNearDeviceMemoryLimit()
   cudaMemGetInfo(&free_t,&total_t);
   return free_t < max_free_t;
 }
-
 #else
-
-using std::max;
-using std::min;
-
 inline bool
 IsNearDeviceMemoryLimit()
 {
   return false;
 }
-
 #endif
 
+// Kernel min/max
+#ifdef KOKKOS_ENABLE_CUDA
+template <typename T>
+KOKKOS_INLINE_FUNCTION
+const T& max (const T& a, const T& b) { return a > b ? a : b; }
+
+template <typename T>
+KOKKOS_INLINE_FUNCTION
+const T& min (const T& a, const T& b) { return a < b ? a : b; }
+#else
+using std::max;
+using std::min;
+#endif
 using Sacado::Fad::max;
 using Sacado::Fad::min;
 using Sacado::Fad::Exp::max;
 using Sacado::Fad::Exp::min;
+
+// Choose atomic based on execution space
+template <typename ExeSpace>
+struct IsAtomic
+{
+  enum : bool
+  {
+    value = true
+  };
+};
+
+#ifdef KOKKOS_ENABLE_SERIAL
+template <>
+struct IsAtomic<Kokkos::Serial>
+{
+  enum : bool
+  {
+    value = false
+  };
+};
+#endif
+
+// Kernel atomic add
+template <typename ExeSpace, typename D, typename V>
+struct AtomicAddImpl
+{
+  KOKKOS_FORCEINLINE_FUNCTION static void
+  atomic_add(D dst, const V& val)
+  {
+    Kokkos::atomic_add(dst, val);
+  }
+};
+
+#ifdef KOKKOS_ENABLE_SERIAL
+template <typename D, typename V>
+struct AtomicAddImpl<Kokkos::Serial, D, V>
+{
+  KOKKOS_FORCEINLINE_FUNCTION static void
+  atomic_add(D dst, const V& val)
+  {
+    *dst += val;
+  }
+};
+#endif
+
+template <typename ExeSpace, typename D, typename V>
+KOKKOS_FORCEINLINE_FUNCTION void
+atomic_add(D dst, const V& val)
+{
+  KU::AtomicAddImpl<ExeSpace, D, V>::atomic_add(dst, val);
+}
 
 }
 

--- a/src/utility/Albany_KokkosUtils.hpp
+++ b/src/utility/Albany_KokkosUtils.hpp
@@ -48,7 +48,7 @@ using Sacado::Fad::Exp::min;
 
 // Choose atomic based on execution space
 template <typename ExeSpace>
-struct IsAtomic
+struct NeedsAtomic
 {
   enum : bool
   {
@@ -58,7 +58,7 @@ struct IsAtomic
 
 #ifdef KOKKOS_ENABLE_SERIAL
 template <>
-struct IsAtomic<Kokkos::Serial>
+struct NeedsAtomic<Kokkos::Serial>
 {
   enum : bool
   {


### PR DESCRIPTION
This PR fixes #767. I created some helper structs that decide whether to use an atomic based on execution space (I only avoid the atomic for Kokkos::Serial). I tested it on one of the performance tests on blake and it fixes the performance regression. I'll try testing clang and weaver/cuda.

Albany_KokkosUtils.hpp was a rewrite because it wasn't a unix file...