### PR TITLE
Minor string utils clean up and add-on

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -12,30 +12,30 @@
 #include "Albany_ResponseFactory.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_Utils.hpp"
+#include "Albany_DataTypes.hpp"
+#include "Albany_DummyParameterAccessor.hpp"
+#include "Albany_ScalarResponseFunction.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "PHAL_Utilities.hpp"
+#include "Albany_KokkosUtils.hpp"
+#include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_Hessian.hpp"
+
 #include "Thyra_MultiVectorStdOps.hpp"
 #include "Thyra_VectorBase.hpp"
 #include "Thyra_VectorStdOps.hpp"
 
 #include "Teuchos_TimeMonitor.hpp"
+#include "Zoltan2_TpetraCrsColorer.hpp"
 
-#include <stdexcept>
-#include <string>
-#include "Albany_DataTypes.hpp"
-
-#include "Albany_DummyParameterAccessor.hpp"
 
 #ifdef ALBANY_TEKO
 #include "Teko_InverseFactoryOperator.hpp"
 #endif
 
-#include "Albany_ScalarResponseFunction.hpp"
-#include "PHAL_Utilities.hpp"
-#include "Albany_KokkosUtils.hpp"
-
-#include "Albany_TpetraThyraUtils.hpp"
-#include "Zoltan2_TpetraCrsColorer.hpp"
-
-#include "Albany_Hessian.hpp"
+#include <stdexcept>
+#include <string>
 
 //#define WRITE_TO_MATRIX_MARKET
 //#define DEBUG_OUTPUT
@@ -2511,11 +2511,11 @@ Application::evaluateResponseHessian_pp(
   validHessianResponseParams->set<bool>("Reconstruct H_pp", false);
 
   for (int i=0; i<problemParams->sublist("Parameters").get<int>("Number Of Parameters"); ++i)
-    validHessianResponseParams->set<bool>(Albany::strint("Replace H_pp with Identity for Parameter", i), false);
+    validHessianResponseParams->set<bool>(util::strint("Replace H_pp with Identity for Parameter", i), false);
 
-  auto hessianResponseParams = problemParams->sublist("Hessian").sublist(Albany::strint("Response", response_index));
+  auto hessianResponseParams = problemParams->sublist("Hessian").sublist(util::strint("Response", response_index));
   hessianResponseParams.validateParametersAndSetDefaults(*validHessianResponseParams, 0);
-  bool replace_by_I = hessianResponseParams.get<bool>(Albany::strint("Replace H_pp with Identity for Parameter", parameter_index));
+  bool replace_by_I = hessianResponseParams.get<bool>(util::strint("Replace H_pp with Identity for Parameter", parameter_index));
 
   if (replace_by_I) {
     auto rangeMap = Ht->getRangeMap();
@@ -3153,7 +3153,7 @@ Application::registerShapeParameters()
   if (shapeParamNames.size() == 0) {
     shapeParamNames.resize(numShParams);
     for (int i = 0; i < numShParams; i++)
-      shapeParamNames[i] = strint("ShapeParam", i);
+      shapeParamNames[i] = util::strint("ShapeParam", i);
   }
   DummyParameterAccessor<PHAL::AlbanyTraits::Jacobian, SPL_Traits>* dJ =
       new DummyParameterAccessor<PHAL::AlbanyTraits::Jacobian, SPL_Traits>();

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -15,6 +15,7 @@
 
 #include "Albany_TpetraThyraUtils.hpp"
 #include "Albany_Hessian.hpp"
+#include "Albany_StringUtils.hpp"
 
 // uncomment the following to write stuff out to matrix market to debug
 //#define WRITE_TO_MATRIX_MARKET
@@ -76,7 +77,7 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
   param_lower_bds.resize(num_param_vecs);
   param_upper_bds.resize(num_param_vecs);
   for (int l = 0; l < num_param_vecs; ++l) {
-    const Teuchos::ParameterList& pList = parameterParams.sublist(Albany::strint("Parameter", l));
+    const Teuchos::ParameterList& pList = parameterParams.sublist(util::strint("Parameter", l));
 
     const std::string& parameterType = pList.isParameter("Type") ?
         pList.get<std::string>("Type") : std::string("Scalar");
@@ -104,7 +105,7 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
           Teuchos::rcp(new Teuchos::Array<std::string>(numParameters));
       for (int k = 0; k < numParameters; ++k) {
         (*param_names[l])[k] =
-            pList.sublist(Albany::strint("Scalar", k)).get<std::string>("Name");
+            pList.sublist(util::strint("Scalar", k)).get<std::string>("Name");
       }
       *out << "Number of parameters in parameter vector " << l << " = "
           << numParameters << std::endl;
@@ -146,7 +147,7 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
     // Create Thyra vector for parameters
     param_vecs[l] = Thyra::createMember(param_vss[l]);
 
-    const Teuchos::ParameterList& pList = parameterParams.sublist(strint("Parameter",l));
+    const Teuchos::ParameterList& pList = parameterParams.sublist(util::strint("Parameter",l));
 
     int numParameters = param_vss[l]->dim();
 
@@ -200,7 +201,7 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
       auto param_vec_nonConstView = getNonconstLocalData(param_vecs[l]);
 
       for (int k = 0; k < numParameters; ++k) {
-        std::string sublistName = strint("Scalar",k);
+        std::string sublistName = util::strint("Scalar",k);
 	//IKT: I believe the following parameters are only for optimization
         if (pList.sublist(sublistName).isParameter("Lower Bound")) {
           ST lb = pList.sublist(sublistName).get<ST>("Lower Bound");
@@ -228,7 +229,7 @@ ModelEvaluator (const Teuchos::RCP<Albany::Application>&    app_,
   std::string p_name;
   std::string  emptyString("");
   for (int i = num_param_vecs; i < total_num_param_vecs; i++) {
-    const std::string& p_sublist_name = strint("Parameter", i);
+    const std::string& p_sublist_name = util::strint("Parameter", i);
     Teuchos::ParameterList param_list = parameterParams.sublist(p_sublist_name);
 
     p_name = param_list.get<std::string>("Name");
@@ -801,8 +802,8 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
 
     std::vector<std::string> toDisableVec, toEnableVec;
 
-    Albany::splitStringOnDelim(toDisable,' ',toDisableVec);
-    Albany::splitStringOnDelim(toEnable,' ',toEnableVec);
+    util::splitStringOnDelim(toDisable,' ',toDisableVec);
+    util::splitStringOnDelim(toEnable,' ',toEnableVec);
 
     for (auto toDisableEntry : toDisableVec)
       for (auto toEnableEntry : toEnableVec)
@@ -912,11 +913,11 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
     // Default value for response:
     bool dADHessVec_g, supportHpp;
 
-    if(hessParams.isSublist(Albany::strint("Response", i))) {
-      dADHessVec_g = hessParams.sublist(Albany::strint("Response", i)).isParameter("Use AD for Hessian-vector products (default)") ?
-        hessParams.sublist(Albany::strint("Response", i)).get<bool>("Use AD for Hessian-vector products (default)") : dADHessVec;
-      supportHpp = hessParams.sublist(Albany::strint("Response", i)).isParameter("Reconstruct H_pp") ?
-        hessParams.sublist(Albany::strint("Response", i)).get<bool>("Reconstruct H_pp") : true;
+    if(hessParams.isSublist(util::strint("Response", i))) {
+      dADHessVec_g = hessParams.sublist(util::strint("Response", i)).isParameter("Use AD for Hessian-vector products (default)") ?
+        hessParams.sublist(util::strint("Response", i)).get<bool>("Use AD for Hessian-vector products (default)") : dADHessVec;
+      supportHpp = hessParams.sublist(util::strint("Response", i)).isParameter("Reconstruct H_pp") ?
+        hessParams.sublist(util::strint("Response", i)).get<bool>("Reconstruct H_pp") : true;
     }
     else {
       dADHessVec_g = dADHessVec;
@@ -951,16 +952,16 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
       }
     }
     
-    if(hessParams.isSublist(Albany::strint("Response", i))) {
-      std::string toDisable = hessParams.sublist(Albany::strint("Response", i)).isParameter("Disable AD for Hessian-vector product contributions of") ?
-        hessParams.sublist(Albany::strint("Response", i)).get<std::string>("Disable AD for Hessian-vector product contributions of") : "";
-      std::string toEnable = hessParams.sublist(Albany::strint("Response", i)).isParameter("Enable AD for Hessian-vector product contributions of") ?
-        hessParams.sublist(Albany::strint("Response", i)).get<std::string>("Enable AD for Hessian-vector product contributions of") : "";
+    if(hessParams.isSublist(util::strint("Response", i))) {
+      std::string toDisable = hessParams.sublist(util::strint("Response", i)).isParameter("Disable AD for Hessian-vector product contributions of") ?
+        hessParams.sublist(util::strint("Response", i)).get<std::string>("Disable AD for Hessian-vector product contributions of") : "";
+      std::string toEnable = hessParams.sublist(util::strint("Response", i)).isParameter("Enable AD for Hessian-vector product contributions of") ?
+        hessParams.sublist(util::strint("Response", i)).get<std::string>("Enable AD for Hessian-vector product contributions of") : "";
 
       std::vector<std::string> toDisableVec, toEnableVec;
 
-      Albany::splitStringOnDelim(toDisable,' ',toDisableVec);
-      Albany::splitStringOnDelim(toEnable,' ',toEnableVec);
+      util::splitStringOnDelim(toDisable,' ',toDisableVec);
+      util::splitStringOnDelim(toEnable,' ',toEnableVec);
 
       for (auto toDisableEntry : toDisableVec)
         for (auto toEnableEntry : toEnableVec)
@@ -1312,7 +1313,7 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
   std::vector<std::string> all_param_names(num_params);
 
   for (int l1 = 0; l1 < num_param_vecs; l1++) {
-    all_param_names[l1] = Albany::strint("parameter_vector", l1);
+    all_param_names[l1] = util::strint("parameter_vector", l1);
   }
   for (int l1 = 0; l1 < num_dist_param_vecs; l1++) {
     all_param_names[l1 + num_param_vecs] = dist_param_names[l1];

--- a/src/Albany_ObserverImpl.cpp
+++ b/src/Albany_ObserverImpl.cpp
@@ -8,6 +8,8 @@
 
 #include "Albany_DistributedParameterLibrary.hpp"
 #include "Albany_AbstractDiscretization.hpp"
+#include "Albany_StringUtils.hpp"
+
 #include <stdexcept>
 
 
@@ -94,7 +96,7 @@ parametersChanged()
       int num_parameters = params_pl.get<int>("Number Of Parameters");
       for (int i=0; i<num_parameters; ++i)
       {
-        const Teuchos::ParameterList& pvi = params_pl.sublist(Albany::strint("Parameter",i));
+        const Teuchos::ParameterList& pvi = params_pl.sublist(util::strint("Parameter",i));
 
         std::string parameterType = "Scalar";
 
@@ -107,7 +109,7 @@ parametersChanged()
           int m = pvi.get<int>("Dimension");
           for (int j=0; j<m; ++j)
           {
-            const Teuchos::ParameterList& pj = pvi.sublist(Albany::strint("Scalar",j));
+            const Teuchos::ParameterList& pj = pvi.sublist(util::strint("Scalar",j));
             p_names.push_back(pj.get<std::string>("Name"));
           }
         }

--- a/src/Albany_RegressionTests.cpp
+++ b/src/Albany_RegressionTests.cpp
@@ -9,6 +9,7 @@
 #include "Albany_ModelEvaluator.hpp"
 #include "Albany_Application.hpp"
 #include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_Macros.hpp"
 
@@ -80,7 +81,7 @@ std::pair<int,int> RegressionTests::checkSensitivity(
         testParams->get<double>("Absolute Tolerance") : 1.0e-8;
 
     std::string sensitivity_sublist_name =
-        strint("Sensitivity For Parameter", parameter_index);
+        util::strint("Sensitivity For Parameter", parameter_index);
 
     if (testParams->isSublist(sensitivity_sublist_name)) {
       // Repeat comparisons for sensitivities
@@ -95,7 +96,7 @@ std::pair<int,int> RegressionTests::checkSensitivity(
         Teuchos::Array<double> testSensValues;
 
         const Teuchos::ParameterList& paramList = appParams->sublist("Problem").sublist("Parameters");
-        const Teuchos::ParameterList& paramSublist = paramList.sublist(strint("Parameter", parameter_index));
+        const Teuchos::ParameterList& paramSublist = paramList.sublist(util::strint("Parameter", parameter_index));
         const std::string parameterType = paramSublist.isParameter("Type") ?
             paramSublist.get<std::string>("Type") : std::string("Scalar");
         if (parameterType == "Vector") {
@@ -172,7 +173,7 @@ assertNoSensitivityTests(
 
   if (testParams != NULL) {
     std::string sensitivity_sublist_name =
-        strint("Sensitivity For Parameter", parameter_index);
+        util::strint("Sensitivity For Parameter", parameter_index);
 
     ALBANY_ASSERT(!testParams->isSublist(sensitivity_sublist_name), error_msg);
   }
@@ -230,7 +231,7 @@ Teuchos::ParameterList*
 RegressionTests::getTestParameters(int response_index) const
 {
   Teuchos::ParameterList* result = &(appParams->sublist(
-      strint("Regression For Response", response_index)));
+      util::strint("Regression For Response", response_index)));
   if(result->isParameter("Test Value"))
     result->validateParameters(
         *getValidRegressionResultsParameters(), 0);
@@ -282,18 +283,18 @@ RegressionTests::getValidRegressionResultsParameters() const
 
   const int maxSensTests = 10;
   for (int i = 0; i < maxSensTests; i++) {
-    std::string sublist_name = strint("Sensitivity For Parameter", i);
+    std::string sublist_name = util::strint("Sensitivity For Parameter", i);
     validPL->sublist(sublist_name, false, "Sensitivity regression sublist");
 
     validPL->sublist(sublist_name).set<double>(
-        strint("Test Value", i),
+        util::strint("Test Value", i),
         0.,
-        strint(
+        util::strint(
             "Array of regression values for Sensitivities w.r.t parameter", i));
     validPL->sublist(sublist_name).set<Array<double>>(
-        strint("Test Values", i),
+        util::strint("Test Values", i),
         ta,
-        strint(
+        util::strint(
             "Array of regression values for Sensitivities w.r.t parameters", i));
   }
 
@@ -316,9 +317,9 @@ RegressionTests::getValidRegressionResultsParameters() const
   const int maxSGTests = 10;
   for (int i = 0; i < maxSGTests; i++) {
     validPL->set<Array<double>>(
-        strint("Stochastic Galerkin Expansion Test Values", i),
+        util::strint("Stochastic Galerkin Expansion Test Values", i),
         ta,
-        strint(
+        util::strint(
             "Array of regression values for stochastic Galerkin expansions",
             i));
   }

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -11,6 +11,7 @@
 #include "Albany_Utils.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_Macros.hpp"
+#include "Albany_StringUtils.hpp"
 
 #include "Piro_ProviderBase.hpp"
 #include "Piro_NOXSolver.hpp"
@@ -333,7 +334,7 @@ SolverFactory::getValidAppParameters() const
   validPL->sublist("Quadrature", false, "Quadrature sublist");
   const int maxRegression = 10;
   for (int i = 0; i < maxRegression; i++) {
-    validPL->sublist(strint("Regression For Response", i), false, "Regression Results sublist");
+    validPL->sublist(util::strint("Regression For Response", i), false, "Regression Results sublist");
   }
   validPL->sublist("VTK", false, "DEPRECATED  VTK sublist");
   validPL->sublist("Piro", false, "Piro sublist");
@@ -393,7 +394,7 @@ SolverFactory::getValidParameterParameters() const
   validPL->set<int>("Number", 0);
   const int maxParameters = 100;
   for (int i = 0; i < maxParameters; i++) {
-    validPL->set<std::string>(strint("Parameter", i), "");
+    validPL->set<std::string>(util::strint("Parameter", i), "");
   }
   return validPL;
 }
@@ -412,7 +413,7 @@ SolverFactory::getValidResponseParameters() const
       "Array of responses for which relative change will be obtained");
   const int maxNumResponses = 50;
   for (int i = 0; i < maxNumResponses; i++)
-    validPL->sublist(strint("Response", i), false, "Response sublist");
+    validPL->sublist(util::strint("Response", i), false, "Response sublist");
   return validPL;
 }
 

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -260,49 +260,6 @@ strint(const std::string s, const int i, const char delim)
   return ss.str();
 }
 
-bool
-isValidInitString(const std::string& initString)
-{
-  // Make sure the first part of the string has the correct verbiage
-  std::string verbiage("initial value ");
-  size_t      pos = initString.find(verbiage);
-  if (pos != 0) return false;
-
-  // Make sure the rest of the string has only allowable characters
-  std::string valueString =
-      initString.substr(verbiage.size(), initString.size() - verbiage.size());
-  for (std::string::iterator it = valueString.begin(); it != valueString.end();
-       it++) {
-    std::string charAsString(1, *it);
-    pos = charAsString.find_first_of("0123456789.-+eE");
-    if (pos == std::string::npos) return false;
-  }
-
-  return true;
-}
-
-std::string
-doubleToInitString(double val)
-{
-  std::string       verbiage("initial value ");
-  std::stringstream ss;
-  ss << verbiage << val;
-  return ss.str();
-}
-
-double
-initStringToDouble(const std::string& initString)
-{
-  ALBANY_ASSERT(
-      isValidInitString(initString),
-      " initStringToDouble() called with invalid initialization string: "
-          << initString);
-  std::string verbiage("initial value ");
-  std::string valueString =
-      initString.substr(verbiage.size(), initString.size() - verbiage.size());
-  return std::atof(valueString.c_str());
-}
-
 void
 splitStringOnDelim(
     const std::string&        s,

--- a/src/Albany_Utils.cpp
+++ b/src/Albany_Utils.cpp
@@ -9,6 +9,7 @@
 #include "Albany_Macros.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_GitVersion.h"
+#include "Albany_StringUtils.hpp"
 
 // Include the concrete Epetra Comm's, if needed
 #if defined(ALBANY_EPETRA)
@@ -116,7 +117,7 @@ CalculateNumberParams(const Teuchos::RCP<const Teuchos::ParameterList> problemPa
     int  num_param_vecs = parameterParams.get<int>("Number Of Parameters");
     for (int i = 0; i < num_param_vecs; ++i) {
       const Teuchos::ParameterList& pList =
-          parameterParams.sublist(Albany::strint("Parameter", i));
+          parameterParams.sublist(util::strint("Parameter", i));
       const std::string& parameterType = pList.isParameter("Type") ?
           pList.get<std::string>("Type") : std::string("Scalar");
       if(parameterType == "Scalar" || parameterType == "Distributed")
@@ -151,7 +152,7 @@ getParameterSizes(const Teuchos::ParameterList parameterParams, int &total_num_p
 
   for (int l = 0; l < total_num_param_vecs; ++l) {
     const Teuchos::ParameterList& pList =
-        parameterParams.sublist(Albany::strint("Parameter", l));
+        parameterParams.sublist(util::strint("Parameter", l));
 
     const std::string parameterType = pList.isParameter("Type") ?
         pList.get<std::string>("Type") : std::string("Scalar");
@@ -250,25 +251,6 @@ AbsRowSum(
     }
     absRowSumsTpetra_nonconstView[row] = scale;
   }
-}
-
-std::string
-strint(const std::string s, const int i, const char delim)
-{
-  std::ostringstream ss;
-  ss << s << delim << i;
-  return ss.str();
-}
-
-void
-splitStringOnDelim(
-    const std::string&        s,
-    char                      delim,
-    std::vector<std::string>& elems)
-{
-  std::stringstream ss(s);
-  std::string       item;
-  while (std::getline(ss, item, delim)) { elems.push_back(item); }
 }
 
 std::string

--- a/src/Albany_Utils.hpp
+++ b/src/Albany_Utils.hpp
@@ -52,19 +52,6 @@ AbsRowSum(
     Teuchos::RCP<Tpetra_Vector>&         absRowSumsTpetra,
     const Teuchos::RCP<Tpetra_CrsMatrix> matrix);
 
-//! Utility to make a string out of a string + int with a delimiter:
-//! strint("dog",2,' ') = "dog 2"
-//! The default delimiter is ' '. Potential delimiters include '_' - "dog_2"
-std::string
-strint(const std::string s, const int i, const char delim = ' ');
-
-//! Splits a std::string on a delimiter
-void
-splitStringOnDelim(
-    const std::string&        s,
-    char                      delim,
-    std::vector<std::string>& elems);
-
 /// Get file name extension
 std::string
 getFileExtension(std::string const& filename);

--- a/src/Albany_Utils.hpp
+++ b/src/Albany_Utils.hpp
@@ -58,21 +58,6 @@ AbsRowSum(
 std::string
 strint(const std::string s, const int i, const char delim = ' ');
 
-//! Returns true of the given string is a valid initialization string of the
-//! format "initial value 1.54"
-bool
-isValidInitString(const std::string& initString);
-
-//! Converts a double to an initialization string:  doubleToInitString(1.54) =
-//! "initial value 1.54"
-std::string
-doubleToInitString(double val);
-
-//! Converts an init string to a double:  initStringToDouble("initial value
-//! 1.54") = 1.54
-double
-initStringToDouble(const std::string& initString);
-
 //! Splits a std::string on a delimiter
 void
 splitStringOnDelim(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -158,7 +158,7 @@ list (APPEND HEADERS
   utility/DisplayTable.hpp
   utility/MonitorBase.hpp
   utility/PerformanceContext.hpp
-  utility/string.hpp
+  utility/Albany_StringUtils.hpp
   utility/TimeGuard.hpp
   utility/TimeMonitor.hpp
   utility/Albany_CombineAndScatterManager.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,6 +144,7 @@ list (APPEND SOURCES
   utility/Albany_Gather.cpp
   utility/Albany_GlobalLocalIndexer.cpp
   utility/Albany_Hessian.cpp
+  utility/Albany_StringUtils.cpp
   utility/Albany_ThyraCrsMatrixFactory.cpp
   utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
   utility/Albany_ThyraUtils.cpp

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -15,7 +15,7 @@
 
 #include "LandIce_BasalFrictionCoefficient.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 #include "Albany_Utils.hpp"
 
@@ -272,7 +272,7 @@ BasalFrictionCoefficient (const Teuchos::ParameterList& p,
         if (!is_power_parameter) {
           int nrparams = rparams.get<int>("Number Of Parameters");
           for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
-            auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+            auto rparams_i = rparams.sublist(util::strint("Parameter",i_rparams));
             if (rparams_i.get<std::string>("Name") == "Power Exponent") {
               is_power_parameter = true;
               break;

--- a/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -15,7 +15,7 @@
 
 #include "LandIce_BasalFrictionCoefficient.hpp"
 
-#include <string.hpp> // for 'upper_case' (comes from src/utility; not to be confused with <string>)
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 #include "Albany_Utils.hpp"
 

--- a/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
+++ b/src/LandIce/evaluators/LandIce_EnthalpyBasalResid.hpp
@@ -16,6 +16,7 @@
 #include "PHAL_Dimension.hpp"
 #include "Albany_Layouts.hpp"
 #include "Albany_ScalarOrdinalTypes.hpp"
+#include "Albany_DiscretizationUtils.hpp"
 
 namespace LandIce
 {

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
@@ -14,7 +14,7 @@
 
 #include "LandIce_StokesFOSynteticTestBC.hpp"
 
-#include <string.hpp> // For util::upper_case (do not confuse this with <string>! string.hpp is an Albany file)
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 //uncomment the following line if you want debug output to be printed to screen
 // #define OUTPUT_TO_SCREEN

--- a/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
@@ -14,7 +14,7 @@
 
 #include "LandIce_StokesFOSynteticTestBC.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 //uncomment the following line if you want debug output to be printed to screen
 // #define OUTPUT_TO_SCREEN

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
@@ -1,5 +1,5 @@
 #include "LandIce_HydrologySurfaceWaterInput.hpp"
-#include "utility/string.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 #include "Phalanx_DataLayout.hpp"
 #include "Phalanx_Print.hpp"

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologySurfaceWaterInput_Def.hpp
@@ -1,5 +1,5 @@
 #include "LandIce_HydrologySurfaceWaterInput.hpp"
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 #include "Phalanx_DataLayout.hpp"
 #include "Phalanx_Print.hpp"

--- a/src/LandIce/interface_with_mpas/Interface.cpp
+++ b/src/LandIce/interface_with_mpas/Interface.cpp
@@ -47,7 +47,7 @@
 #include "Teuchos_TimeMonitor.hpp"
 #include "Albany_GlobalLocalIndexer.hpp"
 
-#include "string.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 #ifdef ALBANY_SEACAS
 #include <stk_io/IossBridge.hpp>

--- a/src/LandIce/interface_with_mpas/Interface.cpp
+++ b/src/LandIce/interface_with_mpas/Interface.cpp
@@ -18,14 +18,6 @@
 //! Includes
 // ===================================================
 
-#include <fstream>
-#include <vector>
-#include <mpi.h>
-#include <list>
-#include <iostream>
-#include <limits>
-#include <cmath>
-
 #include "LandIce_ProblemFactory.hpp"
 
 #include "Albany_MpasSTKMeshStruct.hpp"
@@ -47,13 +39,21 @@
 #include "Teuchos_TimeMonitor.hpp"
 #include "Albany_GlobalLocalIndexer.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 #ifdef ALBANY_SEACAS
 #include <stk_io/IossBridge.hpp>
 #include <stk_io/StkMeshIoBroker.hpp>
 #include <Ionit_Initializer.h>
 #endif
+
+#include <fstream>
+#include <vector>
+#include <mpi.h>
+#include <list>
+#include <iostream>
+#include <limits>
+#include <cmath>
 
 Teuchos::RCP<Albany::MpasSTKMeshStruct> meshStruct;
 Teuchos::RCP<Albany::Application> albanyApp;
@@ -606,17 +606,17 @@ void velocity_solver_extrude_3d_grid(int nLayers, int globalTrianglesStride,
   auto& rfi = discretizationList->sublist("Required Fields Info");
   int fp = rfi.get<int>("Number Of Fields",0);
   discretizationList->sublist("Required Fields Info").set<int>("Number Of Fields",fp+10);
-  Teuchos::ParameterList& field0  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",0+fp));
-  Teuchos::ParameterList& field1  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",1+fp));
-  Teuchos::ParameterList& field2  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",2+fp));
-  Teuchos::ParameterList& field3  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",3+fp));
-  Teuchos::ParameterList& field4  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",4+fp));
-  Teuchos::ParameterList& field5  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",5+fp));
-  Teuchos::ParameterList& field6  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",6+fp));
-  Teuchos::ParameterList& field7  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",7+fp));
-  Teuchos::ParameterList& field8  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",8+fp));
-  Teuchos::ParameterList& field9  = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",9+fp));
-  //Teuchos::ParameterList& field10 = discretizationList->sublist("Required Fields Info").sublist(Albany::strint("Field",10+fp));
+  Teuchos::ParameterList& field0  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",0+fp));
+  Teuchos::ParameterList& field1  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",1+fp));
+  Teuchos::ParameterList& field2  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",2+fp));
+  Teuchos::ParameterList& field3  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",3+fp));
+  Teuchos::ParameterList& field4  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",4+fp));
+  Teuchos::ParameterList& field5  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",5+fp));
+  Teuchos::ParameterList& field6  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",6+fp));
+  Teuchos::ParameterList& field7  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",7+fp));
+  Teuchos::ParameterList& field8  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",8+fp));
+  Teuchos::ParameterList& field9  = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",9+fp));
+  //Teuchos::ParameterList& field10 = discretizationList->sublist("Required Fields Info").sublist(util::strint("Field",10+fp));
 
   //set temperature
   field0.set<std::string>("Field Name", "temperature");

--- a/src/LandIce/problems/LandIce_Enthalpy.cpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.cpp
@@ -103,7 +103,7 @@ buildProblem(Teuchos::ArrayRCP<Teuchos::RCP<Albany::MeshSpecsStruct> >  meshSpec
 
 	  std::string fieldType, fieldUsage, meshPart;
 	  for (unsigned int ifield=0; ifield<num_fields; ++ifield) {
-	    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(Albany::strint("Field", ifield));
+	    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(util::strint("Field", ifield));
 
 	    // Get current state specs
 	    volumeFields.insert(thisFieldList.get<std::string>("Field Name"));

--- a/src/LandIce/problems/LandIce_Enthalpy.hpp
+++ b/src/LandIce/problems/LandIce_Enthalpy.hpp
@@ -8,28 +8,6 @@
 #ifndef LANDICE_ENTHALPY_PROBLEM_HPP
 #define LANDICE_ENTHALPY_PROBLEM_HPP
 
-#include "Intrepid2_DefaultCubatureFactory.hpp"
-#include "Shards_CellTopology.hpp"
-#include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"
-
-#include "Albany_AbstractProblem.hpp"
-#include "Albany_Utils.hpp"
-#include "Albany_ProblemUtils.hpp"
-#include "Albany_EvaluatorUtils.hpp"
-#include "Albany_GeneralPurposeFieldsNames.hpp"
-#include "Albany_ScalarOrdinalTypes.hpp"
-#include "Albany_FieldUtils.hpp"
-
-#include "PHAL_Workset.hpp"
-#include "PHAL_Dimension.hpp"
-#include "PHAL_AlbanyTraits.hpp"
-#include "PHAL_SaveCellStateField.hpp"
-#include "PHAL_SaveStateField.hpp"
-#include "PHAL_LoadSideSetStateField.hpp"
-#include "PHAL_ScatterScalarNodalParameter.hpp"
-#include "PHAL_SharedParameter.hpp"
-
 #include "LandIce_EnthalpyResid.hpp"
 #include "LandIce_EnthalpyBasalResid.hpp"
 #include "LandIce_w_Resid.hpp"
@@ -43,6 +21,29 @@
 #include "LandIce_SurfaceAirEnthalpy.hpp"
 #include "LandIce_ParamEnum.hpp"
 #include "LandIce_ResponseUtilities.hpp"
+
+#include "Albany_AbstractProblem.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_ProblemUtils.hpp"
+#include "Albany_EvaluatorUtils.hpp"
+#include "Albany_GeneralPurposeFieldsNames.hpp"
+#include "Albany_ScalarOrdinalTypes.hpp"
+#include "Albany_FieldUtils.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "PHAL_Workset.hpp"
+#include "PHAL_Dimension.hpp"
+#include "PHAL_AlbanyTraits.hpp"
+#include "PHAL_SaveCellStateField.hpp"
+#include "PHAL_SaveStateField.hpp"
+#include "PHAL_LoadSideSetStateField.hpp"
+#include "PHAL_ScatterScalarNodalParameter.hpp"
+#include "PHAL_SharedParameter.hpp"
+
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+#include "Shards_CellTopology.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
 
 namespace LandIce
 {
@@ -184,7 +185,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
       unsigned int num_fields = req_fields_info.get<int>("Number Of Fields",0);
       for (unsigned int ifield=0; ifield<num_fields; ++ifield)
       {
-        const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(Albany::strint("Field", ifield));
+        const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(util::strint("Field", ifield));
         if(thisFieldList.get<std::string>("Field Name") ==  stateName){
           unsigned int numLayers = thisFieldList.get<int>("Number Of Layers");
           auto sns = dl_basal->node_vector;
@@ -210,7 +211,7 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
       unsigned int num_fields = req_fields_info.get<int>("Number Of Fields",0);
       for (unsigned int ifield=0; ifield<num_fields; ++ifield)
       {
-        const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(Albany::strint("Field", ifield));
+        const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(util::strint("Field", ifield));
         if(thisFieldList.get<std::string>("Field Name") ==  stateName){
           unsigned int numLayers = thisFieldList.get<int>("Number Of Layers");
           auto sns = dl_basal->node_vector;

--- a/src/LandIce/problems/LandIce_Hydrology.hpp
+++ b/src/LandIce/problems/LandIce_Hydrology.hpp
@@ -7,22 +7,6 @@
 #ifndef LANDICE_HYDROLOGY_PROBLEM_HPP
 #define LANDICE_HYDROLOGY_PROBLEM_HPP
 
-#include "Intrepid2_DefaultCubatureFactory.hpp"
-#include "Shards_CellTopology.hpp"
-#include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"
-
-#include "Albany_AbstractProblem.hpp"
-#include "Albany_EvaluatorUtils.hpp"
-#include "Albany_GeneralPurposeFieldsNames.hpp"
-#include "LandIce_ResponseUtilities.hpp"
-
-#include "PHAL_Dimension.hpp"
-#include "PHAL_FieldFrobeniusNorm.hpp"
-#include "PHAL_LoadStateField.hpp"
-#include "PHAL_SaveStateField.hpp"
-#include "PHAL_Workset.hpp"
-
 #include "LandIce_BasalFrictionCoefficient.hpp"
 #include "LandIce_HydrologyBasalGravitationalWaterPotential.hpp"
 #include "LandIce_HydraulicPotential.hpp"
@@ -37,10 +21,27 @@
 #include "LandIce_HydrologySurfaceWaterInput.hpp"
 #include "LandIce_HydrologyWaterThickness.hpp"
 #include "LandIce_ParamEnum.hpp"
-
-#include "PHAL_SharedParameter.hpp"
+#include "LandIce_ResponseUtilities.hpp"
 #include "LandIce_SimpleOperationEvaluator.hpp"
 #include "LandIce_ProblemUtils.hpp"
+
+#include "Albany_AbstractProblem.hpp"
+#include "Albany_EvaluatorUtils.hpp"
+#include "Albany_GeneralPurposeFieldsNames.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "PHAL_Dimension.hpp"
+#include "PHAL_FieldFrobeniusNorm.hpp"
+#include "PHAL_LoadStateField.hpp"
+#include "PHAL_SaveStateField.hpp"
+#include "PHAL_Workset.hpp"
+#include "PHAL_SharedParameter.hpp"
+
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+#include "Shards_CellTopology.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
+
 
 namespace LandIce
 {
@@ -235,7 +236,7 @@ Hydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
 
     for (unsigned int p_index=0; p_index< (unsigned int) num_dist_param_vecs; ++p_index)
     {
-      std::string parameter_sublist_name = Albany::strint("Parameter", p_index+num_param_vecs);
+      std::string parameter_sublist_name = util::strint("Parameter", p_index+num_param_vecs);
       Teuchos::ParameterList param_list = parameterParams.sublist(parameter_sublist_name);
       param_name = param_list.get<std::string>("Name");
       dist_params_name_to_mesh_part[param_name] = param_list.get<std::string>("Mesh Part","");
@@ -294,7 +295,7 @@ Hydrology::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   for (unsigned int ifield=0; ifield<num_fields; ++ifield)
   {
     // Get info on this field
-    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(Albany::strint("Field", ifield));
+    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(util::strint("Field", ifield));
 
     // Get current state name and usage
     stateName  = fieldName = thisFieldList.get<std::string>("Field Name");

--- a/src/LandIce/problems/LandIce_LaplacianSampling.hpp
+++ b/src/LandIce/problems/LandIce_LaplacianSampling.hpp
@@ -7,28 +7,28 @@
 #ifndef LANDICE_LAPLACIAN_SAMPLING_PROBLEM_HPP
 #define LANDICE_LAPLACIAN_SAMPLING_PROBLEM_HPP 1
 
-#include <type_traits>
-
-#include "Intrepid2_DefaultCubatureFactory.hpp"
-#include "Shards_CellTopology.hpp"
-#include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"
+#include "LandIce_ResponseUtilities.hpp"
+#include "LandIce_LaplacianRegularizationResidual.hpp"
 
 #include "Albany_AbstractProblem.hpp"
 #include "Albany_Utils.hpp"
 #include "Albany_ProblemUtils.hpp"
 #include "Albany_EvaluatorUtils.hpp"
 #include "Albany_GeneralPurposeFieldsNames.hpp"
-#include "LandIce_ResponseUtilities.hpp"
+#include "Albany_StringUtils.hpp"
 
 #include "PHAL_Workset.hpp"
 #include "PHAL_Dimension.hpp"
 #include "PHAL_AlbanyTraits.hpp"
-
 #include "PHAL_LoadStateField.hpp"
 #include "PHAL_LoadSideSetStateField.hpp"
 
-#include "LandIce_LaplacianRegularizationResidual.hpp"
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+#include "Shards_CellTopology.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
+
+#include <type_traits>
 
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN
@@ -148,7 +148,7 @@ LandIce::LaplacianSampling::constructEvaluators (PHX::FieldManager<PHAL::AlbanyT
   stateName = "weighted_normal_sample";
   bool isParameter = false;
   for (unsigned int p_index=0; p_index< (unsigned int) num_dist_param_vecs; ++p_index) {
-    std::string parameter_sublist_name = Albany::strint("Parameter", p_index+num_param_vecs);
+    std::string parameter_sublist_name = util::strint("Parameter", p_index+num_param_vecs);
     Teuchos::ParameterList param_list = parameterParams.sublist(parameter_sublist_name);
     param_name = param_list.get<std::string>("Name");
     if(param_name == stateName) {

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -2,7 +2,7 @@
 #include "Albany_GeneralPurposeFieldsNames.hpp"
 #include "Teuchos_CompilerCodeTweakMacros.hpp"
 
-#include <string.hpp>               // For util::upper_case (do not confuse this with <string>! string.hpp is an Albany file)
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 #include <Albany_ProblemUtils.hpp>  // For 'getIntrepidwBasis'
 
 namespace LandIce {

--- a/src/LandIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.cpp
@@ -1,9 +1,10 @@
 #include "LandIce_StokesFOBase.hpp"
 #include "Albany_GeneralPurposeFieldsNames.hpp"
-#include "Teuchos_CompilerCodeTweakMacros.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
-#include <Albany_ProblemUtils.hpp>  // For 'getIntrepidwBasis'
+#include "Albany_ProblemUtils.hpp"  // For 'getIntrepidwBasis'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
+
+#include "Teuchos_CompilerCodeTweakMacros.hpp"
 
 namespace LandIce {
 
@@ -31,7 +32,7 @@ StokesFOBase (const Teuchos::RCP<Teuchos::ParameterList>& params_,
   auto landice_bcs_params = Teuchos::sublist(params,"LandIce BCs");
   unsigned int num_bcs = landice_bcs_params->get<int>("Number",0);
   for (unsigned int i=0; i<num_bcs; ++i) {
-    auto this_bc = Teuchos::sublist(landice_bcs_params,Albany::strint("BC",i));
+    auto this_bc = Teuchos::sublist(landice_bcs_params,util::strint("BC",i));
     std::string type_str = util::upper_case(this_bc->get<std::string>("Type"));
 
     LandIceBC type;
@@ -318,7 +319,7 @@ void StokesFOBase::parseInputFields ()
     Albany::getParameterSizes(parameterParams, total_num_param_vecs, num_param_vecs, num_dist_param_vecs);
 
     for (unsigned int p_index=0; p_index< (unsigned int) num_dist_param_vecs; ++p_index) {
-      std::string parameter_sublist_name = Albany::strint("Parameter", p_index+num_param_vecs);
+      std::string parameter_sublist_name = util::strint("Parameter", p_index+num_param_vecs);
       Teuchos::ParameterList param_list = parameterParams.sublist(parameter_sublist_name);
       param_name = param_list.get<std::string>("Name");
       dist_params_name_to_mesh_part[param_name] = param_list.get<std::string>("Mesh Part","");
@@ -360,7 +361,7 @@ void StokesFOBase::parseInputFields ()
   FL loc;
 
   for (int ifield=0; ifield<num_fields; ++ifield) {
-    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(Albany::strint("Field", ifield));
+    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(util::strint("Field", ifield));
 
     // Get current state specs
     fieldName = thisFieldList.get<std::string>("Field Name");
@@ -435,7 +436,7 @@ void StokesFOBase::parseInputFields ()
 
     Teuchos::RCP<Albany::Layouts> ss_dl = dl->side_layouts.at(ss_name);
     for (unsigned int ifield=0; ifield< (unsigned int) num_fields; ++ifield) {
-      Teuchos::ParameterList& thisFieldList =  info.sublist(Albany::strint("Field", ifield));
+      Teuchos::ParameterList& thisFieldList =  info.sublist(util::strint("Field", ifield));
 
       // Get current state specs
       fieldName = thisFieldList.get<std::string>("Field Name");
@@ -603,12 +604,12 @@ void StokesFOBase::setupEvaluatorRequests ()
       const Teuchos::ParameterList& resp = this->params->sublist("Response Functions",true);
       unsigned int num_resps = resp.get<int>("Number Of Responses");
       for(unsigned int i=0; i<num_resps; i++) {
-        const std::string responseType = resp.sublist(Albany::strint("Response", i)).isParameter("Type") ?
-         resp.sublist(Albany::strint("Response", i)).get<std::string>("Type") : std::string("Scalar Response");
+        const std::string responseType = resp.sublist(util::strint("Response", i)).isParameter("Type") ?
+         resp.sublist(util::strint("Response", i)).get<std::string>("Type") : std::string("Scalar Response");
         if(responseType == "Sum Of Responses") {
-          unsigned int num_sub_resps = resp.sublist(Albany::strint("Response", i)).get<int>("Number Of Responses");
+          unsigned int num_sub_resps = resp.sublist(util::strint("Response", i)).get<int>("Number Of Responses");
           for(unsigned int j=0; j<num_sub_resps; j++) {
-            const auto& response = resp.sublist(Albany::strint("Response", i)).sublist(Albany::strint("Response", j));
+            const auto& response = resp.sublist(util::strint("Response", i)).sublist(util::strint("Response", j));
             if(response.get<std::string>("Name") == "Grounding Line Flux") {
               has_GLF_resp = true;
               continue;
@@ -625,16 +626,16 @@ void StokesFOBase::setupEvaluatorRequests ()
           if (has_GLF_resp && has_SMB_resp)
             break;
         } else {
-          if(resp.sublist(Albany::strint("Response", i)).get<std::string>("Name") == "Grounding Line Flux") {
+          if(resp.sublist(util::strint("Response", i)).get<std::string>("Name") == "Grounding Line Flux") {
             has_GLF_resp = true;
             continue;
           }
-          if(resp.sublist(Albany::strint("Response", i)).get<std::string>("Name") == "Surface Mass Balance Mismatch") {
+          if(resp.sublist(util::strint("Response", i)).get<std::string>("Name") == "Surface Mass Balance Mismatch") {
             has_SMB_resp = true;
             continue;
           }
-          if(resp.sublist(Albany::strint("Response", i)).get<std::string>("Name") == "Squared L2 Difference Side Source ST Target RT") {
-            has_SMB_resp = (resp.sublist(Albany::strint("Response", i)).get<std::string>("Source Field Name").find("flux_divergence") != std::string::npos);
+          if(resp.sublist(util::strint("Response", i)).get<std::string>("Name") == "Squared L2 Difference Side Source ST Target RT") {
+            has_SMB_resp = (resp.sublist(util::strint("Response", i)).get<std::string>("Source Field Name").find("flux_divergence") != std::string::npos);
             continue;
           }
         }

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -57,7 +57,7 @@
 #include "PHAL_RandomPhysicalParameter.hpp"
 #include "PHAL_IsAvailable.hpp"
 
-#include <string.hpp> // For util::upper_case (do not confuse this with <string>! string.hpp is an Albany file)
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN

--- a/src/LandIce/problems/LandIce_StokesFOBase.hpp
+++ b/src/LandIce/problems/LandIce_StokesFOBase.hpp
@@ -8,10 +8,6 @@
 #define LANDICE_STOKES_FO_BASE_HPP
 
 #include "LandIce_GatherVerticallyContractedSolution.hpp"
-#include "Shards_CellTopology.hpp"
-#include "Teuchos_RCP.hpp"
-#include "Teuchos_ParameterList.hpp"
-#include "Phalanx_Print.hpp"
 
 #include "PHAL_Dimension.hpp"
 #include "PHAL_AlbanyTraits.hpp"
@@ -57,7 +53,12 @@
 #include "PHAL_RandomPhysicalParameter.hpp"
 #include "PHAL_IsAvailable.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
+
+#include "Shards_CellTopology.hpp"
+#include "Teuchos_RCP.hpp"
+#include "Teuchos_ParameterList.hpp"
+#include "Phalanx_Print.hpp"
 
 //uncomment the following line if you want debug output to be printed to screen
 //#define OUTPUT_TO_SCREEN
@@ -390,7 +391,7 @@ constructStatesEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
   std::string fieldType, fieldUsage, meshPart;
   Teuchos::RCP<PHX::DataLayout> state_dl;
   for (unsigned int ifield=0; ifield<num_fields; ++ifield) {
-    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(Albany::strint("Field", ifield));
+    Teuchos::ParameterList& thisFieldList = req_fields_info.sublist(util::strint("Field", ifield));
 
     // Get current state specs
     fieldName = thisFieldList.get<std::string>("Field Name");
@@ -526,7 +527,7 @@ constructStatesEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
     const std::string& sideEBName = meshSpecs.sideSetMeshSpecs.at(ss_name)[0]->ebName;
     Teuchos::RCP<Albany::Layouts> ss_dl = dl->side_layouts.at(ss_name);
     for (unsigned int ifield=0; ifield<num_fields; ++ifield) {
-      Teuchos::ParameterList& thisFieldList =  info.sublist(Albany::strint("Field", ifield));
+      Teuchos::ParameterList& thisFieldList =  info.sublist(util::strint("Field", ifield));
 
       // Get current state specs
       fieldName = thisFieldList.get<std::string>("Field Name");
@@ -1043,7 +1044,7 @@ constructVelocityEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
     auto rparams = params->sublist("Random Parameters");
     int nrparams = rparams.get<int>("Number Of Parameters");
     for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
-      auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+      auto rparams_i = rparams.sublist(util::strint("Parameter",i_rparams));
   
       p = rcp(new Teuchos::ParameterList("Theta 1"));
       p->set< Teuchos::RCP<ParamLib> >("Parameter Library", paramLib);

--- a/src/LandIce/problems/LandIce_StokesFOThickness.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThickness.cpp
@@ -8,7 +8,7 @@
 
 #include "PHAL_FactoryTraits.hpp"
 #include "Albany_BCUtils.hpp"
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 // Uncomment for some setup output
 #define OUTPUT_TO_SCREEN

--- a/src/LandIce/problems/LandIce_StokesFOThickness.cpp
+++ b/src/LandIce/problems/LandIce_StokesFOThickness.cpp
@@ -4,13 +4,11 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#include <string>
+#include "LandIce_StokesFOThickness.hpp"
 
 #include "PHAL_FactoryTraits.hpp"
 #include "Albany_BCUtils.hpp"
-#include <string.hpp> // For util::upper_case (do not confuse this with <string>! string.hpp is an Albany file)
-
-#include "LandIce_StokesFOThickness.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 // Uncomment for some setup output
 #define OUTPUT_TO_SCREEN

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -6,13 +6,13 @@
 
 #include <iostream>
 
+#include "Albany_RegressionTests.hpp"
+#include "Albany_SolverFactory.hpp"
+#include "Albany_ObserverImpl.hpp"
+#include "Albany_FactoriesHelpers.hpp"
 #include "Albany_Utils.hpp"
 #include "Albany_CommUtils.hpp"
-#include "Albany_SolverFactory.hpp"
-#include "Albany_RegressionTests.hpp"
-#include "Albany_ObserverImpl.hpp"
-
-#include "Albany_FactoriesHelpers.hpp"
+#include "Albany_StringUtils.hpp"
 
 #include <Piro_PerformAnalysis.hpp>
 #include <Teuchos_GlobalMPISession.hpp>

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -7,12 +7,15 @@
 #include <iostream>
 #include <string>
 
-#include "Albany_Memory.hpp"
-#include "Albany_SolverFactory.hpp"
 #include "Albany_RegressionTests.hpp"
-#include "Albany_Utils.hpp"
+#include "Albany_SolverFactory.hpp"
+#include "Albany_PiroObserver.hpp"
+#include "Albany_Memory.hpp"
 #include "Albany_CommUtils.hpp"
 #include "Albany_ThyraUtils.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+#include "Albany_DataTypes.hpp"
 
 #include "Albany_FactoriesHelpers.hpp"
 
@@ -31,8 +34,6 @@
 #include "Thyra_VectorStdOps.hpp"
 #include "Thyra_MultiVectorStdOps.hpp"
 
-#include "Albany_PiroObserver.hpp"
-
 #if defined(ALBANY_CHECK_FPE) || defined(ALBANY_STRONG_FPE_CHECK) || defined(ALBANY_FLUSH_DENORMALS)
 #include <xmmintrin.h>
 #endif
@@ -44,8 +45,6 @@
 #if defined(ALBANY_FLUSH_DENORMALS)
 #include <pmmintrin.h>
 #endif
-
-#include "Albany_DataTypes.hpp"
 
 #include "Phalanx_config.hpp"
 
@@ -197,7 +196,7 @@ int main(int argc, char *argv[])
     param_names.resize(num_param_vecs);
     for (int l = 0; l < num_param_vecs; ++l) {
       const Teuchos::ParameterList & pList =
-          parameterParams.sublist(Albany::strint("Parameter", l));
+          parameterParams.sublist(util::strint("Parameter", l));
 
       const std::string& parameterType = pList.isParameter("Type") ?
           pList.get<std::string>("Type") : std::string("Scalar");
@@ -223,7 +222,7 @@ int main(int argc, char *argv[])
             Teuchos::rcp(new Teuchos::Array<std::string>(numParameters));
         for (int k = 0; k < numParameters; ++k) {
           (*param_names[l])[k] =
-              pList.sublist(Albany::strint("Scalar", k)).get<std::string>("Name");
+              pList.sublist(util::strint("Scalar", k)).get<std::string>("Name");
         }
       }
     }
@@ -232,7 +231,7 @@ int main(int argc, char *argv[])
     response_names.resize(num_responses);
     for (int l = 0; l < num_responses; ++l) {
       const Teuchos::ParameterList& pList =
-        responseParams.sublist(Albany::strint("Response", l));
+        responseParams.sublist(util::strint("Response", l));
 
       const std::string& type = pList.isParameter("Type") ?
           pList.get<std::string>("Type") : std::string("Scalar Response");
@@ -247,7 +246,7 @@ int main(int argc, char *argv[])
                 << std::endl);
         response_names[l] = "Sum Of Responses: ";
         for (int k = 0; k < num_sub_responses; ++k) {
-          response_names[l] += pList.sublist(Albany::strint("Response", k)).get<std::string>("Name");
+          response_names[l] += pList.sublist(util::strint("Response", k)).get<std::string>("Name");
           if( k != num_sub_responses-1)
             response_names[l] += " + ";
         }

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.cpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.cpp
@@ -4,26 +4,24 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#include <limits>
+#include "Albany_BlockedSTKDiscretization.hpp"
+#include "STKConnManager.hpp"
 
 #include <Albany_ThyraUtils.hpp>
 #include "Albany_Macros.hpp"
 #include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "Teuchos_XMLParameterListHelpers.hpp"
+#include "Panzer_BlockedDOFManager.hpp"
+#include "Panzer_String_Utilities.hpp"
+#include "Thyra_DefaultProductVectorSpace.hpp"
+#include "Intrepid2_HVOL_C0_FEM.hpp"
 
 #include <fstream>
 #include <iostream>
 #include <string>
-
-#include "Teuchos_XMLParameterListHelpers.hpp"
-
-#include "Panzer_BlockedDOFManager.hpp"
-#include "Panzer_String_Utilities.hpp"
-
-#include "Albany_BlockedSTKDiscretization.hpp"
-#include "STKConnManager.hpp"
-
-#include "Thyra_DefaultProductVectorSpace.hpp"
-#include "Intrepid2_HVOL_C0_FEM.hpp"
+#include <limits>
 
 namespace Albany
 {
@@ -161,11 +159,11 @@ namespace Albany
           shards::CellTopology eb_topology;
           for (int i_block = 0; i_block < n_DiscParamsBlocks; ++i_block)
           {
-            if (blocksDiscretizationName[i][j] == bDiscParams->sublist(Albany::strint("Block", i_block)).get<std::string>("Name"))
+            if (blocksDiscretizationName[i][j] == bDiscParams->sublist(util::strint("Block", i_block)).get<std::string>("Name"))
             {
-              type = bDiscParams->sublist(Albany::strint("Block", i_block)).get<std::string>("FE Type");
-              mesh = bDiscParams->sublist(Albany::strint("Block", i_block)).get<std::string>("Mesh", "Element Block 0");
-              domain = bDiscParams->sublist(Albany::strint("Block", i_block)).get<std::string>("Domain", "Volume");
+              type = bDiscParams->sublist(util::strint("Block", i_block)).get<std::string>("FE Type");
+              mesh = bDiscParams->sublist(util::strint("Block", i_block)).get<std::string>("Mesh", "Element Block 0");
+              domain = bDiscParams->sublist(util::strint("Block", i_block)).get<std::string>("Domain", "Volume");
               break;
             }
           }

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -13,8 +13,8 @@
 #include "Albany_AbstractDiscretization.hpp"
 #include "Albany_STKDiscretization.hpp"
 #include "Albany_DataTypes.hpp"
-#include "utility/Albany_ThyraBlockedCrsMatrixFactory.hpp"
-#include "utility/Albany_ThyraUtils.hpp"
+#include "Albany_ThyraBlockedCrsMatrixFactory.hpp"
+#include "Albany_ThyraUtils.hpp"
 
 #include "Panzer_BlockedDOFManager.hpp"
 //#include "Albany_NullSpaceUtils.hpp"

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -13,9 +13,9 @@
 #include "Albany_AbstractDiscretization.hpp"
 #include "Albany_AbstractSTKMeshStruct.hpp"
 #include "Albany_DataTypes.hpp"
-#include "utility/Albany_ThyraCrsMatrixFactory.hpp"
-#include "utility/Albany_ThyraUtils.hpp"
-#include "utility/Albany_GlobalLocalIndexer.hpp"
+#include "Albany_ThyraCrsMatrixFactory.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_GlobalLocalIndexer.hpp"
 
 #include "Albany_NullSpaceUtils.hpp"
 

--- a/src/evaluators/pde/PHAL_NSMaterialProperty_Def.hpp
+++ b/src/evaluators/pde/PHAL_NSMaterialProperty_Def.hpp
@@ -4,11 +4,14 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#include <fstream>
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+
 #include "Teuchos_TestForException.hpp"
 #include "Phalanx_DataLayout.hpp"
 #include "Sacado_ParameterRegistration.hpp"
-#include "Albany_Utils.hpp"
+
+#include <fstream>
 
 namespace PHAL {
 
@@ -59,7 +62,7 @@ NSMaterialProperty(Teuchos::ParameterList& p) :
 
       // Add property as a Sacado-ized parameter
       for (PHX::index_size_type i=0; i<numDims; i++)
-        this->registerSacadoParameter(Albany::strint(name_mp,i), paramLib);
+        this->registerSacadoParameter(util::strint(name_mp,i), paramLib);
     }
     else if (rank == 4) {
       matPropType = TENSOR_CONSTANT;
@@ -84,7 +87,7 @@ NSMaterialProperty(Teuchos::ParameterList& p) :
       // Add property as a Sacado-ized parameter
       for (PHX::index_size_type i=0; i<numRows; i++)
 	for (PHX::index_size_type j=0; j<numCols; j++)
-          this->registerSacadoParameter(Albany::strint(Albany::strint(name_mp,i),j), paramLib);
+          this->registerSacadoParameter(util::strint(util::strint(name_mp,i),j), paramLib);
     }
     else
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
@@ -264,13 +267,13 @@ NSMaterialProperty<EvalT,Traits>::getValue(const std::string &n)
   }
   else if (matPropType == VECTOR_CONSTANT) {
     for (int dim=0; dim<vector_constant_value.size(); ++dim)
-      if (n == Albany::strint(name_mp,dim))
+      if (n == util::strint(name_mp,dim))
 	return vector_constant_value[dim];
   }
   else if (matPropType == TENSOR_CONSTANT) {
     for (int dim1=0; dim1<tensor_constant_value.getNumRows(); ++dim1)
       for (int dim2=0; dim2<tensor_constant_value.getNumCols(); ++dim2)
-	if (n == Albany::strint(Albany::strint(name_mp,dim1),dim2))
+	if (n == util::strint(util::strint(name_mp,dim1),dim2))
 	  return tensor_constant_value(dim1,dim2);
   }
   TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,

--- a/src/evaluators/pde/PHAL_Permittivity_Def.hpp
+++ b/src/evaluators/pde/PHAL_Permittivity_Def.hpp
@@ -162,7 +162,7 @@ Permittivity<EvalT,Traits>::getValue(const std::string &n)
   }
 
   for (int i=0; i<rv.size(); i++) {
-    if (n == Albany::strint("Permittivity KL Random Variable",i))
+    if (n == util::strint("Permittivity KL Random Variable",i))
       return rv[i];
   }
   TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,

--- a/src/evaluators/utility/PHAL_Absorption_Def.hpp
+++ b/src/evaluators/utility/PHAL_Absorption_Def.hpp
@@ -90,7 +90,7 @@ Absorption<EvalT,Traits>::getValue(const std::string &n)
   if (is_constant)
     return constant_value;
   /*for (int i=0; i<rv.size(); i++) {
-    if (n == Albany::strint("Thermal Conductivity KL Random Variable",i))
+    if (n == util::strint("Thermal Conductivity KL Random Variable",i))
       return rv[i];
   }*/
   TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,

--- a/src/evaluators/utility/PHAL_Field_Source_Def.hpp
+++ b/src/evaluators/utility/PHAL_Field_Source_Def.hpp
@@ -4,22 +4,23 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
+#include "PHAL_SharedParameter.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "Sacado_ParameterAccessor.hpp"
+#include "Sacado_ParameterRegistration.hpp"
+#include "Teuchos_VerboseObject.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_TestForException.hpp"
+
+#include "Phalanx_DataLayout_MDALayout.hpp"
+
 #include <cmath>
 #include <sstream>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-
-#include "Sacado_ParameterAccessor.hpp"
-#include "Sacado_ParameterRegistration.hpp"
-#include "Teuchos_VerboseObject.hpp"
-#include "Albany_Utils.hpp"
-#include "Teuchos_Array.hpp"
-#include "Teuchos_TestForException.hpp"
-
-#include "PHAL_SharedParameter.hpp"
-
-#include "Phalanx_DataLayout_MDALayout.hpp"
 
 namespace PHAL
 {
@@ -47,9 +48,9 @@ namespace PHAL
         typename Gaussian<EvalT, Traits>::ScalarT &
         Gaussian<EvalT, Traits>::getValue(const std::string &n)
         {
-            if (n == Albany::strint("Amplitude", m_num))
+            if (n == util::strint("Amplitude", m_num))
                 return m_amplitude;
-            else if (n == Albany::strint("Radius", m_num))
+            else if (n == util::strint("Radius", m_num))
                 return m_radius;
             TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
                                        std::endl
@@ -62,14 +63,14 @@ namespace PHAL
                                                  Teuchos::ParameterList &scalarParam_list,
                                                  std::size_t num,
                                                  PHX::FieldManager<Traits> &fm,
-                                                 const Teuchos::RCP<Albany::Layouts> &dl) : mdf_amplitude(source_list.get<std::string>(Albany::strint("Gaussian: Amplitude", num)), dl->shared_param),
-                                                                                            mdf_radius(source_list.get<std::string>(Albany::strint("Gaussian: Radius", num)), dl->shared_param)
+                                                 const Teuchos::RCP<Albany::Layouts> &dl) : mdf_amplitude(source_list.get<std::string>(util::strint("Gaussian: Amplitude", num)), dl->shared_param),
+                                                                                            mdf_radius(source_list.get<std::string>(util::strint("Gaussian: Radius", num)), dl->shared_param)
         {
             Teuchos::ParameterList &paramList = source_list.sublist("Spatial", true);
             m_amplitude = paramList.get("Amplitude", 1.0);
             m_radius = paramList.get("Radius", 1.0);
             // sigma = 1.0/(sqrt(2.0)*m_radius);
-            m_centroid = source_list.get(Albany::strint("Center", num), m_centroid);
+            m_centroid = source_list.get(util::strint("Center", num), m_centroid);
             m_num = num;
 
             Teuchos::RCP<ParamLib> paramLib =
@@ -78,7 +79,7 @@ namespace PHAL
             Teuchos::RCP<Albany::ScalarParameterAccessors<EvalT>> accessors =
                 source_list.get<Teuchos::RCP<Albany::ScalarParameterAccessors<EvalT>>>("Accessors");
             { //Shared parameter for sensitivity analysis: amplitude
-                const std::string param_name = source_list.get<std::string>(Albany::strint("Gaussian: Amplitude", num));
+                const std::string param_name = source_list.get<std::string>(util::strint("Gaussian: Amplitude", num));
                 // Check if param_name has already been registered in fm or not:
                 bool already_registered = false;
                 const auto dag = fm.template getDagManager<EvalT>();
@@ -94,7 +95,7 @@ namespace PHAL
                 }
                 if (!already_registered)
                 {
-                    Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::rcp(new Teuchos::ParameterList(Albany::strint("Gaussian: Amplitude", num)));
+                    Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::rcp(new Teuchos::ParameterList(util::strint("Gaussian: Amplitude", num)));
                     p->set<Teuchos::RCP<ParamLib>>("Parameter Library", paramLib);
                     p->set<std::string>("Parameter Name", param_name);
                     p->set<Teuchos::RCP<Albany::ScalarParameterAccessors<EvalT>>>("Accessors", accessors);
@@ -107,7 +108,7 @@ namespace PHAL
                 }
             }
             { //Shared parameter for sensitivity analysis: radius
-                const std::string param_name = source_list.get<std::string>(Albany::strint("Gaussian: Radius", num));
+                const std::string param_name = source_list.get<std::string>(util::strint("Gaussian: Radius", num));
                 // Check if param_name has already been registered in fm or not:
                 bool already_registered = false;
                 const auto dag = fm.template getDagManager<EvalT>();
@@ -123,7 +124,7 @@ namespace PHAL
                 }
                 if (!already_registered)
                 {
-                    Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::rcp(new Teuchos::ParameterList(Albany::strint("Gaussian: Radius", num)));
+                    Teuchos::RCP<Teuchos::ParameterList> p = Teuchos::rcp(new Teuchos::ParameterList(util::strint("Gaussian: Radius", num)));
                     p->set<Teuchos::RCP<ParamLib>>("Parameter Library", paramLib);
                     p->set<std::string>("Parameter Name", param_name);
                     p->set<Teuchos::RCP<Albany::ScalarParameterAccessors<EvalT>>>("Accessors", accessors);
@@ -139,11 +140,11 @@ namespace PHAL
             this->addDependentField(mdf_amplitude);
             this->addDependentField(mdf_radius);
 
-            const PHX::Tag<ScalarT> fieldTag(source_list.get<std::string>(Albany::strint("Gaussian: Field", num)), dl->dummy);
+            const PHX::Tag<ScalarT> fieldTag(source_list.get<std::string>(util::strint("Gaussian: Field", num)), dl->dummy);
 
             this->addEvaluatedField(fieldTag);
 
-            this->setName(Albany::strint("Gaussian", num));
+            this->setName(util::strint("Gaussian", num));
         }
 
         template <typename EvalT, typename Traits>

--- a/src/evaluators/utility/PHAL_SharedParameter.hpp
+++ b/src/evaluators/utility/PHAL_SharedParameter.hpp
@@ -4,6 +4,7 @@
 #include "PHAL_Dimension.hpp"
 #include "Albany_SacadoTypes.hpp"
 #include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
 
 #include "Phalanx_Evaluator_WithBaseImpl.hpp"
 #include "Phalanx_Evaluator_Derived.hpp"
@@ -57,7 +58,7 @@ public:
       int n = paramsList->get<int>("Number Of Parameters");
       for (int i=0; (nominalValueSet==false) && i<n; ++i)
       {
-        const Teuchos::ParameterList& pvi = paramsList->sublist(Albany::strint("Parameter",i));
+        const Teuchos::ParameterList& pvi = paramsList->sublist(util::strint("Parameter",i));
         std::string parameterType = "Scalar";
         if(pvi.isParameter("Type"))
           parameterType = pvi.get<std::string>("Type");
@@ -83,7 +84,7 @@ public:
           int m = pvi.get<int>("Dimension");
           for (int j=0; j<m; ++j)
           {
-            const Teuchos::ParameterList& pj = pvi.sublist(Albany::strint("Scalar",j));
+            const Teuchos::ParameterList& pj = pvi.sublist(util::strint("Scalar",j));
             if (pj.get<std::string>("Name")==param_name)
             {
               this->registerSacadoParameter(param_name, paramLib);

--- a/src/evaluators/utility/PHAL_Source_Def.hpp
+++ b/src/evaluators/utility/PHAL_Source_Def.hpp
@@ -4,21 +4,23 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "PHAL_SharedParameter.hpp"
+#include "PHAL_Field_Source.hpp"
+
+#include "Sacado_ParameterAccessor.hpp"
+#include "Sacado_ParameterRegistration.hpp"
+#include "Teuchos_VerboseObject.hpp"
+#include "Teuchos_Array.hpp"
+#include "Teuchos_TestForException.hpp"
+
 #include <cmath>
 #include <sstream>
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-
-#include "Sacado_ParameterAccessor.hpp"
-#include "Sacado_ParameterRegistration.hpp"
-#include "Teuchos_VerboseObject.hpp"
-#include "Albany_Utils.hpp"
-#include "Teuchos_Array.hpp"
-#include "Teuchos_TestForException.hpp"
-
-#include "PHAL_SharedParameter.hpp"
-#include "PHAL_Field_Source.hpp"
 
 namespace PHAL {
 
@@ -600,10 +602,10 @@ MVQuadratic<EvalT,Traits>::MVQuadratic(Teuchos::ParameterList& p) {
   m_factor.resize(num_vars);
   Teuchos::RCP<ParamLib> paramLib = p.get< Teuchos::RCP<ParamLib> > ("Parameter Library", Teuchos::null);
   for (int i=0; i<num_vars; i++) {
-    m_factor[i] = paramList.get(Albany::strint("Nonlinear Factor",i), 0.0);
+    m_factor[i] = paramList.get(util::strint("Nonlinear Factor",i), 0.0);
 
     // Add the factor as a Sacado-ized parameter
-    this->registerSacadoParameter(Albany::strint("Multivariate Quadratic Nonlinear Factor",i), paramLib);
+    this->registerSacadoParameter(util::strint("Multivariate Quadratic Nonlinear Factor",i), paramLib);
   }
 }
 
@@ -652,7 +654,7 @@ typename MVQuadratic<EvalT,Traits>::ScalarT&
 MVQuadratic<EvalT,Traits>::getValue(const std::string &n)
 {
   for (unsigned int i=0; i<m_factor.size(); i++) {
-    if (n == Albany::strint("Multivariate Quadratic Nonlinear Factor",i))
+    if (n == util::strint("Multivariate Quadratic Nonlinear Factor",i))
       return m_factor[i];
   }
   return m_factor[0];
@@ -694,10 +696,10 @@ MVExponential<EvalT,Traits>::MVExponential(Teuchos::ParameterList& p) {
   m_factor.resize(num_vars);
   Teuchos::RCP<ParamLib> paramLib = p.get< Teuchos::RCP<ParamLib> > ("Parameter Library", Teuchos::null);
   for (int i=0; i<num_vars; i++) {
-    m_factor[i] = paramList.get(Albany::strint("Nonlinear Factor",i), 0.0);
+    m_factor[i] = paramList.get(util::strint("Nonlinear Factor",i), 0.0);
 
     // Add the factor as a Sacado-ized parameter
-    this->registerSacadoParameter(Albany::strint("Multivariate Exponential Nonlinear Factor",i), paramLib);
+    this->registerSacadoParameter(util::strint("Multivariate Exponential Nonlinear Factor",i), paramLib);
   }
 }
 
@@ -746,7 +748,7 @@ typename MVExponential<EvalT,Traits>::ScalarT&
 MVExponential<EvalT,Traits>::getValue(const std::string &n)
 {
   for (unsigned int i=0; i<m_factor.size(); i++) {
-    if (n == Albany::strint("Multivariate Exponential Nonlinear Factor",i))
+    if (n == util::strint("Multivariate Exponential Nonlinear Factor",i))
       return m_factor[i];
   }
   return m_factor[0];
@@ -831,9 +833,9 @@ PointSource<EvalT,Traits>::PointSource(Teuchos::ParameterList& p, PHX::FieldMana
         p.get<Teuchos::ParameterList*>("Scalar Parameters List");
     Teuchos::RCP<Gaussian<EvalT,Traits>> ev;
     for (std::size_t i=0; i<m_num_dim; ++i) {
-      paramList.set<std::string>(Albany::strint("Gaussian: Amplitude", i), Albany::strint("Amplitude", i));
-      paramList.set<std::string>(Albany::strint("Gaussian: Radius", i), Albany::strint("Radius", i));
-      paramList.set<std::string>(Albany::strint("Gaussian: Field", i), Albany::strint(p.get<std::string>("Source Name") + ": Gaussian Field", i));
+      paramList.set<std::string>(util::strint("Gaussian: Amplitude", i), util::strint("Amplitude", i));
+      paramList.set<std::string>(util::strint("Gaussian: Radius", i), util::strint("Radius", i));
+      paramList.set<std::string>(util::strint("Gaussian: Field", i), util::strint(p.get<std::string>("Source Name") + ": Gaussian Field", i));
 
       ev = Teuchos::rcp(new Gaussian<EvalT,Traits>(paramList,*scalarParamList,i,fm,dl));
       fm.template registerEvaluator<EvalT>(ev);
@@ -970,7 +972,7 @@ Source<EvalT, Traits>::Source(Teuchos::ParameterList& p, PHX::FieldManager<PHAL:
     this->setName("PointSource" );
 
     for (std::size_t i=0; i<s->getNumDim(); ++i) {
-      const PHX::Tag<ScalarT> fieldTag(Albany::strint(p.get<std::string>("Source Name") + ": Gaussian Field", i), dl->dummy);
+      const PHX::Tag<ScalarT> fieldTag(util::strint(p.get<std::string>("Source Name") + ": Gaussian Field", i), dl->dummy);
       this->addDependentField(fieldTag);
     }
   }

--- a/src/problems/Albany_AdvectionProblem.cpp
+++ b/src/problems/Albany_AdvectionProblem.cpp
@@ -40,7 +40,7 @@ AdvectionProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
     int total_num_param_vecs, num_param_vecs, numDistParams;
     Albany::getParameterSizes(params->sublist("Parameters"), total_num_param_vecs, num_param_vecs, numDistParams);
     for (int i=0; i<numDistParams; ++i) {
-      Teuchos::ParameterList p = params->sublist("Parameters").sublist(Albany::strint("Parameter", 
+      Teuchos::ParameterList p = params->sublist("Parameters").sublist(util::strint("Parameter", 
 			                 i+num_param_vecs));
       if(p.get<std::string>("Name") == "advection_coefficient" && p.get<std::string>("Type") == "Distributed")
         advectionIsDistParam = true;

--- a/src/problems/Albany_BCUtils_Def.hpp
+++ b/src/problems/Albany_BCUtils_Def.hpp
@@ -5,10 +5,10 @@
 //*****************************************************************//
 
 #include "Albany_BCUtils.hpp"
+#include "Albany_StringUtils.hpp"
 #include "Albany_Macros.hpp"
 
 #include <Phalanx_Evaluator_Factory.hpp>
-#include <boost/algorithm/string.hpp>
 
 namespace {
 const char decorator[] = "Evaluator for ";
@@ -19,7 +19,7 @@ bool isRandom(Teuchos::RCP<Teuchos::ParameterList> params, const std::string& bc
     auto rparams = params->sublist("Random Parameters");
     int nrparams = rparams.get<int>("Number Of Parameters");
     for (int i_rparams=0; i_rparams<nrparams; ++i_rparams) {
-      rparams_i = rparams.sublist(Albany::strint("Parameter", i_rparams));
+      rparams_i = rparams.sublist(util::strint("Parameter", i_rparams));
       if (bc_name == rparams_i.get<std::string>("Name")) return true;
     }
   }

--- a/src/problems/Albany_HeatProblem.cpp
+++ b/src/problems/Albany_HeatProblem.cpp
@@ -6,11 +6,13 @@
 
 #include "Albany_HeatProblem.hpp"
 
-#include "Intrepid2_DefaultCubatureFactory.hpp"
-#include "Shards_CellTopology.hpp"
 #include "PHAL_FactoryTraits.hpp"
 #include "Albany_Utils.hpp"
 #include "Albany_BCUtils.hpp"
+#include "Albany_StringUtils.hpp"
+
+#include "Intrepid2_DefaultCubatureFactory.hpp"
+#include "Shards_CellTopology.hpp"
 
 Albany::HeatProblem::
 HeatProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
@@ -47,7 +49,7 @@ HeatProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
     int total_num_param_vecs, num_param_vecs, numDistParams;
     Albany::getParameterSizes(params->sublist("Parameters"), total_num_param_vecs, num_param_vecs, numDistParams);
     for (int i=0; i<numDistParams; ++i) {
-      Teuchos::ParameterList p = params->sublist("Parameters").sublist(Albany::strint("Parameter", i+num_param_vecs));
+      Teuchos::ParameterList p = params->sublist("Parameters").sublist(util::strint("Parameter", i+num_param_vecs));
       if(p.get<std::string>("Name") == "thermal_conductivity" && p.get<std::string>("Type") == "Distributed")
         conductivityIsDistParam = true;
       if(p.get<std::string>("Name") == "dirichlet_field" && p.get<std::string>("Type") == "Distributed") {

--- a/src/problems/Albany_PopulateMesh.cpp
+++ b/src/problems/Albany_PopulateMesh.cpp
@@ -4,13 +4,14 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#include <string>
+#include "Albany_ProblemUtils.hpp"
+#include "Albany_PopulateMesh.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
 
 #include "Shards_CellTopology.hpp"
 
-#include "Albany_Utils.hpp"
-#include "Albany_ProblemUtils.hpp"
-#include "Albany_PopulateMesh.hpp"
+#include <string>
 
 namespace Albany
 {
@@ -90,7 +91,7 @@ void PopulateMesh::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<MeshSpecsStruct>
   int num_fields = req_fields_info.get<int>("Number Of Fields",0);
   for (int ifield=0; ifield<num_fields; ++ifield)
   {
-    const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(strint("Field", ifield));
+    const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(util::strint("Field", ifield));
 
     fname   = thisFieldList.get<std::string>("Field Name");
     flayout = thisFieldList.get<std::string>("Field Type");
@@ -140,14 +141,14 @@ void PopulateMesh::buildProblem (Teuchos::ArrayRCP<Teuchos::RCP<MeshSpecsStruct>
     for (auto ss_name : ss_names)
     {
       Teuchos::ParameterList& this_ss_pl = ss_disc_pl.sublist(ss_name);
-      Teuchos::ParameterList& req_fields_info = this_ss_pl.sublist("Required Fields Info");
+      Teuchos::ParameterList& ss_req_fields_info = this_ss_pl.sublist("Required Fields Info");
       Teuchos::RCP<Layouts> sdl = dl->side_layouts[ss_name];
 
-      int num_fields = req_fields_info.get<int>("Number Of Fields",0);
+      int ss_num_fields = ss_req_fields_info.get<int>("Number Of Fields",0);
 
-      for (int ifield=0; ifield<num_fields; ++ifield)
+      for (int ifield=0; ifield<ss_num_fields; ++ifield)
       {
-        const Teuchos::ParameterList& thisFieldList =  req_fields_info.sublist(strint("Field", ifield));
+        const Teuchos::ParameterList& thisFieldList =  ss_req_fields_info.sublist(util::strint("Field", ifield));
 
         fname   = thisFieldList.get<std::string>("Field Name");
         flayout = thisFieldList.get<std::string>("Field Type");

--- a/src/problems/Albany_ThermalProblem.cpp
+++ b/src/problems/Albany_ThermalProblem.cpp
@@ -65,7 +65,7 @@ ThermalProblem( const Teuchos::RCP<Teuchos::ParameterList>& params_,
     int total_num_param_vecs, num_param_vecs, numDistParams;
     Albany::getParameterSizes(params->sublist("Parameters"), total_num_param_vecs, num_param_vecs, numDistParams);
     for (int i=0; i<numDistParams; ++i) {
-      Teuchos::ParameterList p = params->sublist("Parameters").sublist(Albany::strint("Parameter", 
+      Teuchos::ParameterList p = params->sublist("Parameters").sublist(util::strint("Parameter", 
 			                 i+num_param_vecs));
       if(p.get<std::string>("Name") == "thermal_conductivity" && p.get<std::string>("Type") == "Distributed")
         conductivityIsDistParam = true;

--- a/src/problems/Albany_ThermalProblem.hpp
+++ b/src/problems/Albany_ThermalProblem.hpp
@@ -255,7 +255,7 @@ Albany::ThermalProblem::constructEvaluators(
     int nrparams = rparams.get<int>("Number Of Parameters");
     for (int i_rparams=0; i_rparams<nrparams; ++i_rparams)
     {
-      auto rparams_i = rparams.sublist(Albany::strint("Parameter",i_rparams));
+      auto rparams_i = rparams.sublist(util::strint("Parameter",i_rparams));
 
       RCP<ParameterList> p = rcp(new ParameterList("Theta 1"));
       p->set< RCP<ParamLib> >("Parameter Library", paramLib);

--- a/src/responses/Albany_ResponseFactory.cpp
+++ b/src/responses/Albany_ResponseFactory.cpp
@@ -20,6 +20,8 @@
 #include "Albany_KLResponseFunction.hpp"
 #include "Albany_WeightedMisfitResponseFunction.hpp"
 
+#include "Albany_StringUtils.hpp"
+
 #include "Teuchos_TestForException.hpp"
 
 void
@@ -85,7 +87,7 @@ createResponseFunction(
     Array< RCP<ScalarResponseFunction> > scalar_responses;
     Array<double> scalar_weights;
     for (int i=0; i<num_responses; i++) {
-      std::string id = Albany::strint("Response",i);
+      std::string id = util::strint("Response",i);
       Teuchos::ParameterList sublist = responseParams.sublist(id);
       std::string name = sublist.get<std::string>("Name");
       createResponseFunction(name, sublist, aggregated_responses);
@@ -100,7 +102,7 @@ createResponseFunction(
           "The aggregated response can only aggregate scalar response " << "functions!");
       scalar_responses[i] = Teuchos::rcp_dynamic_cast<ScalarResponseFunction>(aggregated_responses[i]);
 
-      std::string id = Albany::strint("Scaling Coefficient",i);
+      std::string id = util::strint("Scaling Coefficient",i);
       scalar_weights[i] = responseParams.get<double>(id, 1.0);
     }
     responses.push_back(rcp(new Albany::CumulativeScalarResponseFunction(comm, scalar_responses, scalar_weights)));
@@ -197,7 +199,7 @@ createResponseFunctions(Teuchos::ParameterList& responseList) const
   Array<RCP<AbstractResponseFunction> > responses;
 
   for (int i=0; i<num_response_vecs; i++) {
-    std::string sublist_name = Albany::strint("Response",i);
+    std::string sublist_name = util::strint("Response",i);
     ParameterList& response_params =
       responseList.sublist(sublist_name);
     std::string responseType = response_params.isParameter("Type") ?

--- a/src/responses/Albany_WeightedMisfitResponseFunction.cpp
+++ b/src/responses/Albany_WeightedMisfitResponseFunction.cpp
@@ -7,25 +7,23 @@
 #include "Albany_WeightedMisfitResponseFunction.hpp"
 
 #include "Albany_SolutionCullingStrategy.hpp"
+#include "Albany_Application.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_CombineAndScatterManager.hpp"
+#include "Albany_Hessian.hpp"
+#include "Albany_GlobalLocalIndexer.hpp"
+#include "Albany_StringUtils.hpp"
 
+#include "Thyra_VectorStdOps.hpp"
+#include "Teuchos_SerialDenseHelpers.hpp"
+#include "Teuchos_SerialDenseSolver.hpp"
+#include <Teuchos_TwoDArray.hpp>
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_Array.hpp"
-
 #include "Teuchos_Assert.hpp"
 
 #include <iostream>
 
-#include "Albany_Application.hpp"
-#include "Albany_ThyraUtils.hpp"
-#include "Albany_CombineAndScatterManager.hpp"
-#include "Albany_GlobalLocalIndexer.hpp"
-#include "Thyra_VectorStdOps.hpp"
-
-#include "Teuchos_SerialDenseHelpers.hpp"
-#include "Teuchos_SerialDenseSolver.hpp"
-#include <Teuchos_TwoDArray.hpp>
-
-#include "Albany_Hessian.hpp"
 
 using Teuchos::ScalarTraits;
 using Teuchos::SerialDenseMatrix;
@@ -45,8 +43,8 @@ WeightedMisfitResponse(const Teuchos::RCP<const Application>& app,
   dimensions = Teuchos::rcp( new Teuchos::SerialDenseVector<int, int>(n_parameters) );
 
   for (int i=0; i<n_parameters; i++) {
-    if (app->getProblemPL()->sublist("Parameters").sublist(strint("Parameter",i)).isParameter("Dimension"))
-      (*dimensions)(i) = app->getProblemPL()->sublist("Parameters").sublist(strint("Parameter",i)).get<int>("Dimension");
+    if (app->getProblemPL()->sublist("Parameters").sublist(util::strint("Parameter",i)).isParameter("Dimension"))
+      (*dimensions)(i) = app->getProblemPL()->sublist("Parameters").sublist(util::strint("Parameter",i)).get<int>("Dimension");
     else
       (*dimensions)(i) = 1;
     total_dimension += (*dimensions)(i);

--- a/src/utility/Albany_Hessian.cpp
+++ b/src/utility/Albany_Hessian.cpp
@@ -1,5 +1,3 @@
-
-#include <Teuchos_RCP.hpp>
 #include "Albany_TpetraTypes.hpp"
 #include "Albany_StateInfoStruct.hpp"
 #include "Albany_Hessian.hpp"
@@ -7,47 +5,54 @@
 #include "Albany_Utils.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_TpetraThyraUtils.hpp"
+#include "Albany_StringUtils.hpp"
 
+#include <Teuchos_RCP.hpp>
 #include <Kokkos_UnorderedMap.hpp>
 #include <Kokkos_Sort.hpp>
+
 #include <math.h>
 
-Teuchos::RCP<Thyra_LinearOp> Albany::createDenseHessianLinearOp(
-    Teuchos::RCP<const Thyra_VectorSpace> p_vs)
+namespace Albany
 {
-    Teuchos::RCP<const Tpetra_Map> p_map = Albany::getTpetraMap(p_vs);
+
+Teuchos::RCP<Thyra_LinearOp>
+createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
+{
+    Teuchos::RCP<const Tpetra_Map> p_map = getTpetraMap(p_vs);
     Teuchos::RCP<Thyra_LinearOp> H;
 
     Tpetra_GO num_params = p_map->getNodeNumElements();
 
     Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Teuchos::rcp(new Tpetra_CrsGraph(p_map, num_params));
 
-    Tpetra_GO cols[num_params];
+    Teuchos::Array<Tpetra_GO> cols(num_params);
 
     for (Tpetra_GO iparam=0; iparam<num_params; ++iparam) {
         cols[iparam] = p_map->getGlobalElement(iparam);
     }
 
     for (Tpetra_GO iparam=0; iparam<num_params; ++iparam) {
-        Hgraph->insertGlobalIndices(cols[iparam], num_params, cols);
+        Hgraph->insertGlobalIndices(cols[iparam], num_params, cols.getRawPtr());
     }
 
     Hgraph->fillComplete();
     Teuchos::RCP<Tpetra_CrsMatrix> Ht = Teuchos::rcp(new Tpetra_CrsMatrix(Hgraph));
 
-    H = Albany::createThyraLinearOp(Ht);
+    H = createThyraLinearOp(Ht);
     assign(H, 0.0);
 
     return H;
 }
 
-Teuchos::RCP<Thyra_LinearOp> Albany::createSparseHessianLinearOp(
+Teuchos::RCP<Thyra_LinearOp>
+createSparseHessianLinearOp(
     Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
     Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
     const std::vector<IDArray> vElDofs)
 {
-    Teuchos::RCP<const Tpetra_Map> p_overlapped_map = Albany::getTpetraMap(p_overlapped_vs);
-    Teuchos::RCP<const Tpetra_Map> p_owned_map = Albany::getTpetraMap(p_owned_vs);
+    Teuchos::RCP<const Tpetra_Map> p_overlapped_map = getTpetraMap(p_overlapped_vs);
+    Teuchos::RCP<const Tpetra_Map> p_owned_map = getTpetraMap(p_owned_vs);
     Teuchos::RCP<Thyra_LinearOp> H;
 
     std::size_t num_elem = 0;
@@ -105,16 +110,13 @@ Teuchos::RCP<Thyra_LinearOp> Albany::createSparseHessianLinearOp(
     Hgraph->fillComplete();
     Teuchos::RCP<Tpetra_CrsMatrix> Ht = Teuchos::rcp(new Tpetra_CrsMatrix(Hgraph));
 
-    H = Albany::createThyraLinearOp(Ht);
+    H = createThyraLinearOp(Ht);
     assign(H, 0.0);
 
     return H;
 }
 
-void Albany::getHessianBlockIDs(
-    int &i1,
-    int &i2,
-    std::string blockName)
+void getHessianBlockIDs(int &i1, int &i2, std::string blockName)
 {
     std::string tmp = blockName;
     tmp.erase(std::remove(tmp.begin(), tmp.end(), '('), tmp.end());
@@ -122,7 +124,7 @@ void Albany::getHessianBlockIDs(
 
     std::vector<std::string> block_ids;
 
-    Albany::splitStringOnDelim(tmp, ',', block_ids);
+    util::splitStringOnDelim(tmp, ',', block_ids);
     int ids[2];
 
     for (int i = 0; i < 2; ++i)
@@ -148,13 +150,13 @@ void Albany::getHessianBlockIDs(
     i2 = ids[1];
 }
 
-void Albany::getParameterVectorID(
+void getParameterVectorID(
     int &i,
     bool &is_distributed,
     std::string parameterName)
 {
     std::vector<std::string> elems;
-    Albany::splitStringOnDelim(parameterName, ' ', elems);
+    util::splitStringOnDelim(parameterName, ' ', elems);
     if (elems.size() == 2 && elems[0].compare("parameter_vector") == 0)
     {
         is_distributed = false;
@@ -166,3 +168,5 @@ void Albany::getParameterVectorID(
         i = -1;
     }
 }
+
+} // namespace Albany

--- a/src/utility/Albany_StringUtils.cpp
+++ b/src/utility/Albany_StringUtils.cpp
@@ -1,5 +1,8 @@
 #include "Albany_StringUtils.hpp"
 
+// Uncomment the following for more debug output
+// #define DEBUG_OUTPUT
+
 namespace util {
 
 std::string
@@ -20,4 +23,181 @@ splitStringOnDelim(
   while (std::getline(ss, item, delim)) { elems.push_back(item); }
 }
 
-} // namespace util 
+bool validNestedListFormat (const std::string& str)
+{
+  constexpr auto npos = std::string::npos;
+  std::string separators = "[],";
+
+  std::string lower   = "abcdefghijklmnopqrstuvwxyz";
+  std::string upper   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  std::string number  = "0123456789";
+  std::string special = "_";
+  std::string valid = lower+upper+number+special+separators;
+
+  // Check that string contains only valid characters
+  if (str.find_first_not_of(valid)!=npos) {
+#ifdef DEBUG_OUTPUT
+    std::cout << "Input string (" << str << ") contains invalid characters.\n";
+#endif
+    return false;
+  }
+
+  // The string must start with '[' and end with ']'
+  if (str.size()<2 || str.front()!='[' || str.back()!=']') {
+#ifdef DEBUG_OUTPUT
+    std::cout << "Input string (" << str << ") is too short (<2) or doesn't start with '[' or end with ']'.\n";
+#endif
+    return false;
+  }
+
+  // We verified the string starts with '['.
+  size_t start = 1;
+  char last_match = '[';
+  size_t num_open = 1;
+  size_t pos = str.find_first_of(separators,start);
+
+  while (pos!=npos) {
+    if (last_match=='[' && str[pos]==',' && pos==start) {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") contains '[,'.\n";
+#endif
+      return false;
+    }
+
+    // After ',' we need a name or a new list, not a ',' or ']'
+    if (last_match==',' && str[pos]==',' && pos==start) {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") contains ',,'.\n";
+#endif
+      return false;
+    }
+
+    if (last_match==',' && str[pos]==']' && pos==start) {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") contains ',]'.\n";
+#endif
+      return false;
+    }
+
+    // No empty lists
+    if (last_match=='[' && str[pos]==']' && pos==start) {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") contains '[]'.\n";
+#endif
+      return false;
+    }
+
+    // We can open a sublist if a) at the beginning of a list,
+    // or after a comma. No '][' allowed.
+    // if (str[pos]=='[' && last_match!=',' && last_match!='[' && last_match!='\0') {
+    if (str[pos]=='[' && str[pos-1]!=',' && str[pos-1]!='[') {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") contains '[' after an entry. Did you forget a comma?\n";
+#endif
+      return false;
+    }
+
+    // Keep track of nesting level
+    if (str[pos]=='[') {
+      ++num_open;
+    } else if (str[pos]==']') {
+      --num_open;
+    }
+
+    // Cannot close more than you open
+    if (num_open<0) {
+#ifdef DEBUG_OUTPUT
+      std::cout << "Input string (" << str << ") open/closed brackets don't balance.\n";
+#endif
+      return false;
+    }
+
+    // Update current status, and continue
+    last_match = str[pos];
+    start = pos+1;
+    pos = str.find_first_of(separators,start);
+  }
+
+#ifdef DEBUG_OUTPUT
+  if (num_open>0) {
+    std::cout << "Input string (" << str << ") open/closed brackets don't balance.\n";
+  }
+#endif
+
+  return num_open==0;
+}
+
+Teuchos::ParameterList parseNestedList (std::string str)
+{
+  constexpr auto npos = std::string::npos;
+
+  // 1. Strip spaces
+  auto new_end = std::remove(str.begin(),str.end(),' ');
+  str.erase(new_end,str.end());
+
+  // 2. Verify input is valid
+  TEUCHOS_TEST_FOR_EXCEPTION (not validNestedListFormat(str), std::runtime_error,
+      "Error! Input std::string '" + str + "' is not a valid (nested) list.\n");
+
+  Teuchos::ParameterList list;
+
+  // Remove first and last chars (which are '[' and ']')
+  str.erase(str.begin());
+  str.pop_back();
+
+  std::string separators = "[],";
+  size_t start = 0;
+  size_t pos = str.find_first_of(separators,start);
+
+  // Find the closing bracket matching the open one at open_pos
+  auto find_closing = [] (const std::string& s, size_t open_pos) ->size_t {
+    int num_open = 1;
+    auto pos = open_pos;
+    std::string brackets = "[]";
+    pos = s.find_first_of(brackets,pos);
+    while (num_open>0 && pos!=npos) {
+      if (s[pos]==']') {
+        --num_open;
+      } else {
+        ++num_open;
+      }
+    }
+
+    return pos;
+  };
+
+  int num_entries = 0;
+  int depth_max = 1;
+  while (pos!=npos) {
+    if (str[pos]=='[') {
+      // A sublist. Find the closing bracket, and recurse on substring.
+      // NOTE: we *know* close!=npos, cause we already validated str.
+      auto close = find_closing(str,pos);
+      auto substr = str.substr(pos,close-pos+1);
+      auto sublist = parseNestedList(substr);
+      list.set(util::strint("Type",num_entries),"List");
+      list.sublist(util::strint("Entry",num_entries)) = sublist;
+      depth_max = std::max(depth_max,1+sublist.get<int>("Depth"));
+      
+      // Set current position to where sublist closes.
+      pos = close;
+    } else {
+      // A normal entry.
+      auto substr = str.substr(start,pos-start);
+      list.set(util::strint("Type",num_entries),"Value");
+      list.set(util::strint("Entry",num_entries),substr);
+    }
+    ++num_entries;
+
+    // Update current status, and continue
+    start = pos+1;
+    pos = str.find_first_of(separators,start);
+  }
+
+  list.set("Num Entries",num_entries);
+  list.set("Depth",depth_max);
+
+  return list;
+}
+
+} // namespace util

--- a/src/utility/Albany_StringUtils.cpp
+++ b/src/utility/Albany_StringUtils.cpp
@@ -1,0 +1,23 @@
+#include "Albany_StringUtils.hpp"
+
+namespace util {
+
+std::string
+strint(const std::string s, const int i, const char delim)
+{
+  std::ostringstream ss;
+  ss << s << delim << i;
+  return ss.str();
+}
+void
+splitStringOnDelim(
+    const std::string&        s,
+    char                      delim,
+    std::vector<std::string>& elems)
+{
+  std::stringstream ss(s);
+  std::string       item;
+  while (std::getline(ss, item, delim)) { elems.push_back(item); }
+}
+
+} // namespace util 

--- a/src/utility/Albany_StringUtils.hpp
+++ b/src/utility/Albany_StringUtils.hpp
@@ -72,6 +72,19 @@ inline std::string upper_case (const std::string& s) {
   return s_up;
 }
 
+//! Utility to make a string out of a string + int with a delimiter:
+//! strint("dog",2,' ') = "dog 2"
+//! The default delimiter is ' '. Potential delimiters include '_' - "dog_2"
+std::string
+strint(const std::string s, const int i, const char delim = ' ');
+
+//! Splits a std::string on a delimiter
+void
+splitStringOnDelim(
+    const std::string&        s,
+    char                      delim,
+    std::vector<std::string>& elems);
+
 } // namespace util
 
 #endif  // ALBANY_STRING_UTILS_HPP

--- a/src/utility/Albany_StringUtils.hpp
+++ b/src/utility/Albany_StringUtils.hpp
@@ -85,6 +85,12 @@ splitStringOnDelim(
     char                      delim,
     std::vector<std::string>& elems);
 
+// Utils to verify/parse a string encoding nested lists,
+// such as '[a,b,[c,d],e]'
+bool validNestedListFormat (const std::string& str);
+
+Teuchos::ParameterList parseNestedList (std::string str);
+
 } // namespace util
 
 #endif  // ALBANY_STRING_UTILS_HPP

--- a/src/utility/Albany_StringUtils.hpp
+++ b/src/utility/Albany_StringUtils.hpp
@@ -6,22 +6,19 @@
 
 // @HEADER
 
-#ifndef UTIL_STRING_HPP
-#define UTIL_STRING_HPP
+#ifndef ALBANY_STRING_UTILS_HPP
+#define ALBANY_STRING_UTILS_HPP
 
 /**
- *  \file string.hpp
- *
- *  \brief
+ *  \brief A few utility functions for strings
  */
 
 #include <string>
 #include <type_traits>
-#include <cctype>
-#include <algorithm>
+
+#include <Teuchos_ParameterList.hpp>
 
 namespace util {
-typedef std::string string;
 
 namespace detail {
 
@@ -42,57 +39,39 @@ struct has_tostring: public std::integral_constant<bool,
 };
 
 template<typename T>
-string string_convert (
-    typename std::enable_if<std::is_convertible<T, string>::value, T>::type&& val) {
-  return static_cast<string>(val);
+std::string string_convert (
+    typename std::enable_if<std::is_convertible<T, std::string>::value, T>::type&& val) {
+  return static_cast<std::string>(val);
 }
 
 template<typename T>
-string string_convert (
+std::string string_convert (
     typename std::enable_if<has_tostring<T>::value, T>::type&& val) {
   return val.toString();
 }
 
 template<typename T>
-string string_convert (
+std::string string_convert (
     typename std::enable_if<
-        !std::is_convertible<T, string>::value && !has_tostring<T>::value, T>::type&& val) {
+        !std::is_convertible<T, std::string>::value && !has_tostring<T>::value, T>::type&& val) {
   return std::to_string(std::forward<T>(val));
 }
 
-}
+} // namespace detail
 
 template<typename T>
-inline string to_string (T&& val) {
+inline std::string to_string (T&& val) {
   return detail::string_convert<T>(std::forward<T>(val));
 }
 
-inline string upper_case (const string& s) {
-  string s_up = s;
+inline std::string upper_case (const std::string& s) {
+  std::string s_up = s;
   std::transform(s_up.begin(), s_up.end(), s_up.begin(),
                  [](unsigned char c)->char { return std::toupper(c); }
                 );
   return s_up;
 }
 
-/*
- template<typename T>
- inline string to_string (const T& val) {
- return val.toString();
- }
+} // namespace util
 
- inline string to_string (const string &val) {
- return val;
- }
-
- inline string to_string (int val) {
- return std::to_string(val);
- }
-
- inline string to_string (double val) {
- return std::to_string(val);
- }*/
-
-}
-
-#endif  // UTIL_STRING_HPP
+#endif  // ALBANY_STRING_UTILS_HPP

--- a/src/utility/Counter.cpp
+++ b/src/utility/Counter.cpp
@@ -4,8 +4,6 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "Counter.hpp"
 
 namespace util {
@@ -14,4 +12,4 @@ Counter::Counter (const std::string& name, counter_type start)
     : name_(name), value_(start) {
 }
 
-}
+} // namespace util

--- a/src/utility/CounterMonitor.cpp
+++ b/src/utility/CounterMonitor.cpp
@@ -4,12 +4,9 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "CounterMonitor.hpp"
 
 namespace util {
-
 
 CounterMonitor::CounterMonitor () {
   title_ = "CounterMonitor";
@@ -17,8 +14,8 @@ CounterMonitor::CounterMonitor () {
   itemValueLabel_ = "Value";
 }
 
-string CounterMonitor::getStringValue (const monitored_type& val) {
+std::string CounterMonitor::getStringValue (const monitored_type& val) {
   return std::to_string(static_cast<long long>(val.value()));
 }
 
-}
+} // namespace util

--- a/src/utility/CounterMonitor.hpp
+++ b/src/utility/CounterMonitor.hpp
@@ -28,9 +28,10 @@ namespace util {
     virtual ~CounterMonitor() {};
     
   protected:
-    virtual string        getStringValue(const monitored_type& val) override;
+    virtual std::string getStringValue(const monitored_type& val) override;
     
   };
-}
+
+} // namespace util
 
 #endif  // UTIL_COUNTERMONITOR_HPP

--- a/src/utility/DisplayTable.cpp
+++ b/src/utility/DisplayTable.cpp
@@ -4,8 +4,6 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "DisplayTable.hpp"
 
 #include <algorithm>
@@ -58,4 +56,4 @@ std::ostream& DisplayTable::writeCSV (std::ostream& strm, const char delim) {
   return strm;
 }
 
-}
+} // namespace util

--- a/src/utility/DisplayTable.hpp
+++ b/src/utility/DisplayTable.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <utility>
 
-#include "string.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 namespace util {
 
@@ -34,7 +34,7 @@ public:
 
 private:
 
-  typedef std::vector<string> TableRow;
+  typedef std::vector<std::string> TableRow;
   
   template<class T, typename ... Args>
   void addRow (TableRow &row, const T& val, Args ... args);

--- a/src/utility/DisplayTable.hpp
+++ b/src/utility/DisplayTable.hpp
@@ -19,7 +19,7 @@
 #include <vector>
 #include <utility>
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 namespace util {
 

--- a/src/utility/MonitorBase.hpp
+++ b/src/utility/MonitorBase.hpp
@@ -15,17 +15,19 @@
  *  \brief 
  */
 
+
+#include "DisplayTable.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+
 #include <Teuchos_Comm.hpp>
 #include <Teuchos_PtrDecl.hpp>
 #include <Teuchos_RCPDecl.hpp>
 #include <Teuchos_DefaultComm.hpp>
+
 #include <iostream>
 #include <map>
 #include <string>
 #include <vector>
-
-#include "DisplayTable.hpp"
-#include "string.hpp"
 #include <fstream>
 
 namespace util {
@@ -36,7 +38,7 @@ public:
   
   typedef MonitoredType monitored_type;
   typedef Teuchos::RCP<MonitoredType> pointer_type;
-  typedef string key_type;
+  typedef std::string key_type;
   typedef std::map<key_type, Teuchos::RCP<monitored_type> > monitor_map;
 
   MonitorBase ();
@@ -52,11 +54,11 @@ public:
 
 protected:
   
-  virtual string getStringValue (const monitored_type& val) = 0;
+  virtual std::string getStringValue (const monitored_type& val) = 0;
 
-  string title_;
-  string itemTypeLabel_;
-  string itemValueLabel_;
+  std::string title_;
+  std::string itemTypeLabel_;
+  std::string itemValueLabel_;
 
   monitor_map itemMap_;
 };

--- a/src/utility/MonitorBase.hpp
+++ b/src/utility/MonitorBase.hpp
@@ -17,7 +17,7 @@
 
 
 #include "DisplayTable.hpp"
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 #include <Teuchos_Comm.hpp>
 #include <Teuchos_PtrDecl.hpp>

--- a/src/utility/PerformanceContext.cpp
+++ b/src/utility/PerformanceContext.cpp
@@ -4,8 +4,6 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "PerformanceContext.hpp"
 
 namespace util {
@@ -32,4 +30,4 @@ void PerformanceContext::summarizeAll (std::ostream& out) {
   summarizeAll(comm.ptr(), out);
 }
 
-}
+} // namespace util

--- a/src/utility/TimeMonitor.cpp
+++ b/src/utility/TimeMonitor.cpp
@@ -4,11 +4,9 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "TimeMonitor.hpp"
 
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 namespace util {
 

--- a/src/utility/TimeMonitor.cpp
+++ b/src/utility/TimeMonitor.cpp
@@ -7,7 +7,8 @@
 // @HEADER
 
 #include "TimeMonitor.hpp"
-#include "string.hpp"
+
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
 
 namespace util {
 
@@ -17,9 +18,8 @@ TimeMonitor::TimeMonitor () {
   itemValueLabel_ = "Time (s)";
 }
 
-string TimeMonitor::getStringValue (const monitored_type& val) {
+std::string TimeMonitor::getStringValue (const monitored_type& val) {
   return to_string(static_cast<long double>(val.totalElapsedTime()));
 }
 
-}
-
+} // namespace util

--- a/src/utility/TimeMonitor.hpp
+++ b/src/utility/TimeMonitor.hpp
@@ -27,7 +27,7 @@ namespace util {
     virtual ~TimeMonitor() {};
     
   protected:
-    virtual string        getStringValue(const monitored_type& val) override;
+    virtual std::string getStringValue(const monitored_type& val) override;
     
   };
 }

--- a/src/utility/VariableMonitor.cpp
+++ b/src/utility/VariableMonitor.cpp
@@ -4,9 +4,8 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-// @HEADER
-
 #include "VariableMonitor.hpp"
+
 #include <sstream>
 
 namespace util {
@@ -17,7 +16,7 @@ VariableMonitor::VariableMonitor () {
   itemValueLabel_ = "Value";
 }
 
-string VariableMonitor::getStringValue (const monitored_type& val) {
+std::string VariableMonitor::getStringValue (const monitored_type& val) {
   std::stringstream ret;
   for (auto&& v : val.getHistory()) {
     ret << v << " ";
@@ -26,4 +25,4 @@ string VariableMonitor::getStringValue (const monitored_type& val) {
   return ret.str();
 }
 
-}
+} // namespace util

--- a/src/utility/VariableMonitor.hpp
+++ b/src/utility/VariableMonitor.hpp
@@ -16,7 +16,8 @@
  */
 
 #include "MonitorBase.hpp"
-#include "string.hpp"
+#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+
 #include <list>
 
 namespace util {
@@ -24,21 +25,21 @@ namespace util {
 class VariableHistory {
 public:
   
-  VariableHistory (const string &name)
+  VariableHistory (const std::string &name)
       : m_name { name } {
   }
   
   template<typename T>
   void addValue (T&& val);
 
-  const std::list<string>& getHistory () const {
+  const std::list<std::string>& getHistory () const {
     return m_history;
   }
   
 private:
   
-  string m_name;
-  std::list<string> m_history;
+  std::string m_name;
+  std::list<std::string> m_history;
 };
 
 class VariableMonitor: public MonitorBase<VariableHistory> {
@@ -50,12 +51,12 @@ public:
   
 protected:
   
-  virtual string getStringValue (const monitored_type& val) override;
+  virtual std::string getStringValue (const monitored_type& val) override;
 };
 
 template<typename T>
 inline void VariableHistory::addValue (T&& val) {
-  //TODO, when compiler allows, replace following with this for performance: m_history.emplace_back(to_string(std::forward<T>(val)));
+  //TODO, when compiler allows, replace following with this for performance: m_history.emplace_back(to_std::string(std::forward<T>(val)));
   m_history.push_back(to_string(std::forward<T>(val)));
 }
 

--- a/src/utility/VariableMonitor.hpp
+++ b/src/utility/VariableMonitor.hpp
@@ -16,7 +16,7 @@
  */
 
 #include "MonitorBase.hpp"
-#include "utility/Albany_StringUtils.hpp" // for 'upper_case'
+#include "Albany_StringUtils.hpp" // for 'upper_case'
 
 #include <list>
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -26,6 +26,12 @@ if(ALBANY_MPI)
     COMMAND ${PARALLEL_CALL} null_space_utils)
 endif(ALBANY_MPI)
 
+# StringUtils unit tests (no MPI test, since it's pointless)
+add_executable (string_utils ./UnitTest_StringUtils.cpp)
+target_link_libraries (string_utils PUBLIC albany_ut_main)
+add_test(NAME StringUtils_Serial_Unit_Test
+         COMMAND ${SERIAL_CALL} string_utils)
+
 #####################################################################
 
 add_subdirectory(evaluators)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -4,38 +4,27 @@
 ##    in the file "license.txt" in the top-level Albany directory  //
 ##*****************************************************************//
 
-#####################################################################
+#######################################
+#          Unit tests main            #
+#######################################
+
+# We build the main as a library, then link it to each executable
+add_library (albany_ut_main ./Albany_UnitTestMain.cpp)
+target_link_libraries (albany_ut_main PUBLIC albanyLib)
+
+#######################################
+#       Individual unit tests         #
+#######################################
+
 # NullSpaceUtils unit tests
-INCLUDE_DIRECTORIES(
-  ${Trilinos_INCLUDE_DIRS}
-  ${Trilinos_TPL_INCLUDE_DIRS}
-  ${CMAKE_BINARY_DIR}/src
-  ${CMAKE_SOURCE_DIR}/src
-  ${CMAKE_CURRENT_SOURCE_DIR}
-)
-
-SET(SOURCES
-  ./UnitTest_NullSpaceUtils.cpp
-  ./Albany_UnitTestMain.cpp
-)
-
-#LINK_DIRECTORIES(${Trilinos_LIBRARY_DIRS} ${Trilinos_TPL_LIBRARY_DIRS})
-
-ADD_EXECUTABLE(
-  nullSpaceUtils_unit_tester
-  ${SOURCES}
-)
-
-TARGET_LINK_LIBRARIES(nullSpaceUtils_unit_tester albanyLib ${ALB_TRILINOS_LIBS} ${Trilinos_EXTRA_LD_FLAGS})
-
-ADD_TEST(
-  NullSpaceUtils_Serial_Unit_Test ${SERIAL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/nullSpaceUtils_unit_tester
-)
-IF(ALBANY_MPI)
-  ADD_TEST(
-    NullSpaceUtils_Parallel_Unit_Test ${PARALLEL_CALL} ${CMAKE_CURRENT_BINARY_DIR}/nullSpaceUtils_unit_tester
-  )
-ENDIF(ALBANY_MPI)
+add_executable (null_space_utils ./UnitTest_NullSpaceUtils.cpp)
+target_link_libraries (null_space_utils PUBLIC albany_ut_main)
+add_test(NAME NullSpaceUtils_Serial_Unit_Test
+         COMMAND ${SERIAL_CALL} null_space_utils)
+if(ALBANY_MPI)
+  add_test(NAME NullSpaceUtils_Parallel_Unit_Test
+    COMMAND ${PARALLEL_CALL} null_space_utils)
+endif(ALBANY_MPI)
 
 #####################################################################
 

--- a/tests/unit/UnitTest_StringUtils.cpp
+++ b/tests/unit/UnitTest_StringUtils.cpp
@@ -1,0 +1,96 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Albany_StringUtils.hpp"
+
+#include <Teuchos_UnitTestHarness.hpp>
+
+namespace Albany
+{
+
+TEUCHOS_UNIT_TEST(StringUtils,strint)
+{
+  std::string s = "foo";
+  TEST_ASSERT (util::strint(s,0)=="foo 0");
+}
+
+TEUCHOS_UNIT_TEST(StringUtils,ParseList)
+{
+  std::string valid_1 = "[a]";
+  std::string valid_2 = "[a,b]";
+  std::string valid_3 = "[a,[b,c]]";
+  std::string valid_4 = "[[a,b],c]";
+  std::string valid_5 = "[[a]]";
+  std::string valid_6 = "[[a,[b,c]],d]";
+
+  std::string invalid_1 = "[]";
+  std::string invalid_2 = "[,b]";
+  std::string invalid_3 = "[a[b,c]]";
+  std::string invalid_4 = "[,,c]";
+  std::string invalid_5 = "[a,]";
+
+  using namespace util;
+
+  // Ensure we can tell valid from unvalid strings
+  TEST_ASSERT (validNestedListFormat(valid_1));
+  TEST_ASSERT (validNestedListFormat(valid_2));
+  TEST_ASSERT (validNestedListFormat(valid_3));
+  TEST_ASSERT (validNestedListFormat(valid_4));
+  TEST_ASSERT (validNestedListFormat(valid_5));
+  TEST_ASSERT (validNestedListFormat(valid_6));
+  
+  TEST_ASSERT (not validNestedListFormat(invalid_1));
+  TEST_ASSERT (not validNestedListFormat(invalid_2));
+  TEST_ASSERT (not validNestedListFormat(invalid_3));
+  TEST_ASSERT (not validNestedListFormat(invalid_4));
+  TEST_ASSERT (not validNestedListFormat(invalid_5));
+
+  // Parse strings into lists
+  auto pl_1 = parseNestedList(valid_1);
+  auto pl_2 = parseNestedList(valid_2);
+  auto pl_3 = parseNestedList(valid_3);
+  auto pl_4 = parseNestedList(valid_4);
+  auto pl_5 = parseNestedList(valid_5);
+  auto pl_6 = parseNestedList(valid_6);
+
+  // Test counters
+  TEST_ASSERT (pl_1.get<int>("Num Entries")==1);
+  TEST_ASSERT (pl_2.get<int>("Num Entries")==2);
+  TEST_ASSERT (pl_3.get<int>("Num Entries")==2);
+  TEST_ASSERT (pl_4.get<int>("Num Entries")==2);
+  TEST_ASSERT (pl_5.get<int>("Num Entries")==1);
+  TEST_ASSERT (pl_6.get<int>("Num Entries")==2);
+
+  TEST_ASSERT (pl_1.get<int>("Depth")==1);
+  TEST_ASSERT (pl_2.get<int>("Depth")==1);
+  TEST_ASSERT (pl_3.get<int>("Depth")==2);
+  TEST_ASSERT (pl_4.get<int>("Depth")==2);
+  TEST_ASSERT (pl_5.get<int>("Depth")==2);
+  TEST_ASSERT (pl_6.get<int>("Depth")==3);
+
+  // For entries, only test valid_6 = "[[a,[b,c]],d]";
+  TEST_ASSERT (pl_6.get<std::string>("Type 0")=="List");
+  TEST_ASSERT (pl_6.get<std::string>("Type 1")=="Value");
+  TEST_ASSERT (pl_6.get<std::string>("Entry 1")=="d");
+
+  const auto& sub = pl_6.sublist("Entry 0");
+
+  TEST_ASSERT (sub.get<int>("Num Entries")==2);
+  TEST_ASSERT (sub.get<int>("Depth")==2);
+  TEST_ASSERT (sub.get<std::string>("Type 0")=="Value");
+  TEST_ASSERT (sub.get<std::string>("Type 1")=="List");
+  TEST_ASSERT (sub.get<std::string>("Entry 0")=="a");
+
+  const auto& subsub = sub.sublist("Entry 1");
+  TEST_ASSERT (subsub.get<int>("Num Entries")==2);
+  TEST_ASSERT (subsub.get<int>("Depth")==1);
+  TEST_ASSERT (subsub.get<std::string>("Type 0")=="Value");
+  TEST_ASSERT (subsub.get<std::string>("Type 1")=="Value");
+  TEST_ASSERT (subsub.get<std::string>("Entry 0")=="b");
+  TEST_ASSERT (subsub.get<std::string>("Entry 1")=="a");
+}
+
+} // namespace Albany


### PR DESCRIPTION
Some minor mods:

* Renamed `string.hpp` to `Albany_StringUtils.hpp` (the former was a way too common name, and way to close to std lib `string`).
* Moves some string utils out of `Albany_Utils.*pp` and into `Albany_StringUtils.*pp`.
* Add a unit test file for string utils.
* Add a function to parse a string representing nested lists into a `Teuchos::ParameterList`.

I'm planning to use the latter in a few places, when parsing strings representing block structures.