### PR TITLE
Switch to current correct TriBITS usage of libraries for TeuchosParameterList

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,14 +193,18 @@ if (ALBANY_EPETRA)
   )
 endif()
 
+message("TeuchosParameterList_LIBRARIES = '${TeuchosParameterList_LIBRARIES}'")
+message("TeuchosParameterList_INCLUDE_DIRS = '${TeuchosParameterList_INCLUDE_DIRS}'")
+message("TeuchosParameterList_TPL_INCLUDE_DIRS = '${TeuchosParameterList_TPL_INCLUDE_DIRS}'")
+
 add_executable(xml2yaml utility/xml2yaml.cpp)
 add_executable(yaml2xml utility/yaml2xml.cpp)
-target_link_libraries(xml2yaml teuchosparameterlist)
-target_link_libraries(yaml2xml teuchosparameterlist)
+target_link_libraries(xml2yaml PUBLIC ${TeuchosParameterList_LIBRARIES})
+target_link_libraries(yaml2xml PUBLIC ${TeuchosParameterList_LIBRARIES})
 target_include_directories(yaml2xml SYSTEM PUBLIC
-                          "${Trilinos_INCLUDE_DIRS};${Trilinos_TPL_INCLUDE_DIRS}")
+  "${TeuchosParameterList_INCLUDE_DIRS};${TeuchosParameterList_TPL_INCLUDE_DIRS}")
 target_include_directories(xml2yaml SYSTEM PUBLIC
-                          "${Trilinos_INCLUDE_DIRS};${Trilinos_TPL_INCLUDE_DIRS}")
+  "${TeuchosParameterList_INCLUDE_DIRS};${TeuchosParameterList_TPL_INCLUDE_DIRS}")
 
 #problems
 list (APPEND SOURCES


### PR DESCRIPTION
This Albany CMakeLists.txt file was making assumptions about the implementation details of the TriBITS-generated `<Package>Config.cmake` files that it should not have been making.  It was assuming that the raw TriBITS target
'teuchosparameterlist' existed which is a no-no.  The correct old-school TriBITS usage is `${TeuchosParameterList_LIBRARIES}` and the associated include directories.

This works with old TriBITS and refactored TriBITS as documented in detail with complete reproduction instructions in the internal issue comment:

* https://cee-gitlab.sandia.gov/rabartl/tribitsrefactoring/-/issues/1#note_2118925

With this, Albany builds against Trilinos built with the branch in https://github.com/trilinos/Trilinos/pull/9978 for the repo versions:

```
*** Git Repo: Albany
a4ddf552088a876f908b0721010d38feca0d6a4a [Wed Jan 12 09:23:56 2022 -0700] <rabartl@sandia.gov>
Switch to current correct TriBITS usage of libraries for TeuchosParameterList
*** Git Repo: Trilinos
3ff4b9c0c7d0833547348ad3c5d607c0d0d65d58 [Tue Jan 11 20:05:37 2022 -0700] <rabartl@sandia.gov>
Merge commit '7b1fc5a1bf77449b6eeb53996cf30bcf15d0a7ee' into tribits-299-modern-cmake-targets-1-again-albany
```

and passes the Albany test suite run on 

```
$ rm ctest.out ; time ctest -j15 &> ctest.out ; grep -B 1 -A 100 "failed out of" ctest.out

real    4m57.432s
user    77m24.118s
sys     9m17.570s

100% tests passed, 0 tests failed out of 137

Label Time Summary:
Adjoint        = 402.93 sec*proc (8 tests)
Analysis       = 158.33 sec*proc (4 tests)
Basic          = 1408.41 sec*proc (75 tests)
Demo           = 1391.30 sec*proc (46 tests)
Epetra         = 941.97 sec*proc (53 tests)
Forward        = 2238.45 sec*proc (109 tests)
ROL            = 107.63 sec*proc (3 tests)
RegressFail    = 155.54 sec*proc (3 tests)
Serial         = 654.27 sec*proc (19 tests)
Tempus         =  15.16 sec*proc (1 test)
Tpetra         = 1857.73 sec*proc (68 tests)

Total Test time (real) = 297.39 sec
```



This is related to trilinos/Trilinos#9972 and PR trilinos/Trilinos#9978