### PR TITLE
[WIP] Split the connectivity info from the dof numbering

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -939,7 +939,7 @@ namespace {
 inline Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>&
 deref_nfm(
     Teuchos::ArrayRCP<Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>>& nfm,
-    const WorksetArray<int>::type& wsPhysIndex,
+    const WorksetArray<int>&       wsPhysIndex,
     int                            ws)
 {
   return nfm.size() == 1 ?  // Currently, all problems seem to have one nfm ...

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -41,13 +41,6 @@ class Application
 {
 public:
 
-  enum SolutionMethod
-  {
-    Steady,
-    Transient,
-    Continuation
-  };
-
   enum SolutionStatus
   {
     Converged,
@@ -142,7 +135,7 @@ public:
   getDistributedParameterLibrary() const;
 
   //! Get solution method
-  SolutionMethod
+  SolutionMethodType
   getSolutionMethod() const
   {
     return solMethod;
@@ -1228,7 +1221,7 @@ void
   std::string                          precType;
 
   //! Type of solution method
-  SolutionMethod solMethod;
+  SolutionMethodType solMethod;
 
   //! Integer specifying whether user wants to write Jacobian to MatrixMarket
   //! file

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -1007,7 +1007,7 @@ void
   int
   getNumWorksets()
   {
-    return disc->getWsElNodeEqID().size();
+    return disc->getWsElNodeLID().size();
   }
 
   //! Const access to problem parameter list
@@ -1118,8 +1118,7 @@ void
       const Teuchos::RCP<const Thyra_MultiVector>& Vxdotdot,
       const Teuchos::RCP<const Thyra_MultiVector>& Vp);
 
-  int
-  calcTangentDerivDimension(const Teuchos::RCP<Teuchos::ParameterList>& problemParams);
+  int calcTangentDerivDimension();
 
  private:
   template <typename EvalT>
@@ -1307,17 +1306,16 @@ void
 Application::loadWorksetBucketInfo(PHAL::Workset& workset, const int& ws,
     const std::string& evalName)
 {
-  auto const& wsElNodeEqID       = disc->getWsElNodeEqID();
-  auto const& wsElNodeID         = disc->getWsElNodeID();
-  auto const& coords             = disc->getCoords();
-  auto const& wsEBNames          = disc->getWsEBNames();
+  // auto const& wsElNodeEqID       = disc->getWsElNodeEqID();
+  auto const& wsElNodeLID = disc->getWsElNodeLID();
+  auto const& coords      = disc->getCoords();
+  auto const& wsEBNames   = disc->getWsEBNames();
 
-  workset.numCells             = wsElNodeEqID[ws].extent(0);
-  workset.wsElNodeEqID         = wsElNodeEqID[ws];
-  workset.wsElNodeID           = wsElNodeID[ws];
-  workset.wsCoords             = coords[ws];
-  workset.EBName               = wsEBNames[ws];
-  workset.wsIndex              = ws;
+  workset.numCells        = wsElNodeLID[ws].dev().extent(0);
+  workset.wsElNodeLID     = wsElNodeLID[ws];
+  workset.wsCoords        = coords[ws];
+  workset.EBName          = wsEBNames[ws];
+  workset.wsIndex         = ws;
 
   workset.local_Vp.resize(workset.numCells);
 

--- a/src/Albany_DistributedParameter.hpp
+++ b/src/Albany_DistributedParameter.hpp
@@ -7,14 +7,16 @@
 #ifndef ALBANY_DISTRIBUTED_PARAMETER_HPP
 #define ALBANY_DISTRIBUTED_PARAMETER_HPP
 
-#include <string>
+#include "Albany_CombineAndScatterManager.hpp"
+#include "Albany_StateInfoStruct.hpp" // For IDArray
+#include "Albany_NodalDOFManager.hpp"
+#include "Albany_DiscretizationUtils.hpp"
+#include "Albany_ThyraTypes.hpp"
 
 #include "Teuchos_RCP.hpp"
 #include "Teuchos_TestForException.hpp"
 
-#include "Albany_StateInfoStruct.hpp" // For IDArray
-#include "Albany_ThyraTypes.hpp"
-#include "Albany_CombineAndScatterManager.hpp"
+#include <string>
 
 namespace Albany {
 
@@ -51,13 +53,18 @@ public:
   //! Get name
   const std::string& name() const { return param_name; }
 
-  //! Set workset_elem_dofs map
-  void set_workset_elem_dofs(const Teuchos::RCP<const id_array_vec_type>& ws_elem_dofs_) {
-    ws_elem_dofs = ws_elem_dofs_;
+  //! Set workset_elem_nodes map
+  // void set_workset_elem_nodes (const Connectivity<LO>& ws_el_nodes_) {
+  //   ws_el_nodes = ws_el_nodes_;
+  // }
+  // Set the dof manager for the parameter
+  void set_dof_mgr (const NodalDOFManager& dof_mgr_) {
+    dof_mgr = dof_mgr_;
   }
 
   //! Return constant workset_elem_dofs. For each workset, workset_elem_dofs maps (elem, node, nComp) into local id
-  const id_array_vec_type& workset_elem_dofs() const { return *ws_elem_dofs; }
+  // const Connectivity<LO>&   workset_elem_nodes() const { return ws_el_nodes; }
+  const NodalDOFManager&    get_dof_mgr () const { return dof_mgr; }
 
   //! Get vector space 
   virtual Teuchos::RCP<const Thyra_VectorSpace> vector_space() const { return owned_vec->space(); }
@@ -109,8 +116,12 @@ protected:
   //! The manager for scatter/combine operation
   Teuchos::RCP<const CombineAndScatterManager> cas_manager;
 
-  //! Vector over worksets, containing DOF's map from (elem, node, nComp) into local id
-  Teuchos::RCP<const id_array_vec_type> ws_elem_dofs;
+  // Together, the following two allow to retrieve the GID of
+  // any dof of the parameter. The first retrieves the list of
+  // LOCAL node ids given the tripled (ws,cell,node), while the
+  // latter gives the dof id as a function of the node id.
+  Connectivity<LO>  ws_el_nodes;
+  NodalDOFManager   dof_mgr;
 };
 
 } // namespace Albany

--- a/src/Albany_DummyParameterAccessor.hpp
+++ b/src/Albany_DummyParameterAccessor.hpp
@@ -29,7 +29,7 @@ class DummyParameterAccessor :
 
    public:
      DummyParameterAccessor() { dummy = 0.0;};
-     typename EvalT::ScalarT& getValue(const std::string &name)
+     typename EvalT::ScalarT& getValue(const std::string &/* name */)
      { return dummy;};
    private:
      typename EvalT::ScalarT dummy;

--- a/src/Albany_StatelessObserverImpl.cpp
+++ b/src/Albany_StatelessObserverImpl.cpp
@@ -24,10 +24,9 @@ StatelessObserverImpl (const Teuchos::RCP<Application> &app)
 RealType StatelessObserverImpl::
 getTimeParamValueOrDefault (RealType defaultValue) const {
   const std::string label("Time");
-  //IKT, NOTE: solMethod == 1 corresponds to Transient
   bool const
     use_time_param = (app_->getParamLib()->isParameter(label) == true) &&
-      (app_->getSolutionMethod() != 1);
+      (app_->getSolutionMethod() != Transient);
 
   double const
     this_time = use_time_param == true ?

--- a/src/InitialCondition.hpp
+++ b/src/InitialCondition.hpp
@@ -4,25 +4,22 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef INITIAL_CONDITION_HPP
-#define INITIAL_CONDITION_HPP
+#ifndef ALBANY_INITIAL_CONDITION_HPP
+#define ALBANY_INITIAL_CONDITION_HPP
 
-#include "Albany_DataTypes.hpp"
-#include "Albany_DiscretizationUtils.hpp"
+#include "Albany_AbstractDiscretization.hpp"
+#include "Albany_ThyraTypes.hpp"
 
-#include <string>
 #include "Teuchos_ParameterList.hpp"
+#include "Teuchos_RCP.hpp"
 
 namespace Albany {
 
 void InitialConditions (const Teuchos::RCP<Thyra_Vector>& soln,
-                        const Albany::Conn& wsElNodeEqID,
-                        const Teuchos::ArrayRCP<std::string>& wsEBNames,
-                        const Teuchos::ArrayRCP<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*> > > coords,
-                        const int neq, const int numDim,
+                        const AbstractDiscretization& disc,
                         Teuchos::ParameterList& icParams,
-                        const bool gasRestartSolution = false);
+                        const bool hasRestartSolution);
 
 } // namespace Albany
 
-#endif // INITIAL_CONDITION_HPP
+#endif // ALBANY_INITIAL_CONDITION_HPP

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -208,25 +208,6 @@ struct Workset
       typedef Teuchos::RCP<Teuchos::ValueTypeSerializer<int, T>> type;
     };
   };
-
-  void
-  print(std::ostream& os)
-  {
-    os << "Printing workset data:" << std::endl;
-    os << "\tEB name : " << EBName << std::endl;
-    os << "\tnumCells : " << numCells << std::endl;
-    os << "\twsElNodeEqID : " << std::endl;
-    for (unsigned int i = 0; i < wsElNodeEqID.extent(0); i++)
-      for (unsigned int j = 0; j < wsElNodeEqID.extent(1); j++)
-        for (unsigned int k = 0; k < wsElNodeEqID.extent(2); k++)
-          os << "\t\twsElNodeEqID(" << i << "," << j << "," << k
-             << ") = " << wsElNodeEqID(i, j, k) << std::endl;
-    os << "\twsCoords : " << std::endl;
-    for (int i = 0; i < wsCoords.size(); i++)
-      for (int j = 0; j < wsCoords[i].size(); j++)
-        os << "\t\tcoord0:" << wsCoords[i][j][0] << "][" << wsCoords[i][j][1]
-           << std::endl;
-  }
 };
 
 }  // namespace PHAL

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -135,13 +135,12 @@ struct Workset
   bool                                              transpose_dist_param_deriv;
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double>>> local_Vp;
 
-  Albany::WorksetConn                           wsElNodeEqID;
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>      wsElNodeID;
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>> wsCoords;
-  std::string                                   EBName;
+  Albany::WorksetConnectivity<LO>                 wsElNodeLID;
+  // Albany::WorksetConnectivity<GO>                 wsElNodeGID;
+  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>   wsCoords;
+  std::string                                     EBName;
 
-  // Needed for Schwarz coupling and for dirichlet conditions based on dist
-  // parameters.
+  // Needed for retrieving information about dofs (e.g. DOFManager)
   Teuchos::RCP<Albany::AbstractDiscretization> disc;
 
   int spatial_dimension_{0};

--- a/src/SolutionManager.cpp
+++ b/src/SolutionManager.cpp
@@ -68,8 +68,6 @@ SolutionManager::SolutionManager(
   }
   //  }
 
-  {
-
   auto owned_vs      = disc_->getVectorSpace();
   auto overlapped_vs = disc_->getOverlapVectorSpace();
 
@@ -81,9 +79,6 @@ SolutionManager::SolutionManager(
     overlapped_soln_dxdp = Teuchos::null;
   }
 
-  // TODO: ditch the overlapped_*T and keep only overlapped_*.
-  //       You need to figure out how to pass the graph in a Tpetra-free way
-  //       though...
   overlapped_f = Thyra::createMember(overlapped_vs);
 
   // This call allocates the non-overlapped MV
@@ -92,15 +87,6 @@ SolutionManager::SolutionManager(
   // Create the CombineAndScatterManager for handling distributed memory linear
   // algebra communications
   cas_manager = Albany::createCombineAndScatterManager(owned_vs, overlapped_vs);
-
-  }
-
-
-  auto                           wsElNodeEqID = disc_->getWsElNodeEqID();
-  auto                           coords       = disc_->getCoords();
-  Teuchos::ArrayRCP<std::string> wsEBNames    = disc_->getWsEBNames();
-  const int                      numDim       = disc_->getNumDim();
-  const int                      neq          = disc_->getNumEq();
 
   Teuchos::RCP<Teuchos::ParameterList> pbParams =
       Teuchos::sublist(appParams_, "Problem", true);
@@ -114,11 +100,7 @@ SolutionManager::SolutionManager(
         Albany::CombineMode::INSERT);
     InitialConditions(
         overlapped_soln->col(0),
-        wsElNodeEqID,
-        wsEBNames,
-        coords,
-        neq,
-        numDim,
+        *disc,
         pbParams->sublist("Initial Condition"),
         disc_->hasRestartSolution());
     cas_manager->combine(
@@ -133,11 +115,7 @@ SolutionManager::SolutionManager(
           Albany::CombineMode::INSERT);
       InitialConditions(
           overlapped_soln->col(1),
-          wsElNodeEqID,
-          wsEBNames,
-          coords,
-          neq,
-          numDim,
+          *disc,
           pbParams->sublist("Initial Condition Dot"),
           disc_->hasRestartSolution());
       cas_manager->combine(
@@ -153,11 +131,7 @@ SolutionManager::SolutionManager(
           Albany::CombineMode::INSERT);
       InitialConditions(
           overlapped_soln->col(2),
-          wsElNodeEqID,
-          wsEBNames,
-          coords,
-          neq,
-          numDim,
+          *disc,
           pbParams->sublist("Initial Condition DotDot"),
           disc_->hasRestartSolution());
       cas_manager->combine(

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -99,7 +99,7 @@ class AbstractDiscretization
   getWsElNodeEqID() const = 0;
 
   //! Get map from (Ws, El, Local Node) -> unkGID
-  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type&
+  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
   getWsElNodeID() const = 0;
 
   //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
@@ -140,8 +140,7 @@ class AbstractDiscretization
   getOverlapNodeGlobalLocalIndexer () const { return getOverlapGlobalLocalIndexer(nodes_dof_name()); }
 
   //! Retrieve coodinate ptr_field (ws, el, node)
-  virtual const WorksetArray<
-      Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type&
+  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>&
   getCoords() const = 0;
 
   //! Get coordinates (overlap map).
@@ -181,11 +180,11 @@ class AbstractDiscretization
   getNodalParameterSIS() const = 0;
 
   //! Retrieve Vector (length num worksets) of element block names
-  virtual const WorksetArray<std::string>::type&
+  virtual const WorksetArray<std::string>&
   getWsEBNames() const = 0;
 
   //! Retrieve Vector (length num worksets) of Physics Index
-  virtual const WorksetArray<int>::type&
+  virtual const WorksetArray<int>&
   getWsPhysIndex() const = 0;
 
   //! Retrieve connectivity map from elementGID to workset

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -94,26 +94,34 @@ class AbstractDiscretization
   virtual const std::map<std::string, Kokkos::View<LO****, PHX::Device>>&
   getLocalDOFViews(const int workset) const = 0;
 
-  //! Get map from (Ws, El, Local Node, Eq) -> unkLID
-  virtual const Conn&
-  getWsElNodeEqID() const = 0;
+  // Get number of cell worksets
+  int getNumWorksets () const {
+    return getWsElNodeLID().size();
+  }
 
-  //! Get map from (Ws, El, Local Node) -> unkGID
-  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
-  getWsElNodeID() const = 0;
-
-  //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
-  //! both scalar and vector fields
-  virtual const std::vector<IDArray>&
-  getElNodeEqID(const std::string& field_name) const = 0;
+  //! Get WS array of (Ws, El, Local Node) -> nodeLID
+  virtual const Connectivity<LO>&
+  getWsElNodeLID() const = 0;
 
   //! Get Dof Manager of field field_name
   virtual const NodalDOFManager&
   getDOFManager(const std::string& field_name) const = 0;
 
+  // Handy shortcut of the above for solution dof name
+  const NodalDOFManager&
+  getSolutionDOFManager() const {
+    return getDOFManager (solution_dof_name());
+  }
+
   //! Get Dof Manager of field field_name
   virtual const NodalDOFManager&
   getOverlapDOFManager(const std::string& field_name) const = 0;
+
+  // Handy shortcut of the above for solution dof name
+  const NodalDOFManager&
+  getSolutionOverlapDOFManager() const {
+    return getOverlapDOFManager (solution_dof_name());
+  }
 
   //! Get Dof Manager of field field_name
   virtual Teuchos::RCP<const GlobalLocalIndexer>

--- a/src/disc/Albany_DOFManager.hpp
+++ b/src/disc/Albany_DOFManager.hpp
@@ -1,0 +1,74 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_DOF_MANAGER_HPP
+#define ALBANY_DOF_MANAGER_HPP
+
+#include "Albany_ScalarOrdinalTypes.hpp"
+
+#include "Kokkos_Macros.hpp"
+
+namespace Albany {
+
+/*
+ * DOFManager: a lightweight struct to map entity_id->dof_id
+ *
+ * A DOFManager produces a global/local ID for a DOF given the
+ * global/local ID of the entity where the DOF is defined.
+ * Depending on whether the dof components are interleaved,
+ * the relation between entity and dof id is
+ *
+ *  - interleaved:     dof_id = entity_id*num_comp + icomp
+ *  - non-interleaved: dof_id = entity_id + (max_entity_id+1)*icomp
+ *
+ * Note: id mapping routines are device friendly
+ */
+
+class DOFManager {
+public:
+  DOFManager ()  = default;
+
+  void setup (const int numComponents, const LO numLocalEntities,
+              const GO maxGlobalEntityIdID, const bool interleaved) {
+    m_numComponents = numComponents;
+    m_numLocalEntities = numLocalEntities;
+    m_maxGlobalEntityIdIDp1 = maxGlobalEntityIdID + 1;
+    m_interleaved = interleaved;
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  LO getLocalDOF(LO iEntity, int icomp) const {
+    if (m_interleaved) {
+      return iEntity*m_numComponents + icomp;
+    } else {
+      return iEntity + m_numLocalEntities*icomp;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  GO getGlobalDOF(GO node, int icomp) const {
+    if (m_interleaved) {
+      return node*m_numComponents + icomp;
+    } else {
+      return node + m_maxGlobalEntityIdIDp1*icomp;
+    }
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  int numComponents() const {
+    return m_numComponents;
+  }
+
+private:
+  int       m_numComponents;
+  LO        m_numLocalEntities;
+  GO        m_maxGlobalEntityIdIDp1;
+  bool      m_interleaved;
+};
+
+} // namespace Albany
+
+#endif // ALBANY_DOF_MANAGER_HPP

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -94,10 +94,7 @@ class wsLid
 using WsLIDList = std::map<GO, wsLid>;
 
 template <typename T>
-struct WorksetArray
-{
-  using type = Teuchos::ArrayRCP<T>;
-};
+using WorksetArray = Teuchos::ArrayRCP<T>;
 
 // LB 8/17/18: I moved these out of AbstractDiscretization, so if one only needs
 // these types,
@@ -105,7 +102,7 @@ struct WorksetArray
 //             Albany_AbstractDiscretization.hpp, which has tons of
 //             dependencies.
 using WorksetConn = Kokkos::View<LO***, Kokkos::LayoutRight, PHX::Device>;
-using Conn        = WorksetArray<WorksetConn>::type;
+using Conn        = WorksetArray<WorksetConn>;
 
 }  // namespace Albany
 

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -96,13 +96,17 @@ using WsLIDList = std::map<GO, wsLid>;
 template <typename T>
 using WorksetArray = Teuchos::ArrayRCP<T>;
 
-// LB 8/17/18: I moved these out of AbstractDiscretization, so if one only needs
-// these types,
-//             he/she can include this small file rather than
-//             Albany_AbstractDiscretization.hpp, which has tons of
-//             dependencies.
-using WorksetConn = Kokkos::View<LO***, Kokkos::LayoutRight, PHX::Device>;
-using Conn        = WorksetArray<WorksetConn>;
+// LB 8/17/18:
+// I moved these out of AbstractDiscretization, so if one only needs
+// these types, they can include this small file rather than
+// Albany_AbstractDiscretization.hpp, which has tons of dependencies.
+
+// Connectivity means a map (cell_id, entity_id) -> ID
+template<typename T>
+using WorksetConnectivity = DualView<T**>;
+
+template<typename T>
+using Connectivity = WorksetArray<WorksetConnectivity<T>>;
 
 }  // namespace Albany
 

--- a/src/disc/Albany_NodalDOFManager.hpp
+++ b/src/disc/Albany_NodalDOFManager.hpp
@@ -7,60 +7,11 @@
 #ifndef ALBANY_NODAL_DOF_MANAGER_HPP
 #define ALBANY_NODAL_DOF_MANAGER_HPP
 
-#include "Albany_MeshSpecs.hpp"
-#include "Albany_ScalarOrdinalTypes.hpp"
-#include "Albany_ThyraTypes.hpp"
-#include "Albany_GlobalLocalIndexer.hpp"
-
-#include "Teuchos_RCP.hpp"
+#include "Albany_DOFManager.hpp"
 
 namespace Albany {
 
-class NodalDOFManager {
-public:
-  NodalDOFManager ()  = default;
-
-  void setup (const int numComponents, const LO numLocalNodes,
-              const GO maxGlobalNodeID, const DiscType discType) {
-    m_numComponents = numComponents;
-    m_numLocalNodes = numLocalNodes;
-    m_maxGlobalNodeIDp1 = maxGlobalNodeID + 1;
-    m_discType = discType;
-  }
-
-  void setup (const int numComponents, const Teuchos::RCP<const Thyra_VectorSpace>& node_vs,
-              const DiscType discType) {
-    const auto indexer = createGlobalLocalIndexer(node_vs);
-    const int numLocalNodes = indexer->getNumLocalElements();
-    const int maxGlobalGID  = indexer->getMaxGlobalGID();
-    setup(numComponents,numLocalNodes,maxGlobalGID,discType);
-  }
-
-  inline LO getLocalDOF(LO inode, int icomp) const {
-    if (m_discType == DiscType::Interleaved) {
-      return inode*m_numComponents + icomp;
-    } else {
-      return inode + m_numLocalNodes*icomp;
-    }
-  }
-  inline GO getGlobalDOF(GO node, int icomp) const {
-    if (m_discType == DiscType::Interleaved) {
-      return node*m_numComponents + icomp;
-    } else {
-      return node + m_maxGlobalNodeIDp1*icomp;
-    }
-  }
-
-  int numComponents() const {
-    return m_numComponents;
-  }
-
-private:
-  int       m_numComponents;
-  LO        m_numLocalNodes;
-  GO        m_maxGlobalNodeIDp1;
-  DiscType  m_discType;
-};
+using NodalDOFManager = DOFManager;
 
 } // namespace Albany
 

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -245,7 +245,7 @@ namespace Albany
       return wsElNodeEqID;
     }
 
-    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type &
+    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> &
     getWsElNodeID() const
     {
       return wsElNodeID;
@@ -297,7 +297,7 @@ namespace Albany
       return m_blocks[i_block]->getOverlapDOFManager(field_name);
     }
 
-    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>>::type &
+    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>> &
     getCoords() const
     {
       return coords;
@@ -329,13 +329,13 @@ namespace Albany
     }
 
     //! Retrieve Vector (length num worksets) of element block names
-    const WorksetArray<std::string>::type &
+    const WorksetArray<std::string> &
     getWsEBNames() const
     {
       return wsEBNames;
     }
     //! Retrieve Vector (length num worksets) of physics set index
-    const WorksetArray<int>::type &
+    const WorksetArray<int> &
     getWsPhysIndex() const
     {
       return wsPhysIndex;
@@ -835,15 +835,15 @@ namespace Albany
     Conn wsElNodeEqID;
 
     //! Connectivity array [workset, element, local-node] => GID
-    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type wsElNodeID;
+    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> wsElNodeID;
 
     mutable Teuchos::ArrayRCP<double> coordinates;
     Teuchos::RCP<Thyra_MultiVector> coordMV;
-    WorksetArray<std::string>::type wsEBNames;
-    WorksetArray<int>::type wsPhysIndex;
-    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>>::type coords;
-    WorksetArray<Teuchos::ArrayRCP<double>>::type sphereVolume;
-    WorksetArray<Teuchos::ArrayRCP<double *>>::type latticeOrientation;
+    WorksetArray<std::string> wsEBNames;
+    WorksetArray<int> wsPhysIndex;
+    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>> coords;
+    WorksetArray<Teuchos::ArrayRCP<double>> sphereVolume;
+    WorksetArray<Teuchos::ArrayRCP<double *>> latticeOrientation;
 
     //! Connectivity map from elementGID to workset and LID in workset
     WsLIDList elemGIDws;

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -670,6 +670,7 @@ namespace Albany
         const double /* time */,
         const bool overlapped)
     {
+      ALBANY_ABORT ("This function not yet implemented.\n");
       this->writeSolutionToMeshDatabase(soln, soln_dxdp, soln_dot, 0.0, overlapped);
     }
     void
@@ -715,6 +716,7 @@ namespace Albany
         const double /* time */,
         const bool overlapped)
     {
+      ALBANY_ABORT ("This function not yet implemented.\n");
       this->writeSolutionMVToMeshDatabase(soln, soln_dxdp, 0.0, overlapped);
     }
     void

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -66,6 +66,11 @@ namespace Albany
     void printConnectivity() const;
     void printConnectivity(const size_t i_block) const;
 
+    Teuchos::RCP<disc_type> get_block (const int iblock) const {
+      ALBANY_ASSERT (iblock>=0 && iblock<n_m_blocks);
+      return m_blocks[iblock];
+    }
+
     int getBlockFADLength(const size_t i_block);
 
     int getBlockFADOffset(const size_t i_block)
@@ -238,31 +243,24 @@ namespace Albany
       return elemGIDws;
     }
 
-    //! Get map from ws, elem, node [, eq] -> [Node|DOF] GID
-    const Conn &
-    getWsElNodeEqID() const
+    const Connectivity<LO>&
+    getWsElNodeLID() const
     {
-      return wsElNodeEqID;
+      return m_blocks[0]->getWsElNodeLID();
     }
 
-    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> &
-    getWsElNodeID() const
-    {
-      return wsElNodeID;
-    }
-
-    //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
-    //! both scalar and vector fields
-    const std::vector<IDArray> &
-    getElNodeEqID(const std::string &field_name) const
-    {
-      return this->getElNodeEqID(0, field_name);
-    }
-    const std::vector<IDArray> &
-    getElNodeEqID(const size_t i_block, const std::string &field_name) const
-    {
-      return m_blocks[i_block]->getElNodeEqID(field_name);
-    }
+    // //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
+    // //! both scalar and vector fields
+    // const std::vector<IDArray> &
+    // getElNodeEqID(const std::string &field_name) const
+    // {
+    //   return this->getElNodeEqID(0, field_name);
+    // }
+    // const std::vector<IDArray> &
+    // getElNodeEqID(const size_t i_block, const std::string &field_name) const
+    // {
+    //   return m_blocks[i_block]->getElNodeEqID(field_name);
+    // }
 
     void
     setBlockedDOFManager(Teuchos::RCP<panzer::BlockedDOFManager> blockedDOFManagerVolume_)
@@ -834,10 +832,10 @@ namespace Albany
     NodeSetCoordList nodeSetCoords;
 
     //! Connectivity array [workset, element, local-node, Eq] => LID
-    Conn wsElNodeEqID;
+    // Conn wsElNodeEqID;
 
     //! Connectivity array [workset, element, local-node] => GID
-    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> wsElNodeID;
+    Connectivity<LO>    wsElNodeLID;
 
     mutable Teuchos::ArrayRCP<double> coordinates;
     Teuchos::RCP<Thyra_MultiVector> coordMV;

--- a/src/disc/stk/Albany_MultiSTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_MultiSTKFieldContainer.cpp
@@ -290,7 +290,7 @@ MultiSTKFieldContainer::fillSolnVector(
 
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   int offset = 0;
   for (int k = 0; k < sol_index[0].size(); k++) {
@@ -320,7 +320,7 @@ MultiSTKFieldContainer::fillSolnMultiVector(
   // to retrieve the local entry id in the thyra vector.
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   for (int icomp = 0; icomp < solution.domain()->dim(); ++icomp) {
     int offset = 0;
@@ -364,7 +364,7 @@ MultiSTKFieldContainer::saveVector(
 void
 MultiSTKFieldContainer::saveSolnVector(
     const Thyra_Vector&                          solution,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
     stk::mesh::Selector&                         sel,
     const Teuchos::RCP<const Thyra_VectorSpace>& node_vs)
 {
@@ -380,7 +380,7 @@ MultiSTKFieldContainer::saveSolnVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   int offset = 0;
   for (int k = 0; k < sol_index[0].size(); ++k) {
@@ -448,7 +448,7 @@ MultiSTKFieldContainer::saveSolnVector(
 void
 MultiSTKFieldContainer::saveSolnMultiVector(
     const Thyra_MultiVector&                     solution,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
     stk::mesh::Selector&                         sel,
     const Teuchos::RCP<const Thyra_VectorSpace>& node_vs)
 {
@@ -464,7 +464,7 @@ MultiSTKFieldContainer::saveSolnMultiVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   for (int icomp = 0; icomp < solution.domain()->dim(); ++icomp) {
     int offset = 0;
@@ -499,7 +499,7 @@ MultiSTKFieldContainer::saveResVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   int offset = 0;
   for (int k = 0; k < res_index.size(); k++) {

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
@@ -43,7 +43,7 @@ OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
     const Teuchos::RCP<Teuchos::ParameterList>&               params_,
     const Teuchos::RCP<stk::mesh::MetaData>&                  metaData_,
     const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
-    const AbstractFieldContainer::FieldContainerRequirements& req,
+    const AbstractFieldContainer::FieldContainerRequirements& /* req */,
     const DiscType                                            interleaved_,
     const int                                                 numDim_,
     const Teuchos::RCP<StateInfoStruct>&                      sis,
@@ -99,7 +99,7 @@ OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
     const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
     const DiscType                                            interleaved_,
     const int                                                 neq_,
-    const AbstractFieldContainer::FieldContainerRequirements& req,
+    const AbstractFieldContainer::FieldContainerRequirements& /* req */,
     const int                                                 numDim_,
     const Teuchos::RCP<StateInfoStruct>&                      sis,
     const int                                                 num_params_)
@@ -272,7 +272,7 @@ OrdinarySTKFieldContainer::fillSolnVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   fillVectorImpl(
       solution, solution_field[0]->name(), sel, node_vs, nodalDofManager);
@@ -298,7 +298,7 @@ OrdinarySTKFieldContainer::fillSolnMultiVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::BlockedDisc);
 
   for (int icomp = 0; icomp < solution.domain()->dim(); ++icomp) {
     fillVectorImpl(
@@ -354,7 +354,7 @@ OrdinarySTKFieldContainer::saveSolnVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::BlockedDisc);
 
   saveVectorImpl(
       solution, solution_field[0]->name(), sel, node_vs, nodalDofManager);
@@ -398,7 +398,7 @@ OrdinarySTKFieldContainer::saveSolnVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::BlockedDisc);
 
   saveVectorImpl(
       solution, solution_field[0]->name(), sel, node_vs, nodalDofManager);
@@ -444,7 +444,7 @@ OrdinarySTKFieldContainer::saveSolnVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::BlockedDisc);
 
   saveVectorImpl(
       solution, solution_field[0]->name(), sel, node_vs, nodalDofManager);
@@ -491,7 +491,7 @@ OrdinarySTKFieldContainer::saveSolnMultiVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::BlockedDisc);
 
   for (int icomp = 0; icomp < solution.domain()->dim(); ++icomp) {
     saveVectorImpl(
@@ -535,7 +535,7 @@ OrdinarySTKFieldContainer::saveResVector(
   // The number of equations is given by sol_index
   const LO        numLocalNodes = getSpmdVectorSpace(node_vs)->localSubDim();
   NodalDOFManager nodalDofManager;
-  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved);
+  nodalDofManager.setup(this->neq, numLocalNodes, -1, interleaved==DiscType::Interleaved);
 
   saveVectorImpl(res, residual_field->name(), sel, node_vs, nodalDofManager);
 }

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1156,8 +1156,8 @@ void STKDiscretization::computeVectorSpaces()
         dofs->vs_indexer         = dofs->node_vs_indexer;
       } else {
         // Create dof vs by replicating the nodal one (possibly interleaved)
-        dofs->vs         = createVectorSpace(dofs->node_vs,numComponents,interleavedOrdering);
-        dofs->overlap_vs = createVectorSpace(dofs->overlap_node_vs,numComponents,interleavedOrdering);
+        dofs->vs         = createVectorSpace(dofs->node_vs,numComponents,interleavedOrdering==DiscType::Interleaved);
+        dofs->overlap_vs = createVectorSpace(dofs->overlap_node_vs,numComponents,interleavedOrdering==DiscType::Interleaved);
         dofs->overlap_vs_indexer = createGlobalLocalIndexer(dofs->overlap_vs);
         dofs->vs_indexer         = createGlobalLocalIndexer(dofs->vs);
       }
@@ -1165,12 +1165,12 @@ void STKDiscretization::computeVectorSpaces()
       dofs->dofManager.setup(numComponents,
                              numNodes,
                              maxGlobalNodeGID,
-                             interleavedOrdering);
+                             interleavedOrdering==DiscType::Interleaved);
 
       dofs->overlap_dofManager.setup(numComponents,
                              numNodes+numGhostedNodes,
                              maxGlobalNodeGID,
-                             interleavedOrdering);
+                             interleavedOrdering==DiscType::Interleaved);
     }
   }
 

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -231,7 +231,7 @@ class STKDiscretization : public AbstractDiscretization
     return wsElNodeEqID;
   }
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type&
+  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
   getWsElNodeID() const
   {
     return wsElNodeID;
@@ -275,7 +275,7 @@ class STKDiscretization : public AbstractDiscretization
   const Teuchos::ArrayRCP<double>&
   getCoordinates() const;
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type&
+  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>&
   getCoords() const
   {
     return coords;
@@ -307,13 +307,13 @@ class STKDiscretization : public AbstractDiscretization
   }
 
   //! Retrieve Vector (length num worksets) of element block names
-  const WorksetArray<std::string>::type&
+  const WorksetArray<std::string>&
   getWsEBNames() const
   {
     return wsEBNames;
   }
   //! Retrieve Vector (length num worksets) of physics set index
-  const WorksetArray<int>::type&
+  const WorksetArray<int>&
   getWsPhysIndex() const
   {
     return wsPhysIndex;
@@ -658,15 +658,15 @@ class STKDiscretization : public AbstractDiscretization
   Conn wsElNodeEqID;
 
   //! Connectivity array [workset, element, local-node] => GID
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type wsElNodeID;
+  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>        wsElNodeID;
 
   mutable Teuchos::ArrayRCP<double>                                 coordinates;
   Teuchos::RCP<Thyra_MultiVector>                                   coordMV;
-  WorksetArray<std::string>::type                                   wsEBNames;
-  WorksetArray<int>::type                                           wsPhysIndex;
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type coords;
-  WorksetArray<Teuchos::ArrayRCP<double>>::type  sphereVolume;
-  WorksetArray<Teuchos::ArrayRCP<double*>>::type latticeOrientation;
+  WorksetArray<std::string>                                         wsEBNames;
+  WorksetArray<int>                                                 wsPhysIndex;
+  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>       coords;
+  WorksetArray<Teuchos::ArrayRCP<double>>        sphereVolume;
+  WorksetArray<Teuchos::ArrayRCP<double*>>       latticeOrientation;
 
   //! Connectivity map from elementGID to workset and LID in workset
   WsLIDList elemGIDws;
@@ -685,7 +685,7 @@ class STKDiscretization : public AbstractDiscretization
   size_t           netCDFOutputRequest;
   std::vector<int> varSolns;
 
-  WorksetArray<Teuchos::ArrayRCP<std::vector<interp>>>::type interpolateData;
+  WorksetArray<Teuchos::ArrayRCP<std::vector<interp>>> interpolateData;
 
   // Storage used in periodic BCs to un-roll coordinates. Pointers saved for
   // destructor.

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -44,10 +44,6 @@ struct DOFsStruct
   Teuchos::RCP<const Thyra_VectorSpace> overlap_vs;
   NodalDOFManager                       dofManager;
   NodalDOFManager                       overlap_dofManager;
-  std::vector<std::vector<LO>>          wsElNodeEqID_rawVec;
-  std::vector<IDArray>                  wsElNodeEqID;
-  std::vector<std::vector<GO>>          wsElNodeID_rawVec;
-  std::vector<GIDArray>                 wsElNodeID;
 
   Teuchos::RCP<const GlobalLocalIndexer> node_vs_indexer;
   Teuchos::RCP<const GlobalLocalIndexer> overlap_node_vs_indexer;
@@ -225,25 +221,25 @@ class STKDiscretization : public AbstractDiscretization
   }
 
   //! Get map from ws, elem, node [, eq] -> [Node|DOF] GID
-  const Conn&
-  getWsElNodeEqID() const
+  const Connectivity<LO>&
+  getWsElNodeLID() const
   {
-    return wsElNodeEqID;
+    return wsElNodeLID;
   }
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
-  getWsElNodeID() const
-  {
-    return wsElNodeID;
-  }
+  // const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
+  // getWsElNodeID() const
+  // {
+  //   return wsElNodeID;
+  // }
 
-  //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
-  //! both scalar and vector fields
-  const std::vector<IDArray>&
-  getElNodeEqID(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name).wsElNodeEqID;
-  }
+  // //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
+  // //! both scalar and vector fields
+  // const std::vector<IDArray>&
+  // getElNodeEqID(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name).wsElNodeEqID;
+  // }
 
   Teuchos::RCP<const GlobalLocalIndexer>
   getGlobalLocalIndexer(const std::string& field_name) const
@@ -389,7 +385,8 @@ class STKDiscretization : public AbstractDiscretization
   int
   getFADLength() const
   {
-    return neq * wsElNodeID[0][0].size();
+    // TODO: switch depending on where the dofs are defined.
+    return neq * wsElNodeLID[0].dev().extent(1);
   }
 
   Teuchos::RCP<LayeredMeshNumbering<GO>>
@@ -655,10 +652,10 @@ class STKDiscretization : public AbstractDiscretization
   std::map<int, std::map<std::string, Kokkos::View<LO****, PHX::Device>>> wsLocalDOFViews;
 
   //! Connectivity array [workset, element, local-node, Eq] => LID
-  Conn wsElNodeEqID;
+  Connectivity<LO> wsElNodeLID;
 
   //! Connectivity array [workset, element, local-node] => GID
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>        wsElNodeID;
+  // WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>        wsElNodeID;
 
   mutable Teuchos::ArrayRCP<double>                                 coordinates;
   Teuchos::RCP<Thyra_MultiVector>                                   coordMV;

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -4,17 +4,18 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#include <vector>
-#include <string>
-#include <chrono>
+#include "PHAL_GatherSolution.hpp"
+
+#include "Albany_AbstractDiscretization.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_Macros.hpp"
 
 #include "Teuchos_TestForException.hpp"
 #include "Phalanx_DataLayout.hpp"
 
-#include "Albany_Macros.hpp"
-#include "Albany_ThyraUtils.hpp"
-
-#include "PHAL_GatherSolution.hpp"
+#include <vector>
+#include <string>
+#include <chrono>
 
 namespace PHAL {
 
@@ -212,81 +213,99 @@ template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank1_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valVec)(cell,node,eq)= x_constView(nodeID(cell, node,this->offset+eq));
+      this->valVec(cell,node,eq)= x_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank1_Transient_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valVec_dot)(cell,node,eq)= xdot_constView(nodeID(cell, node, this->offset+eq));
+      this->valVec_dot(cell,node,eq)= xdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank1_Acceleration_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valVec_dotdot)(cell,node,eq)= xdotdot_constView(nodeID(cell, node, this->offset+eq));
+      this->valVec_dotdot(cell,node,eq)= xdotdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank2_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valTensor)(cell,node,eq/numDim,eq%numDim)= x_constView(nodeID(cell, node, this->offset+eq));
+      this->valTensor(cell,node,eq/numDim,eq%numDim)= x_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank2_Transient_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim)= xdot_constView(nodeID(cell, node, this->offset+eq));
+      this->valTensor_dot(cell,node,eq/numDim,eq%numDim)= xdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank2_Acceleration_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim)= xdotdot_constView(nodeID(cell, node, this->offset+eq));
+      this->valTensor_dotdot(cell,node,eq/numDim,eq%numDim)= xdotdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank0_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      d_val[eq](cell,node)= x_constView(nodeID(cell, node, this->offset+eq));
+      d_val[eq](cell,node)= x_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank0_Transient_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      d_val_dot[eq](cell,node)= xdot_constView(nodeID(cell, node, this->offset+eq));
+      d_val_dot[eq](cell,node)= xdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 template<typename Traits>
 KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 operator() (const PHAL_GatherSolRank0_Acceleration_Tag&, const int& cell) const{
-  for (size_t node = 0; node < this->numNodes; ++node)
+  for (size_t node = 0; node < this->numNodes; ++node) {
+    const auto node_lid = elNodeLID(cell,node);
     for (int eq = 0; eq < numFields; eq++)
-      d_val_dotdot[eq](cell,node)= xdotdot_constView(nodeID(cell, node, this->offset+eq));
+      d_val_dotdot[eq](cell,node)= xdotdot_constView(this->dof_id(node_lid,eq));
+  }
 }
 
 #endif
@@ -300,8 +319,11 @@ evaluateFields(typename Traits::EvalData workset)
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
 
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
+
 #ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-  auto nodeID = workset.wsElNodeEqID;
+  auto h_elNodeLID = workset.wsElNodeLID.host();
+
   Teuchos::ArrayRCP<const ST> x_constView, xdot_constView, xdotdot_constView;
   x_constView = Albany::getLocalData(x);
   if(!xdot.is_null()) {
@@ -314,15 +336,16 @@ evaluateFields(typename Traits::EvalData workset)
   if (this->tensorRank == 1) {
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->valVec)(cell,node,eq) = x_constView[nodeID(cell,node,this->offset + eq)];
+          (this->valVec)(cell,node,eq) = x_constView[this->dof_id(node_lid,eq)];
         if (workset.transientTerms && this->enableTransient) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valVec_dot)(cell,node,eq) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+            (this->valVec_dot)(cell,node,eq) = xdot_constView[this->dof_id(node_lid,eq)];
         }
         if (workset.accelerationTerms && this->enableAcceleration) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valVec_dotdot)(cell,node,eq) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+            (this->valVec_dotdot)(cell,node,eq) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
@@ -330,30 +353,32 @@ evaluateFields(typename Traits::EvalData workset)
     int numDim = this->valTensor.extent(2);
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->valTensor)(cell,node,eq/numDim,eq%numDim) = x_constView[nodeID(cell,node,this->offset + eq)];
+          (this->valTensor)(cell,node,eq/numDim,eq%numDim) = x_constView[this->dof_id(node_lid,eq)];
         if (workset.transientTerms && this->enableTransient) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+            (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim) = xdot_constView[this->dof_id(node_lid,eq)];
         }
         if (workset.accelerationTerms && this->enableAcceleration) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+            (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
   } else {
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->val[eq])(cell,node) = x_constView[nodeID(cell,node,this->offset + eq)];
+          this->val[eq](cell,node) = x_constView[this->dof_id(node_lid,eq)];
         if (workset.transientTerms && this->enableTransient) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->val_dot[eq])(cell,node) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+            this->val_dot[eq](cell,node) = xdot_constView[this->dof_id(node_lid,eq)];
         }
         if (workset.accelerationTerms && this->enableAcceleration) {
           for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->val_dotdot[eq])(cell,node) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+            this->val_dotdot[eq](cell,node) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
@@ -365,7 +390,7 @@ evaluateFields(typename Traits::EvalData workset)
 #endif
 
   // Get map for local data structures
-  nodeID = workset.wsElNodeEqID;
+  elNodeLID = workset.wsElNodeLID.dev();
 
   // Get vector view from a specific device
   x_constView = Albany::getDeviceData(x);
@@ -477,10 +502,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank2_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
-      typename PHAL::Ref<ScalarT>::type valref = (this->valTensor)(cell,node,eq/numDim,eq%numDim);
-      valref=FadType(valref.size(), x_constView(nodeID(cell,node,this->offset+eq)));
+      typename PHAL::Ref<ScalarT>::type valref = this->valTensor(cell,node,eq/numDim,eq%numDim);
+      valref=FadType(valref.size(), x_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =j_coeff;
     }
   }
@@ -491,10 +517,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank2_Transient_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
-      typename PHAL::Ref<ScalarT>::type valref = (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim);
-      valref =FadType(valref.size(), xdot_constView(nodeID(cell,node,this->offset+eq)));
+      typename PHAL::Ref<ScalarT>::type valref = this->valTensor_dot(cell,node,eq/numDim,eq%numDim);
+      valref =FadType(valref.size(), xdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =m_coeff;
     }
   }
@@ -505,10 +532,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank2_Acceleration_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim);
-      valref=FadType(valref.size(), xdotdot_constView(nodeID(cell,node,this->offset+eq)));
+      valref=FadType(valref.size(), xdotdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =n_coeff;
     }
   }
@@ -519,10 +547,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank1_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; node++){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = (this->valVec)(cell,node,eq);
-      valref =FadType(valref.size(), x_constView(nodeID(cell,node,this->offset+eq)));
+      valref =FadType(valref.size(), x_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =j_coeff;
     }
   }
@@ -533,10 +562,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank1_Transient_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = (this->valVec_dot)(cell,node,eq);
-      valref =FadType(valref.size(), xdot_constView(nodeID(cell,node,this->offset+eq)));
+      valref =FadType(valref.size(), xdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =m_coeff;
     }
   }
@@ -547,10 +577,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank1_Acceleration_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = (this->valVec_dotdot)(cell,node,eq);
-      valref =FadType(valref.size(), xdotdot_constView(nodeID(cell,node,this->offset+eq)));
+      valref =FadType(valref.size(), xdotdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =n_coeff;
     }
   }
@@ -561,10 +592,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank0_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = d_val[eq](cell,node);
-      valref =FadType(valref.size(), x_constView(nodeID(cell,node,this->offset+eq)));
+      valref =FadType(valref.size(), x_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =j_coeff;
     }
   }
@@ -575,10 +607,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank0_Transient_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = d_val_dot[eq](cell,node);
-      valref =FadType(valref.size(), xdot_constView(nodeID(cell,node,this->offset+eq)));
+      valref =FadType(valref.size(), xdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) =m_coeff;
     }
   }
@@ -589,10 +622,11 @@ KOKKOS_INLINE_FUNCTION
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 operator() (const PHAL_GatherJacRank0_Acceleration_Tag&, const int& cell) const{
   for (size_t node = 0; node < this->numNodes; ++node){
+    const LO node_lid = elNodeLID(cell,node);
     int firstunk = neq * node + this->offset;
     for (int eq = 0; eq < numFields; eq++){
       typename PHAL::Ref<ScalarT>::type valref = d_val_dotdot[eq](cell,node);
-      valref = FadType(valref.size(), xdotdot_constView(nodeID(cell,node,this->offset+eq)));
+      valref = FadType(valref.size(), xdotdot_constView(this->dof_id(node_lid,eq)));
       valref.fastAccessDx(firstunk + eq) = n_coeff;
     }
   }
@@ -609,8 +643,9 @@ evaluateFields(typename Traits::EvalData workset)
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
 
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
 #ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-  auto nodeID = workset.wsElNodeEqID;
+  auto h_elNodeLID = workset.wsElNodeLID.host();
   Teuchos::ArrayRCP<const ST> x_constView, xdot_constView, xdotdot_constView;
   x_constView = Albany::getLocalData(x);
   if(!xdot.is_null()) {
@@ -623,17 +658,17 @@ evaluateFields(typename Traits::EvalData workset)
   int numDim = 0;
   if (this->tensorRank==2) numDim = this->valTensor.extent(2); // only needed for tensor fields
 
+  const int neq = this->sol_dof_mgr.numComponents();
   for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
-    const int neq = nodeID.extent(2);
-
     for (std::size_t node = 0; node < this->numNodes; ++node) {
+      const auto node_lid = h_elNodeLID(cell,node);
       int firstunk = neq * node + this->offset;
       for (std::size_t eq = 0; eq < numFields; eq++) {
         typename PHAL::Ref<ScalarT>::type
           valref = (this->tensorRank == 0 ? this->val[eq](cell,node) :
                     this->tensorRank == 1 ? this->valVec(cell,node,eq) :
                     this->valTensor(cell,node, eq/numDim, eq%numDim));
-        valref = FadType(valref.size(), x_constView[nodeID(cell,node,this->offset + eq)]);
+        valref = FadType(valref.size(), x_constView[this->dof_id(node_lid,eq)];
         valref.fastAccessDx(firstunk + eq) = workset.j_coeff;
       }
       if (workset.transientTerms && this->enableTransient) {
@@ -642,7 +677,7 @@ evaluateFields(typename Traits::EvalData workset)
           valref = (this->tensorRank == 0 ? this->val_dot[eq](cell,node) :
                     this->tensorRank == 1 ? this->valVec_dot(cell,node,eq) :
                     this->valTensor_dot(cell,node, eq/numDim, eq%numDim));
-        valref = FadType(valref.size(), xdot_constView[nodeID(cell,node,this->offset + eq)]);
+        valref = FadType(valref.size(), xdot_constView[this->dof_id(node_lid,eq)];
         valref.fastAccessDx(firstunk + eq) = workset.m_coeff;
         }
       }
@@ -652,7 +687,7 @@ evaluateFields(typename Traits::EvalData workset)
           valref = (this->tensorRank == 0 ? this->val_dotdot[eq](cell,node) :
                     this->tensorRank == 1 ? this->valVec_dotdot(cell,node,eq) :
                     this->valTensor_dotdot(cell,node, eq/numDim, eq%numDim));
-        valref = FadType(valref.size(), xdotdot_constView[nodeID(cell,node,this->offset + eq)]);
+        valref = FadType(valref.size(), xdotdot_constView[this->dof_id(node_lid,eq)];
         valref.fastAccessDx(firstunk + eq) = workset.n_coeff;
         }
       }
@@ -665,10 +700,11 @@ evaluateFields(typename Traits::EvalData workset)
 #endif
 
   // Get map for local data structures
-  nodeID = workset.wsElNodeEqID;
+  elNodeLID = workset.wsElNodeLID.dev();
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
 
   // Get dimensions and coefficients
-  neq = nodeID.extent(2);
+  neq = this->sol_dof_mgr.numComponents();
   j_coeff=workset.j_coeff;
   m_coeff=workset.m_coeff;
   n_coeff=workset.n_coeff;
@@ -784,8 +820,6 @@ template<typename Traits>
 void GatherSolution<PHAL::AlbanyTraits::Tangent, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-  auto nodeID = workset.wsElNodeEqID;
-
   const auto& x       = workset.x;
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
@@ -799,6 +833,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto& Vx_data       = Albany::getLocalData(Vx);
   const auto& Vxdot_data    = Albany::getLocalData(Vxdot);
   const auto& Vxdotdot_data = Albany::getLocalData(Vxdotdot);
+  auto h_elNodeLID = workset.wsElNodeLID.host();
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
 
   Teuchos::RCP<ParamVec> params = workset.params;
   //int num_cols_tot = workset.param_offset + workset.num_cols_p;
@@ -810,36 +846,38 @@ evaluateFields(typename Traits::EvalData workset)
 
   for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
     for (std::size_t node = 0; node < this->numNodes; ++node) {
+      const auto node_lid = h_elNodeLID(cell,node);
       for (std::size_t eq = 0; eq < numFields; eq++) {
         typename PHAL::Ref<ScalarT>::type
           valref = ((this->tensorRank == 2) ? (this->valTensor)(cell,node,eq/numDim,eq%numDim) :
                     (this->tensorRank == 1) ? (this->valVec)(cell,node,eq) :
                     (this->val[eq])(cell,node));
         if (Vx != Teuchos::null && workset.j_coeff != 0.0) {
-          valref = TanFadType(valref.size(), x_constView[nodeID(cell,node,this->offset + eq)]);
+          valref = TanFadType(valref.size(), x_constView[this->dof_id(node_lid,eq)]);
           for (int k=0; k<workset.num_cols_x; k++)
             valref.fastAccessDx(k) =
-              workset.j_coeff*Vx_data[k][nodeID(cell,node,this->offset + eq)];
+              workset.j_coeff*Vx_data[k][this->dof_id(node_lid,eq)];
         } else {
-          valref = TanFadType(x_constView[nodeID(cell,node,this->offset + eq)]);
+          valref = TanFadType(x_constView[this->dof_id(node_lid,eq)]);
         }
       }
-   }
+    }
 
 
-   if (workset.transientTerms && this->enableTransient) {
-    Teuchos::ArrayRCP<const ST> xdot_constView = Albany::getLocalData(xdot);
-    for (std::size_t node = 0; node < this->numNodes; ++node) {
+    if (workset.transientTerms && this->enableTransient) {
+      Teuchos::ArrayRCP<const ST> xdot_constView = Albany::getLocalData(xdot);
+      for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++) {
         typename PHAL::Ref<ScalarT>::type
           valref = ((this->tensorRank == 2) ? (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim) :
                     (this->tensorRank == 1) ? (this->valVec_dot)(cell,node,eq) :
                     (this->val_dot[eq])(cell,node));
-          valref = TanFadType(valref.size(), xdot_constView[nodeID(cell,node,this->offset + eq)]);
+          valref = TanFadType(valref.size(), xdot_constView[this->dof_id(node_lid,eq)]);
           if (Vxdot != Teuchos::null && workset.m_coeff != 0.0) {
             for (int k=0; k<workset.num_cols_x; k++)
               valref.fastAccessDx(k) =
-                workset.m_coeff*Vxdot_data[k][nodeID(cell,node,this->offset + eq)];
+                workset.m_coeff*Vxdot_data[k][this->dof_id(node_lid,eq)];
           }
         }
       }
@@ -848,17 +886,18 @@ evaluateFields(typename Traits::EvalData workset)
    if (workset.accelerationTerms && this->enableAcceleration) {
     Teuchos::ArrayRCP<const ST> xdotdot_constView = Albany::getLocalData(xdotdot);
     for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++) {
         typename PHAL::Ref<ScalarT>::type
           valref = ((this->tensorRank == 2) ? (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim) :
                     (this->tensorRank == 1) ? (this->valVec_dotdot)(cell,node,eq) :
                     (this->val_dotdot[eq])(cell,node));
 
-          valref = TanFadType(valref.size(), xdotdot_constView[nodeID(cell,node,this->offset + eq)]);
+          valref = TanFadType(valref.size(), xdotdot_constView[this->dof_id(node_lid,eq)]);
           if (Vxdotdot != Teuchos::null && workset.n_coeff != 0.0) {
             for (int k=0; k<workset.num_cols_x; k++)
               valref.fastAccessDx(k) =
-                workset.n_coeff*Vxdotdot_data[k][nodeID(cell,node,this->offset + eq)];
+                workset.n_coeff*Vxdotdot_data[k][this->dof_id(node_lid,eq)];
           }
         }
       }
@@ -894,7 +933,6 @@ template<typename Traits>
 void GatherSolution<PHAL::AlbanyTraits::DistParamDeriv, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-  auto nodeID = workset.wsElNodeEqID;
   const auto& x       = workset.x;
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
@@ -902,26 +940,32 @@ evaluateFields(typename Traits::EvalData workset)
   //get const (read-only) view of x and xdot
   const auto& x_constView = Albany::getLocalData(x);
 
+  auto h_elNodeLID = workset.wsElNodeLID.host();
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
+
   if (this->tensorRank == 1) {
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->valVec)(cell,node,eq) = x_constView[nodeID(cell,node,this->offset + eq)];
+          this->valVec(cell,node,eq) = x_constView[this->dof_id(node_lid,eq)];
       }
 
     if (workset.transientTerms && this->enableTransient) {
       Teuchos::ArrayRCP<const ST> xdot_constView = Albany::getLocalData(xdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valVec_dot)(cell,node,eq) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->valVec_dot(cell,node,eq) = xdot_constView[this->dof_id(node_lid,eq)];
       }
     }
 
     if (workset.accelerationTerms && this->enableAcceleration) {
       Teuchos::ArrayRCP<const ST> xdotdot_constView = Albany::getLocalData(xdotdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valVec_dotdot)(cell,node,eq) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->valVec_dotdot(cell,node,eq) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
@@ -929,45 +973,51 @@ evaluateFields(typename Traits::EvalData workset)
     int numDim = this->valTensor.extent(2);
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->valTensor)(cell,node,eq/numDim,eq%numDim) = x_constView[nodeID(cell,node,this->offset + eq)];
+          this->valTensor(cell,node,eq/numDim,eq%numDim) = x_constView[this->dof_id(node_lid,eq)];
       }
 
     if (workset.transientTerms && this->enableTransient) {
       Teuchos::ArrayRCP<const ST> xdot_constView = Albany::getLocalData(xdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valTensor_dot)(cell,node,eq/numDim,eq%numDim) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->valTensor_dot(cell,node,eq/numDim,eq%numDim) = xdot_constView[this->dof_id(node_lid,eq)];
       }
     }
 
     if (workset.accelerationTerms && this->enableAcceleration) {
       Teuchos::ArrayRCP<const ST> xdotdot_constView = Albany::getLocalData(xdotdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->valTensor_dotdot)(cell,node,eq/numDim,eq%numDim) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->valTensor_dotdot(cell,node,eq/numDim,eq%numDim) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
   } else {
     for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
       for (std::size_t node = 0; node < this->numNodes; ++node) {
+        const auto node_lid = h_elNodeLID(cell,node);
         for (std::size_t eq = 0; eq < numFields; eq++)
-          (this->val[eq])(cell,node) = x_constView[nodeID(cell,node,this->offset + eq)];
+          this->val[eq](cell,node) = x_constView[this->dof_id(node_lid,eq)];
       }
     if (workset.transientTerms && this->enableTransient) {
       Teuchos::ArrayRCP<const ST> xdot_constView = Albany::getLocalData(xdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->val_dot[eq])(cell,node) = xdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->val_dot[eq](cell,node) = xdot_constView[this->dof_id(node_lid,eq)];
       }
     }
 
     if (workset.accelerationTerms && this->enableAcceleration) {
       Teuchos::ArrayRCP<const ST> xdotdot_constView = Albany::getLocalData(xdotdot);
       for (std::size_t node = 0; node < this->numNodes; ++node) {
-          for (std::size_t eq = 0; eq < numFields; eq++)
-            (this->val_dotdot[eq])(cell,node) = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+        const auto node_lid = h_elNodeLID(cell,node);
+        for (std::size_t eq = 0; eq < numFields; eq++)
+          this->val_dotdot[eq](cell,node) = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }
@@ -1006,7 +1056,6 @@ evaluateFields(typename Traits::EvalData workset)
 
   Teuchos::RCP<const Thyra_MultiVector> direction_x = workset.hessianWorkset.direction_x;
 
-  auto nodeID = workset.wsElNodeEqID;
   Teuchos::ArrayRCP<const ST> x_constView, xdot_constView, xdotdot_constView, direction_x_constView;
   bool g_xx_is_active = !workset.hessianWorkset.hess_vec_prod_g_xx.is_null();
   bool g_xp_is_active = !workset.hessianWorkset.hess_vec_prod_g_xp.is_null();
@@ -1046,17 +1095,20 @@ evaluateFields(typename Traits::EvalData workset)
   int numDim = 0;
   if (this->tensorRank==2) numDim = this->valTensor.extent(2); // only needed for tensor fields
 
-  for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
-    const int neq = nodeID.extent(2);
+  this->sol_dof_mgr = workset.disc->getSolutionOverlapDOFManager();
+  auto h_elNodeLID = workset.wsElNodeLID.host();
+  const int neq = this->sol_dof_mgr.numComponents();
 
+  for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
     for (std::size_t node = 0; node < this->numNodes; ++node) {
+      const auto node_lid = h_elNodeLID(cell,node);
       int firstunk = neq * node + this->offset;
       for (std::size_t eq = 0; eq < numFields; eq++) {
         typename PHAL::Ref<ScalarT>::type
           valref = (this->tensorRank == 0 ? this->val[eq](cell,node) :
                     this->tensorRank == 1 ? this->valVec(cell,node,eq) :
                     this->valTensor(cell,node, eq/numDim, eq%numDim));
-        RealType xvec_val = x_constView[nodeID(cell,node,this->offset + eq)];
+        RealType xvec_val = x_constView[this->dof_id(node_lid,eq)];
 
         valref = HessianVecFad(valref.size(), xvec_val);
         // If we differentiate w.r.t. the solution, we have to set the first
@@ -1066,20 +1118,21 @@ evaluateFields(typename Traits::EvalData workset)
         // If we differentiate w.r.t. the solution direction, we have to set
         // the second derivative to the related direction value
         if (is_x_direction_active)
-          valref.val().fastAccessDx(0) = direction_x_constView[nodeID(cell,node,this->offset + eq)];
+          valref.val().fastAccessDx(0) = direction_x_constView[this->dof_id(node_lid,eq)];
       }
     }
   }
 
   for (std::size_t cell=0; cell < workset.numCells; ++cell ) {
     for (std::size_t node = 0; node < this->numNodes; ++node) {
+      const auto node_lid = h_elNodeLID(cell,node);
       if (workset.transientTerms && this->enableTransient) {
         for (std::size_t eq = 0; eq < numFields; eq++) {
           typename PHAL::Ref<ScalarT>::type
             valref = (this->tensorRank == 0 ? this->val_dot[eq](cell,node) :
                       this->tensorRank == 1 ? this->valVec_dot(cell,node,eq) :
                       this->valTensor_dot(cell,node, eq/numDim, eq%numDim));
-          valref = xdot_constView[nodeID(cell,node,this->offset + eq)];
+          valref = xdot_constView[this->dof_id(node_lid,eq)];
         }
       }
       if (workset.accelerationTerms && this->enableAcceleration) {
@@ -1088,7 +1141,7 @@ evaluateFields(typename Traits::EvalData workset)
             valref = (this->tensorRank == 0 ? this->val_dotdot[eq](cell,node) :
                       this->tensorRank == 1 ? this->valVec_dotdot(cell,node,eq) :
                       this->valTensor_dotdot(cell,node, eq/numDim, eq%numDim));
-          valref = xdotdot_constView[nodeID(cell,node,this->offset + eq)];
+          valref = xdotdot_constView[this->dof_id(node_lid,eq)];
         }
       }
     }

--- a/src/evaluators/pde/PHAL_HeatEqResid_Def.hpp
+++ b/src/evaluators/pde/PHAL_HeatEqResid_Def.hpp
@@ -117,10 +117,6 @@ template<typename EvalT, typename Traits>
 void HeatEqResid<EvalT, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-
-//// workset.print(std::cout);
-
-
   typedef Intrepid2::FunctionSpaceTools<PHX::Device> FST;
 
   FST::scalarMultiplyDataData (flux, ThermalCond.get_view(), TGrad.get_view());

--- a/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
+++ b/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
@@ -223,8 +223,7 @@ template<typename EvalT>
 void FieldManagerScalarResponseFunction::
 evaluate(PHAL::Workset& workset)
 {
-  const WorksetArray<int>::type&
-    wsPhysIndex = application->getDiscretization()->getWsPhysIndex();
+  const auto& wsPhysIndex = application->getDiscretization()->getWsPhysIndex();
   rfm->preEvaluate<EvalT>(workset);
   for (int ws = 0, numWorksets = application->getNumWorksets();
        ws < numWorksets; ws++) {

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -1,6 +1,9 @@
 #ifndef ALBANY_HESSIAN_HPP
 #define ALBANY_HESSIAN_HPP
 
+#include "Albany_DiscretizationUtils.hpp"
+#include "Albany_ThyraTypes.hpp"
+
 namespace Albany
 {
     /**
@@ -29,7 +32,7 @@ namespace Albany
     Teuchos::RCP<Thyra_LinearOp> createSparseHessianLinearOp(
         Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
         Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
-        const std::vector<IDArray> wsElDofs);
+        const Connectivity<LO>& ws_nodes);
 
     /**
      * \brief getHessianBlockIDs function

--- a/src/utility/Albany_ThyraUtils.cpp
+++ b/src/utility/Albany_ThyraUtils.cpp
@@ -264,7 +264,7 @@ createVectorSpace (const Teuchos::RCP<const Teuchos_Comm>& comm,
 
 Teuchos::RCP<const Thyra_VectorSpace>
 createVectorSpace (const Teuchos::RCP<const Thyra_VectorSpace>& scalar_vs,
-                   const int numComponents, const DiscType discType)
+                   const int numComponents, const bool interleaved)
 {
   if (numComponents==1) {
     return scalar_vs;
@@ -275,7 +275,7 @@ createVectorSpace (const Teuchos::RCP<const Thyra_VectorSpace>& scalar_vs,
   const GO maxGlobalGID = scalar_indexer->getMaxGlobalGID();
   const int numMyGids = scalar_indexer->getNumLocalElements();
   NodalDOFManager mgr;
-  mgr.setup(numComponents,numMyGids,maxGlobalGID,discType);
+  mgr.setup(numComponents,numMyGids,maxGlobalGID,interleaved);
 
   Teuchos::Array<GO> indices(numMyGids*numComponents);
   for (int i=0; i<numMyGids; ++i) {

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -10,9 +10,6 @@
 // Get Kokkos types (for the 1d device view)
 #include "Albany_KokkosTypes.hpp"
 
-// Get DiscType
-#include "Albany_DiscretizationUtils.hpp"
-
 namespace Albany
 {
 
@@ -50,7 +47,7 @@ createVectorSpace (const Teuchos::RCP<const Teuchos_Comm>& comm,
 // Create a vector VectorSpace from a scalar one.
 Teuchos::RCP<const Thyra_VectorSpace>
 createVectorSpace (const Teuchos::RCP<const Thyra_VectorSpace>& scalar_vs,
-                   const int numComponents, const DiscType discType);
+                   const int numComponents, const bool interleaved);
 
 // Intersects vectors spaces
 Teuchos::RCP<const Thyra_VectorSpace>

--- a/src/utility/Albany_UnivariateDistribution.hpp
+++ b/src/utility/Albany_UnivariateDistribution.hpp
@@ -7,6 +7,8 @@
 #ifndef ALBANY_UNIVARIATE_DISTRIBUTION_HPP
 #define ALBANY_UNIVARIATE_DISTRIBUTION_HPP
 
+#include <Teuchos_ParameterList.hpp>
+
 #include <boost/math/special_functions/erf.hpp>
 
 namespace Albany
@@ -19,7 +21,7 @@ namespace Albany
       {
         // Nothing to be done here
       }
-      UnivariatDistribution(const Teuchos::ParameterList &distributionParams)
+      UnivariatDistribution(const Teuchos::ParameterList &/* distributionParams */)
       {
         // Nothing to be done here
       }
@@ -83,15 +85,15 @@ namespace Albany
         return 2*sqrt(2)*M_PI * sigma * exp(2*pow(boost::math::erf_inv(-1+2*x),2))*boost::math::erf_inv(2*x-1);
       }
 
-      double ppf(const double x, const double v) {
+      double ppf(const double /* x */, const double v) {
         return mu + sigma * v;
       }
 
-      double ppf_dx(const double x, const double v) {
+      double ppf_dx(const double /* x */, const double v) {
         return sqrt(2*M_PI) * sigma * exp(pow(v/sqrt(2),2));
       }
 
-      double ppf_dx_dx(const double x, const double v) {
+      double ppf_dx_dx(const double /* x */, const double v) {
         return 2*sqrt(2)*M_PI * sigma * exp(2*pow(v/sqrt(2),2))*v/sqrt(2);
       }
 
@@ -167,15 +169,15 @@ namespace Albany
         return sqrt(2)*M_PI*sigma*(2*boost::math::erf_inv(2*x-1)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*boost::math::erf_inv(2*x-1)+2*pow(boost::math::erf_inv(2*x-1),2)+mu);
       }
 
-      double ppf(const double x, const double v) {
+      double ppf(const double /* x */, const double v) {
         return exp(mu + sqrt(2) * sigma * v/sqrt(2));
       }
 
-      double ppf_dx(const double x, const double v) {
+      double ppf_dx(const double /* x */, const double v) {
         return sqrt(2*M_PI)*sigma*exp(sqrt(2)*sigma*v/sqrt(2)+pow(v/sqrt(2),2)+mu);
       }
 
-      double ppf_dx_dx(const double x, const double v) {
+      double ppf_dx_dx(const double /* x */, const double v) {
         return sqrt(2)*M_PI*sigma*(2*v/sqrt(2)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*v/sqrt(2)+2*pow(v/sqrt(2),2)+mu);
       }
 
@@ -241,11 +243,11 @@ namespace Albany
         return (x-a)/(b-a);
       }
 
-      double cdf_dx(const double x) {
+      double cdf_dx(const double /* x */) {
         return 1./(b-a);
       }
 
-      double cdf_dx_dx(const double x) {
+      double cdf_dx_dx(const double /* x */) {
         return 0;
       }
       
@@ -253,11 +255,11 @@ namespace Albany
         return (b-a) * x + a;
       }
 
-      double ppf_dx(const double x) {
+      double ppf_dx(const double /* x */) {
         return (b-a);
       }
 
-      double ppf_dx_dx(const double x) {
+      double ppf_dx_dx(const double /* x */) {
         return 0;
       }
 


### PR DESCRIPTION
This PR aims at simplifying how we store gids for different DOFs. Right now, we store arrays of the form `(numWs, numCells, numNodes, numDims)`, where `numDIms` is the number of scalar quantities in this particular DOF. Once this PR is completed, we will instead store a single `(numWs, numCells, numNodes)` array in the discretization (or maybe the mesh struct), use this array to retrieve the node id, and then use the NodalDOFManager to retrieve the dof id.

This will have a few benefits:

- reduce the amount of data stored for all DOFs (the `DOFsStruct` need not contain any ID array anymore)
- lay the ground for an easier change to block discretizations, where different blocks can share the same connectivity info.

Note: this is heavily relying on how we label our dofs (although this way of numbering dofs is the most natural). Another thing to keep in mind for when blocks will be implemented, and different FE used, is that the concept of 'Node' is a bit overloaded: sometimes it refers to the FE-Nodes. which need not be on Nodes, or even all on the same entity (e.g., P2 have some edge and some "node" FE nodes); some other times it refers to the 'point' node of the mesh. I suspect we'll need to clear this up before trying to add support for non-P1 FE spaces.