### PR TITLE
[WIP] Make panzer::DOFManager the only way we access dofs on elements

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -939,7 +939,7 @@ namespace {
 inline Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>&
 deref_nfm(
     Teuchos::ArrayRCP<Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>>& nfm,
-    const WorksetArray<int>::type& wsPhysIndex,
+    const WorksetArray<int>&       wsPhysIndex,
     int                            ws)
 {
   return nfm.size() == 1 ?  // Currently, all problems seem to have one nfm ...

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -41,13 +41,6 @@ class Application
 {
 public:
 
-  enum SolutionMethod
-  {
-    Steady,
-    Transient,
-    Continuation
-  };
-
   enum SolutionStatus
   {
     Converged,
@@ -142,7 +135,7 @@ public:
   getDistributedParameterLibrary() const;
 
   //! Get solution method
-  SolutionMethod
+  SolutionMethodType
   getSolutionMethod() const
   {
     return solMethod;
@@ -1228,7 +1221,7 @@ void
   std::string                          precType;
 
   //! Type of solution method
-  SolutionMethod solMethod;
+  SolutionMethodType solMethod;
 
   //! Integer specifying whether user wants to write Jacobian to MatrixMarket
   //! file

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -1004,10 +1004,10 @@ void
       Teuchos::Ptr<const Thyra_MultiVector> dxdp = Teuchos::null);
 
   //! Access to number of worksets - needed for working with StateManager
-  int
+  int 
   getNumWorksets()
   {
-    return disc->getWsElNodeEqID().size();
+    return disc->getNumWorksets ();
   }
 
   //! Const access to problem parameter list
@@ -1307,15 +1307,17 @@ void
 Application::loadWorksetBucketInfo(PHAL::Workset& workset, const int& ws,
     const std::string& evalName)
 {
-  auto const& wsElNodeEqID       = disc->getWsElNodeEqID();
-  auto const& wsElNodeID         = disc->getWsElNodeID();
+  const auto ALL = Kokkos::ALL();
+  // auto const& wsElNodeEqID       = disc->getWsElNodeEqID();
+  // auto const& wsElNodeID         = disc->getWsElNodeID();
   auto const& coords             = disc->getCoords();
   auto const& wsEBNames          = disc->getWsEBNames();
 
-  workset.numCells             = wsElNodeEqID[ws].extent(0);
-  workset.wsElNodeEqID         = wsElNodeEqID[ws];
-  workset.wsElNodeID           = wsElNodeID[ws];
-  workset.wsCoords             = coords[ws];
+  workset.numCells             = disc->getWorksetSizes()[ws];
+  // workset.numCells             = wsElNodeEqID[ws].extent(0);
+  // workset.wsElNodeEqID         = wsElNodeEqID[ws];
+  // workset.wsElNodeID           = wsElNodeID[ws];
+  workset.wsCoords             = Kokkos::subview(coords.host(),ws,ALL,ALL,ALL);
   workset.EBName               = wsEBNames[ws];
   workset.wsIndex              = ws;
 

--- a/src/Albany_DummyParameterAccessor.hpp
+++ b/src/Albany_DummyParameterAccessor.hpp
@@ -29,7 +29,7 @@ class DummyParameterAccessor :
 
    public:
      DummyParameterAccessor() { dummy = 0.0;};
-     typename EvalT::ScalarT& getValue(const std::string &name)
+     typename EvalT::ScalarT& getValue(const std::string &/* name */)
      { return dummy;};
    private:
      typename EvalT::ScalarT dummy;

--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -22,11 +22,20 @@
 // Phalanx determines the Kokkos node we use for Tpetra types
 #include "Phalanx_KokkosDeviceTypes.hpp"
 
+// To get assert macros
+#include "Albany_Macros.hpp"
+
 // The Kokkos node is determined from the Phalanx Device
 typedef Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>  KokkosNode;
 
 namespace Albany
 {
+
+using DeviceMemSpace = PHX::Device::memory_space;
+using HostMemSpace   = Kokkos::HostSpace;
+
+template<typename DT, typename MemSpace = DeviceMemSpace>
+using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,MemSpace>;
 // NOTE: Tpetra may use a different LO type (Albany uses int32, while tpetra uses int). When extracting local views/matrices,
 //       be careful about this. At worst, you may need to extract pointers and reinterpret_cast them.
 
@@ -41,6 +50,60 @@ using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, KokkosN
 
 template<typename Scalar>
 using DeviceLocalMatrix = KokkosSparse::CrsMatrix<Scalar, LO, KokkosNode::device_type, void, DeviceLocalGraph::size_type>;
+
+// A tiny tiny version of a dual view.
+// No correctness check except non-null dev view in ctor.
+template<typename DT>
+struct DualView {
+  using dev_t  = ViewLR<DT,DeviceMemSpace>;
+  using host_t = typename dev_t::HostMirror;
+
+  DualView () = default;
+
+  // Construct DualView on the fly.
+  DualView (const std::string& name,
+      const size_t n0,
+      const size_t n1 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n2 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n3 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n4 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n5 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n6 = KOKKOS_IMPL_CTOR_DEFAULT_ARG,
+      const size_t n7 = KOKKOS_IMPL_CTOR_DEFAULT_ARG)
+   : d_view(name,n0,n1,n2,n3,n4,n5,n6,n7)
+  {
+    h_view = Kokkos::create_mirror_view (d_view);
+  }
+  DualView (dev_t d_view_) : d_view(d_view_) {
+    ALBANY_ALWAYS_ASSERT (d_view.data!=nullptr);
+    h_view = Kokkos::create_mirror_view (d_view);
+  }
+  DualView (const DualView&) = default;
+  DualView& operator= (const DualView&) = default;
+
+  DualView& operator= (const dev_t d_view_) {
+    d_view = d_view_;
+    h_view = Kokkos::create_mirror_view (d_view);
+  }
+
+  const dev_t&  dev  () const { return d_view; }
+  const host_t& host () const { return h_view; }
+
+  void sync_to_host () {
+    Kokkos::deep_copy(h_view,d_view);
+  }
+  void sync_to_dev  () {
+    Kokkos::deep_copy(d_view,h_view);
+  }
+
+  int size () const { return d_view().size(); }
+
+private:
+
+  dev_t   d_view;
+  host_t  h_view;
+};
+
 
 } // namespace Albany
 

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -583,10 +583,15 @@ ModelEvaluator::create_hess_g_pp( int j, int l1, int l2 ) const
 
     Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOverlappedVectorSpace();
     Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOwnedVectorSpace();
-    std::vector<IDArray> vElDofs =
-      distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs();
 
-    return Albany::createSparseHessianLinearOp(p_owned_vs, p_overlapped_vs, vElDofs);
+    const auto& param_name = dist_param_names[l1 - num_param_vecs];
+    auto param_dof_mgr = distParamLib->get(param_name)->dof_mgr();
+    return createSparseHessianLinearOp(distParamLib->get(param_name),
+                                       app->getDisc());
+    // std::vector<IDArray> vElDofs =
+    //   distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs();
+
+    // return Albany::createSparseHessianLinearOp(p_owned_vs, p_overlapped_vs, vElDofs);
   }
 }
 

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -63,7 +63,7 @@ enableMueLu(
     Stratimikos::DefaultLinearSolverBuilder&    linearSolverBuilder)
 {
 #ifdef ALBANY_MUELU
-  Stratimikos::enableMueLu<LO, Tpetra_GO, KokkosNode>(linearSolverBuilder);
+  Stratimikos::enableMueLu<ST, LO, Tpetra_GO, KokkosNode>(linearSolverBuilder);
 #endif
 }
 

--- a/src/Albany_StatelessObserverImpl.cpp
+++ b/src/Albany_StatelessObserverImpl.cpp
@@ -24,10 +24,9 @@ StatelessObserverImpl (const Teuchos::RCP<Application> &app)
 RealType StatelessObserverImpl::
 getTimeParamValueOrDefault (RealType defaultValue) const {
   const std::string label("Time");
-  //IKT, NOTE: solMethod == 1 corresponds to Transient
   bool const
     use_time_param = (app_->getParamLib()->isParameter(label) == true) &&
-      (app_->getSolutionMethod() != 1);
+      (app_->getSolutionMethod() != Transient);
 
   double const
     this_time = use_time_param == true ?

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -34,19 +34,18 @@
 #error "Albany needs Tpetra to enable double as a Scalar type"
 #endif
 
-typedef int Tpetra_LO;
-#if defined( HAVE_TPETRA_INST_INT_LONG_LONG )
-typedef long long Tpetra_GO;
-#elif defined( HAVE_TPETRA_INST_INT_LONG )
-static_assert(sizeof(long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is long but thats not 64 bit");
-typedef long Tpetra_GO;
-#elif defined( HAVE_TPETRA_INST_INT_UNSIGNED_LONG )
-static_assert(sizeof(unsigned long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is unsigned long but thats not 64 bit");
-typedef unsigned long Tpetra_GO;
+using Tpetra_LO = int;
+// NOTE: this ifdef logic allows Tpetra_GO to be the *exact same type*
+//       as panzer::GlobalOrdinal. In turn, panzer is keeping the first
+//       branch of the if only for backward compatibility with some
+//       deprecated code. As soon as that code in PanzerCore_config.hpp
+//       is removed, we can keep the one using DefaulTypes.
+#if defined(HAVE_TPETRA_INST_INT_LONG_LONG)
+using Tpetra_GO = long long int;  // NOTE: long long is *guaranteed* to be >=64 bits
 #else
-#error "Albany needs a 64-bit GlobalOrdinal enabled in Tpetra"
+using Tpetra_GO = Tpetra::Details::DefaultTypes::global_ordinal_type;
+static_assert(sizeof(Tpetra_GO) == sizeof(GO),
+    "Tpetra's default global ordinal is not 64 bit");
 #endif
 
 typedef Tpetra::Map<Tpetra_LO, Tpetra_GO, KokkosNode>                 Tpetra_Map;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -144,7 +144,7 @@ list (APPEND SOURCES
   utility/Albany_Hessian.cpp
   utility/Albany_StringUtils.cpp
   utility/Albany_ThyraCrsMatrixFactory.cpp
-  utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
+  # utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
   utility/Albany_ThyraUtils.cpp
   utility/Albany_TpetraThyraUtils.cpp
   utility/Albany_UnivariateDistribution.hpp
@@ -168,7 +168,7 @@ list (APPEND HEADERS
   utility/Albany_GlobalLocalIndexerTpetra.hpp
   utility/Albany_Hessian.hpp
   utility/Albany_ThyraCrsMatrixFactory.hpp
-  utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
+  # utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
   utility/Albany_ThyraUtils.hpp
   utility/Albany_TpetraThyraUtils.hpp
   utility/VariableMonitor.hpp
@@ -312,13 +312,13 @@ list (APPEND HEADERS
 list(APPEND SOURCES
   disc/stk/Albany_AsciiSTKMesh2D.cpp
   disc/stk/Albany_AsciiSTKMeshStruct.cpp
-  disc/stk/Albany_BlockedSTKDiscretization.cpp
+  # disc/stk/Albany_BlockedSTKDiscretization.cpp
   disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
   disc/stk/Albany_GenericSTKFieldContainer.cpp
   disc/stk/Albany_GenericSTKMeshStruct.cpp
   disc/stk/Albany_GmshSTKMeshStruct.cpp
   disc/stk/Albany_IossSTKMeshStruct.cpp
-  disc/stk/Albany_MultiSTKFieldContainer.cpp
+  # disc/stk/Albany_MultiSTKFieldContainer.cpp
   disc/stk/Albany_OrdinarySTKFieldContainer.cpp
   disc/stk/Albany_SideSetSTKMeshStruct.cpp
   disc/stk/Albany_STKDiscretization.cpp
@@ -334,13 +334,13 @@ list (APPEND HEADERS
   disc/stk/Albany_AbstractSTKMeshStruct.hpp
   disc/stk/Albany_AsciiSTKMeshStruct.hpp
   disc/stk/Albany_AsciiSTKMesh2D.hpp
-  disc/stk/Albany_BlockedSTKDiscretization.hpp
+  # disc/stk/Albany_BlockedSTKDiscretization.hpp
   disc/stk/Albany_ExtrudedSTKMeshStruct.hpp
   disc/stk/Albany_GenericSTKMeshStruct.hpp
   disc/stk/Albany_GmshSTKMeshStruct.hpp
   disc/stk/Albany_GenericSTKFieldContainer.hpp
   disc/stk/Albany_IossSTKMeshStruct.hpp
-  disc/stk/Albany_MultiSTKFieldContainer.hpp
+  # disc/stk/Albany_MultiSTKFieldContainer.hpp
   disc/stk/Albany_NodalGraphUtils.hpp
   disc/stk/Albany_OrdinarySTKFieldContainer.hpp
   disc/stk/Albany_SideSetSTKMeshStruct.hpp

--- a/src/InitialCondition.hpp
+++ b/src/InitialCondition.hpp
@@ -7,21 +7,16 @@
 #ifndef INITIAL_CONDITION_HPP
 #define INITIAL_CONDITION_HPP
 
-#include "Albany_DataTypes.hpp"
-#include "Albany_DiscretizationUtils.hpp"
+#include "Albany_AbstractDiscretization.hpp"
 
-#include <string>
+#include "Teuchos_RCP.hpp"
 #include "Teuchos_ParameterList.hpp"
 
 namespace Albany {
 
 void InitialConditions (const Teuchos::RCP<Thyra_Vector>& soln,
-                        const Albany::Conn& wsElNodeEqID,
-                        const Teuchos::ArrayRCP<std::string>& wsEBNames,
-                        const Teuchos::ArrayRCP<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*> > > coords,
-                        const int neq, const int numDim,
-                        Teuchos::ParameterList& icParams,
-                        const bool gasRestartSolution = false);
+                        const Teuchos::RCP<Albany::AbstractDiscretization>& disc,
+                        Teuchos::ParameterList& icParams);
 
 } // namespace Albany
 

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -208,25 +208,6 @@ struct Workset
       typedef Teuchos::RCP<Teuchos::ValueTypeSerializer<int, T>> type;
     };
   };
-
-  void
-  print(std::ostream& os)
-  {
-    os << "Printing workset data:" << std::endl;
-    os << "\tEB name : " << EBName << std::endl;
-    os << "\tnumCells : " << numCells << std::endl;
-    os << "\twsElNodeEqID : " << std::endl;
-    for (unsigned int i = 0; i < wsElNodeEqID.extent(0); i++)
-      for (unsigned int j = 0; j < wsElNodeEqID.extent(1); j++)
-        for (unsigned int k = 0; k < wsElNodeEqID.extent(2); k++)
-          os << "\t\twsElNodeEqID(" << i << "," << j << "," << k
-             << ") = " << wsElNodeEqID(i, j, k) << std::endl;
-    os << "\twsCoords : " << std::endl;
-    for (int i = 0; i < wsCoords.size(); i++)
-      for (int j = 0; j < wsCoords[i].size(); j++)
-        os << "\t\tcoord0:" << wsCoords[i][j][0] << "][" << wsCoords[i][j][1]
-           << std::endl;
-  }
 };
 
 }  // namespace PHAL

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -135,13 +135,10 @@ struct Workset
   bool                                              transpose_dist_param_deriv;
   Teuchos::ArrayRCP<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double>>> local_Vp;
 
-  Albany::WorksetConn                           wsElNodeEqID;
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>      wsElNodeID;
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>> wsCoords;
-  std::string                                   EBName;
+  Albany::ViewLR<double***,Albany::HostMemSpace>    wsCoords;
+  std::string                                       EBName;
 
-  // Needed for Schwarz coupling and for dirichlet conditions based on dist
-  // parameters.
+  // The disc is crucial to access DOF numbering for all dofs
   Teuchos::RCP<Albany::AbstractDiscretization> disc;
 
   int spatial_dimension_{0};

--- a/src/SolutionManager.cpp
+++ b/src/SolutionManager.cpp
@@ -95,13 +95,6 @@ SolutionManager::SolutionManager(
 
   }
 
-
-  auto                           wsElNodeEqID = disc_->getWsElNodeEqID();
-  auto                           coords       = disc_->getCoords();
-  Teuchos::ArrayRCP<std::string> wsEBNames    = disc_->getWsEBNames();
-  const int                      numDim       = disc_->getNumDim();
-  const int                      neq          = disc_->getNumEq();
-
   Teuchos::RCP<Teuchos::ParameterList> pbParams =
       Teuchos::sublist(appParams_, "Problem", true);
 
@@ -114,13 +107,8 @@ SolutionManager::SolutionManager(
         Albany::CombineMode::INSERT);
     InitialConditions(
         overlapped_soln->col(0),
-        wsElNodeEqID,
-        wsEBNames,
-        coords,
-        neq,
-        numDim,
-        pbParams->sublist("Initial Condition"),
-        disc_->hasRestartSolution());
+        disc,
+        pbParams->sublist("Initial Condition"));
     cas_manager->combine(
         overlapped_soln->col(0),
         current_soln->col(0),
@@ -133,13 +121,8 @@ SolutionManager::SolutionManager(
           Albany::CombineMode::INSERT);
       InitialConditions(
           overlapped_soln->col(1),
-          wsElNodeEqID,
-          wsEBNames,
-          coords,
-          neq,
-          numDim,
-          pbParams->sublist("Initial Condition Dot"),
-          disc_->hasRestartSolution());
+          disc,
+          pbParams->sublist("Initial Condition Dot"));
       cas_manager->combine(
           overlapped_soln->col(1),
           current_soln->col(1),
@@ -153,13 +136,8 @@ SolutionManager::SolutionManager(
           Albany::CombineMode::INSERT);
       InitialConditions(
           overlapped_soln->col(2),
-          wsElNodeEqID,
-          wsEBNames,
-          coords,
-          neq,
-          numDim,
-          pbParams->sublist("Initial Condition DotDot"),
-          disc_->hasRestartSolution());
+          disc,
+          pbParams->sublist("Initial Condition DotDot"));
       cas_manager->combine(
           overlapped_soln->col(1),
           current_soln->col(1),

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -99,7 +99,7 @@ class AbstractDiscretization
   getWsElNodeEqID() const = 0;
 
   //! Get map from (Ws, El, Local Node) -> unkGID
-  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type&
+  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
   getWsElNodeID() const = 0;
 
   //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
@@ -140,8 +140,7 @@ class AbstractDiscretization
   getOverlapNodeGlobalLocalIndexer () const { return getOverlapGlobalLocalIndexer(nodes_dof_name()); }
 
   //! Retrieve coodinate ptr_field (ws, el, node)
-  virtual const WorksetArray<
-      Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type&
+  virtual const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>&
   getCoords() const = 0;
 
   //! Get coordinates (overlap map).
@@ -181,11 +180,11 @@ class AbstractDiscretization
   getNodalParameterSIS() const = 0;
 
   //! Retrieve Vector (length num worksets) of element block names
-  virtual const WorksetArray<std::string>::type&
+  virtual const WorksetArray<std::string>&
   getWsEBNames() const = 0;
 
   //! Retrieve Vector (length num worksets) of Physics Index
-  virtual const WorksetArray<int>::type&
+  virtual const WorksetArray<int>&
   getWsPhysIndex() const = 0;
 
   //! Retrieve connectivity map from elementGID to workset

--- a/src/disc/Albany_DOF.hpp
+++ b/src/disc/Albany_DOF.hpp
@@ -1,0 +1,33 @@
+#ifndef ALBANY_DOF_HPP
+#define ALBANY_DOF_HPP
+
+#include "Albany_ThyraTypes.hpp"
+#include "Albany_GlobalLocalIndexer.hpp"
+
+#include <Panzer_DOFManager.hpp>
+#include <Teuchos_RCP.hpp>
+
+namespace Albany {
+
+struct DOF {
+  std::string mesh_part;
+
+  // The dof_mgr is to be used for elem-wise operations
+  Teuchos::RCP<panzer::DOFManager>        dof_mgr;
+
+  // VectorSpaces are mostly to create (Multi)Vector's 
+  Teuchos::RCP<const Thyra_VectorSpace>   vs;
+  Teuchos::RCP<const Thyra_VectorSpace>   overlapped_vs;
+
+  // Indexers are mostly useful for node-centric operations
+  // that do not involve a loop over elements (e.g. Dirichlet)
+  Teuchos::RCP<const GlobalLocalIndexer>  indexer;
+  Teuchos::RCP<const GlobalLocalIndexer>  overlapped_indexer;
+
+  // To access node information
+  Teuchos::RCP<const DOF> node_dof;
+};
+
+} // namespace Albany
+
+#endif // ALBANY_DOF_HPP

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -9,7 +9,7 @@
 #include "Albany_DiscretizationFactory.hpp"
 
 #include "Albany_STKDiscretization.hpp"
-#include "Albany_BlockedSTKDiscretization.hpp"
+// #include "Albany_BlockedSTKDiscretization.hpp"
 #include "Albany_TmplSTKMeshStruct.hpp"
 #include "Albany_STK3DPointStruct.hpp"
 #include "Albany_GenericSTKMeshStruct.hpp"
@@ -248,10 +248,10 @@ DiscretizationFactory::createDiscretizationFromInternalMeshStruct(
     case AbstractMeshStruct::STK_MS:
     {
       auto ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
-      if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
-        auto disc = Teuchos::rcp(new BlockedSTKDiscretization(discParams, ms, commT, rigidBodyModes, sideSetEquations));
-        return disc;
-      } else
+      // if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
+      //   auto disc = Teuchos::rcp(new BlockedSTKDiscretization(discParams, ms, commT, rigidBodyModes, sideSetEquations));
+      //   return disc;
+      // } else
       {
         auto disc = Teuchos::rcp(new STKDiscretization(discParams, neq, ms, commT, rigidBodyModes, sideSetEquations));
         return disc;
@@ -271,10 +271,10 @@ DiscretizationFactory::setFieldData(Teuchos::RCP<AbstractDiscretization> disc,
     case AbstractMeshStruct::STK_MS:
     {
       auto ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
-      if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
-        auto stk_disc = Teuchos::rcp_dynamic_cast<BlockedSTKDiscretization>(disc);
-        stk_disc->setFieldData(req, sis);
-      } else
+      // if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
+      //   auto stk_disc = Teuchos::rcp_dynamic_cast<BlockedSTKDiscretization>(disc);
+      //   stk_disc->setFieldData(req, sis);
+      // } else
       {
         auto stk_disc = Teuchos::rcp_dynamic_cast<STKDiscretization>(disc);
         stk_disc->setFieldData(req, sis);
@@ -291,10 +291,10 @@ DiscretizationFactory::completeDiscSetup(Teuchos::RCP<AbstractDiscretization> di
     case AbstractMeshStruct::STK_MS:
     {
       auto ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(meshStruct);
-      if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
-        auto stk_disc = Teuchos::rcp_dynamic_cast<BlockedSTKDiscretization>(disc);
-        stk_disc->updateMesh();
-      } else
+      // if(ms->interleavedOrdering == DiscType::BlockedDisc){ // Use Panzer to do a blocked discretization
+      //   auto stk_disc = Teuchos::rcp_dynamic_cast<BlockedSTKDiscretization>(disc);
+      //   stk_disc->updateMesh();
+      // } else
       {
         auto stk_disc = Teuchos::rcp_dynamic_cast<STKDiscretization>(disc);
         stk_disc->updateMesh();

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -94,10 +94,7 @@ class wsLid
 using WsLIDList = std::map<GO, wsLid>;
 
 template <typename T>
-struct WorksetArray
-{
-  using type = Teuchos::ArrayRCP<T>;
-};
+using WorksetArray = Teuchos::ArrayRCP<T>;
 
 // LB 8/17/18: I moved these out of AbstractDiscretization, so if one only needs
 // these types,
@@ -105,7 +102,7 @@ struct WorksetArray
 //             Albany_AbstractDiscretization.hpp, which has tons of
 //             dependencies.
 using WorksetConn = Kokkos::View<LO***, Kokkos::LayoutRight, PHX::Device>;
-using Conn        = WorksetArray<WorksetConn>::type;
+using Conn        = WorksetArray<WorksetConn>;
 
 }  // namespace Albany
 

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -7,13 +7,14 @@
 #ifndef ALBANY_DISCRETIZATION_UTILS_HPP
 #define ALBANY_DISCRETIZATION_UTILS_HPP
 
+#include "Albany_KokkosTypes.hpp"
+#include "Albany_ScalarOrdinalTypes.hpp"
+
+#include <Teuchos_ArrayRCP.hpp>
+
 #include <map>
 #include <string>
 #include <vector>
-
-#include "Albany_KokkosTypes.hpp"
-#include "Albany_ScalarOrdinalTypes.hpp"
-#include "Teuchos_ArrayRCP.hpp"
 
 namespace Albany {
 
@@ -84,17 +85,20 @@ public:
 };
 using LocalSideSetInfoList = std::map<std::string, LocalSideSetInfo>;
 
-class wsLid
+// Better than std::pair, since ws/LID are more self-explanatory than first/second
+struct wsLid
 {
- public:
-  int ws;   // workset of element containing side
-  int LID;  // local id of element containing side
+  int ws;   // workset of element containing the entity
+  int LID;  // local id of the entity
 };
 
 using WsLIDList = std::map<GO, wsLid>;
 
 template <typename T>
 using WorksetArray = Teuchos::ArrayRCP<T>;
+
+template <typename T, typename MemSpace = DeviceMemSpace>
+using WorksetView = Kokkos::View<T*,Kokkos::LayoutRight,MemSpace>;
 
 // LB 8/17/18: I moved these out of AbstractDiscretization, so if one only needs
 // these types,

--- a/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
@@ -12,18 +12,17 @@
 #include "Teuchos_ParameterList.hpp"
 #include "Teuchos_RCP.hpp"
 
-// This include is added in Tpetra branch to get all the necessary
-// Tpetra includes (e.g., Tpetra_Vector.hpp, Tpetra_Map.hpp, etc.)
-#include "Albany_DataTypes.hpp"
+// // This include is added in Tpetra branch to get all the necessary
+// // Tpetra includes (e.g., Tpetra_Vector.hpp, Tpetra_Map.hpp, etc.)
+// #include "Albany_DataTypes.hpp"
 
-#include "Albany_AbstractFieldContainer.hpp"
-#include "Albany_NodalDOFManager.hpp"
+// #include "Albany_AbstractFieldContainer.hpp"
+#include "Albany_DOF.hpp"
 #include "Albany_StateInfoStruct.hpp"
 #include "Albany_Utils.hpp"
 
 #include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/FieldTraits.hpp>
 
 namespace Albany {
 
@@ -31,31 +30,37 @@ namespace Albany {
  * \brief Abstract interface for an STK field container
  *
  */
-class AbstractSTKFieldContainer : public AbstractFieldContainer
+// class AbstractSTKFieldContainer : public AbstractFieldContainer
+class AbstractSTKFieldContainer
 {
- public:
-  // Tensor per Node/Cell  - (Node, Dim, Dim) or (Cell,Dim,Dim)
-  typedef stk::mesh::Field<double, stk::mesh::Cartesian, stk::mesh::Cartesian>
-      TensorFieldType;
-  // Vector per Node/Cell  - (Node, Dim) or (Cell,Dim)
-  typedef stk::mesh::Field<double, stk::mesh::Cartesian> VectorFieldType;
-  // Scalar per Node/Cell  - (Node) or (Cell)
-  typedef stk::mesh::Field<double> ScalarFieldType;
-  // One int scalar per Node/Cell  - (Node) or (Cell)
-  typedef stk::mesh::Field<int> IntScalarFieldType;
-  // int vector per Node/Cell  - (Node,Dim/VecDim) or (Cell,Dim/VecDim)
-  typedef stk::mesh::Field<int, stk::mesh::Cartesian> IntVectorFieldType;
+public:
+  // ------------------------- Public Types ------------------------------- //
+  using vs_ptr_t  = Teuchos::RCP<const Thyra_VectorSpace>;
+  using cmv_ptr_t = Teuchos::RCP<const Thyra_MultiVector>;
+  using Cartesian = stk::mesh::Cartesian;
+  using QPTag     = stk::mesh::Cartesian;
 
-  typedef stk::mesh::Cartesian QPTag;  // need to invent shards::ArrayDimTag
+  template<typename... Args>
+  using Field = stk::mesh::Field<Args...>;
+
+  // Tensor per Node/Cell  - (Node, Dim, Dim) or (Cell,Dim,Dim)
+  typedef Field<double, Cartesian, Cartesian> TensorFieldType;
+  // Vector per Node/Cell  - (Node, Dim) or (Cell,Dim)
+  typedef Field<double, Cartesian> VectorFieldType;
+  // Scalar per Node/Cell  - (Node) or (Cell)
+  typedef Field<double> ScalarFieldType;
+  // One int scalar per Node/Cell  - (Node) or (Cell)
+  typedef Field<int> IntScalarFieldType;
+  // int vector per Node/Cell  - (Node,Dim/VecDim) or (Cell,Dim/VecDim)
+  typedef Field<int, Cartesian> IntVectorFieldType;
+
   // Tensor per QP   - (Cell, QP, Dim, Dim)
-  typedef stk::mesh::
-      Field<double, QPTag, stk::mesh::Cartesian, stk::mesh::Cartesian>
-          QPTensorFieldType;
+  typedef Field<double, QPTag, Cartesian, Cartesian> QPTensorFieldType;
   // Vector per QP   - (Cell, QP, Dim)
-  typedef stk::mesh::Field<double, QPTag, stk::mesh::Cartesian>
-      QPVectorFieldType;
+  typedef Field<double, QPTag, Cartesian> QPVectorFieldType;
+
   // One scalar per QP   - (Cell, QP)
-  typedef stk::mesh::Field<double, QPTag> QPScalarFieldType;
+  typedef Field<double, QPTag> QPScalarFieldType;
 
   typedef std::vector<const std::string*> ScalarValueState;
   typedef std::vector<QPScalarFieldType*> QPScalarState;
@@ -73,181 +78,120 @@ class AbstractSTKFieldContainer : public AbstractFieldContainer
   typedef std::map<std::string, GO>               MeshScalarInteger64State;
   typedef std::map<std::string, std::vector<int>> MeshVectorIntegerState;
 
+  // ---------------------------------------------------------------------- //
 
+  //! Constructor and Destructor
   AbstractSTKFieldContainer(bool solutionFieldContainer_) : proc_rank_field(nullptr), solutionFieldContainer(solutionFieldContainer_) {};
 
+  virtual ~AbstractSTKFieldContainer () = default;
 
-  //! Destructor
-  virtual ~AbstractSTKFieldContainer(){};
+  // Add stk fields from state structs data
+  virtual void addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis) = 0;
 
-  virtual void
-  addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis) = 0;
+  // Coordinates field ALWAYS in 3D, and of intrinsic mesh dimension
+  const VectorFieldType* getCoordinatesField3d() const { return coordinates_field3d; }
+        VectorFieldType* getCoordinatesField3d()       { return coordinates_field3d; }
+  const VectorFieldType* getCoordinatesField()   const { return coordinates_field;   }
+        VectorFieldType* getCoordinatesField()         { return coordinates_field;   }
 
-  // Coordinates field ALWAYS in 3D
-  const VectorFieldType*
-  getCoordinatesField3d() const
-  {
-    return coordinates_field3d;
-  }
-  VectorFieldType*
-  getCoordinatesField3d()
-  {
-    return coordinates_field3d;
-  }
+  IntScalarFieldType* getProcRankField() const { return proc_rank_field; }
 
-  const VectorFieldType*
-  getCoordinatesField() const
-  {
-    return coordinates_field;
-  }
-  VectorFieldType*
-  getCoordinatesField()
-  {
-    return coordinates_field;
-  }
+  // Get states, based on rank, location, data type
+  ScalarValueState&           getScalarValueStates()         { return scalarValue_states; }
+  MeshScalarState&            getMeshScalarStates()          { return mesh_scalar_states; }
+  MeshVectorState&            getMeshVectorStates()          { return mesh_vector_states; }
+  MeshScalarIntegerState&     getMeshScalarIntegerStates()   { return mesh_scalar_integer_states; }
+  MeshScalarInteger64State&   getMeshScalarInteger64States() { return mesh_scalar_integer_64_states; }
+  MeshVectorIntegerState&     getMeshVectorIntegerStates()   { return mesh_vector_integer_states; }
+  ScalarState&                getCellScalarStates()          { return cell_scalar_states; }
+  VectorState&                getCellVectorStates()          { return cell_vector_states; }
+  TensorState&                getCellTensorStates()          { return cell_tensor_states; }
+  QPScalarState&              getQPScalarStates()            { return qpscalar_states; }
+  QPVectorState&              getQPVectorStates()            { return qpvector_states; }
+  QPTensorState&              getQPTensorStates()            { return qptensor_states; }
 
-  IntScalarFieldType*
-  getProcRankField()
-  {
-    return proc_rank_field;
-  }
+  const StateInfoStruct& getNodalSIS()          const { return nodal_sis; }
+  const StateInfoStruct& getNodalParameterSIS() const { return nodal_parameter_sis; }
 
-  ScalarValueState&
-  getScalarValueStates()
-  {
-    return scalarValue_states;
-  }
-  MeshScalarState&
-  getMeshScalarStates()
-  {
-    return mesh_scalar_states;
-  }
-  MeshVectorState&
-  getMeshVectorStates()
-  {
-    return mesh_vector_states;
-  }
-  MeshScalarIntegerState&
-  getMeshScalarIntegerStates()
-  {
-    return mesh_scalar_integer_states;
-  }
-  MeshScalarInteger64State&
-  getMeshScalarInteger64States()
-  {
-    return mesh_scalar_integer_64_states;
-  }
-  MeshVectorIntegerState&
-  getMeshVectorIntegerStates()
-  {
-    return mesh_vector_integer_states;
-  }
-  ScalarState&
-  getCellScalarStates()
-  {
-    return cell_scalar_states;
-  }
-  VectorState&
-  getCellVectorStates()
-  {
-    return cell_vector_states;
-  }
-  TensorState&
-  getCellTensorStates()
-  {
-    return cell_tensor_states;
-  }
-  QPScalarState&
-  getQPScalarStates()
-  {
-    return qpscalar_states;
-  }
-  QPVectorState&
-  getQPVectorStates()
-  {
-    return qpvector_states;
-  }
-  QPTensorState&
-  getQPTensorStates()
-  {
-    return qptensor_states;
-  }
-  const StateInfoStruct&
-  getNodalSIS() const
-  {
-    return nodal_sis;
-  }
-  const StateInfoStruct&
-  getNodalParameterSIS() const
-  {
-    return nodal_parameter_sis;
-  }
+  std::map<std::string, double>& getTime() { return time; }
 
-  std::map<std::string, double>&
-  getTime()
-  {
-    return time;
-  }
+  // Copy fields from STK mesh into Thyra vectors
+  // virtual void fillSolnVector (Thyra_Vector&        soln,
+  //                             stk::mesh::Selector&  sel,
+  //                             const vs_ptr_t&       node_vs) = 0;
+  virtual void fillSolnVector (Thyra_Vector& solution,
+                               const DOF&    solution_dof) = 0;
 
-  virtual void
-  fillSolnVector(
-      Thyra_Vector&                                soln,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  fillVector(
-      Thyra_Vector&                                field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager) = 0;
-  virtual void
-  fillSolnMultiVector(
-      Thyra_MultiVector&                           soln,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  saveVector(
-      const Thyra_Vector&                          field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager) = 0;
-  virtual void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      const Thyra_Vector&                          soln_dot,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      const Thyra_Vector&                          soln_dot,
-      const Thyra_Vector&                          soln_dotdot,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  saveResVector(
-      const Thyra_Vector&                          res,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
-  virtual void
-  saveSolnMultiVector(
-      const Thyra_MultiVector&                     soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs) = 0;
+  // virtual void fillVector (Thyra_Vector&          field_vector,
+  //                          const std::string&     field_name,
+  //                          stk::mesh::Selector&   field_selection,
+  //                          const vs_ptr_t&        field_node_vs,
+  //                          const NodalDOFManager& nodalDofManager) = 0;
+  virtual void fillVector (Thyra_Vector&      field_vector,
+                           const std::string& field_name,
+                           const DOF&         field_dof) = 0;
 
-  virtual void
-  transferSolutionToCoords() = 0;
+  // virtual void fillSolnMultiVector (Thyra_MultiVector&    soln,
+  //                                   stk::mesh::Selector&  sel,
+  //                                   const vs_ptr_t&       node_vs) = 0;
+  virtual void fillSolnMultiVector (Thyra_MultiVector& solution,
+                                    const DOF&         solution_dof) = 0;
+
+  // Copy fields from Thyra vectors into STK mesh
+  // virtual void saveVector (const Thyra_Vector&     field_vector,
+  //                          const std::string&      field_name,
+  //                          stk::mesh::Selector&    field_selection,
+  //                          const vs_ptr_t&         field_node_vs,
+  //                          const NodalDOFManager&  nodalDofManager) = 0;
+  virtual void saveVector (const Thyra_Vector&  field_vector,
+                           const std::string&   field_name,
+                           const DOF&           field_dof) = 0;
+
+  // virtual void saveSolnVector (const Thyra_Vector&  soln,
+  //                              const cmv_ptr_t&     soln_dxdp,
+  //                              stk::mesh::Selector& sel,
+  //                              const vs_ptr_t&      node_vs) = 0;
+  virtual void saveSolnVector (const Thyra_Vector&  solution,
+                               const cmv_ptr_t&     solution_dxdp,
+                               const DOF&           solution_dof) = 0;
+
+  // virtual void saveSolnVector (const Thyra_Vector&  soln,
+  //                              const cmv_ptr_t&     soln_dxdp,
+  //                              const Thyra_Vector&  soln_dot,
+  //                              stk::mesh::Selector& sel,
+  //                              const vs_ptr_t&      node_vs) = 0;
+  virtual void saveSolnVector (const Thyra_Vector&  solution,
+                               const cmv_ptr_t&     solution_dxdp,
+                               const Thyra_Vector&  solution_dot,
+                               const DOF&           solution_dof) = 0;
+
+  // virtual void saveSolnVector (const Thyra_Vector&  soln,
+  //                              const cmv_ptr_t&     soln_dxdp,
+  //                              const Thyra_Vector&  soln_dot,
+  //                              const Thyra_Vector&  soln_dotdot,
+  //                              stk::mesh::Selector& sel,
+  //                              const vs_ptr_t&      node_vs) = 0;
+  virtual void saveSolnVector (const Thyra_Vector&  solution,
+                               const cmv_ptr_t&     solution_dxdp,
+                               const Thyra_Vector&  solution_dot,
+                               const Thyra_Vector&  solution_dotdot,
+                               const DOF&           solution_dof) = 0;
+
+  // virtual void saveResVector (const Thyra_Vector&   res,
+  //                             stk::mesh::Selector&  sel,
+  //                             const vs_ptr_t&       node_vs) = 0;
+  virtual void saveResVector (const Thyra_Vector& residual,
+                              const DOF&          solution_dof) = 0;
+
+  // virtual void saveSolnMultiVector (const Thyra_MultiVector&  soln,
+  //                                   const cmv_ptr_t&          soln_dxdp,
+  //                                   stk::mesh::Selector&      sel,
+  //                                   const vs_ptr_t&           node_vs) = 0;
+  virtual void saveSolnMultiVector (const Thyra_MultiVector&  solution,
+                                    const cmv_ptr_t&          solution_dxdp,
+                                    const DOF&                solution_dof) = 0;
+
+  virtual void transferSolutionToCoords() = 0;
 
  protected:
   // Note: for 3d meshes, coordinates_field3d==coordinates_field (they point to

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -245,7 +245,7 @@ namespace Albany
       return wsElNodeEqID;
     }
 
-    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type &
+    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> &
     getWsElNodeID() const
     {
       return wsElNodeID;
@@ -297,7 +297,7 @@ namespace Albany
       return m_blocks[i_block]->getOverlapDOFManager(field_name);
     }
 
-    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>>::type &
+    const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>> &
     getCoords() const
     {
       return coords;
@@ -329,13 +329,13 @@ namespace Albany
     }
 
     //! Retrieve Vector (length num worksets) of element block names
-    const WorksetArray<std::string>::type &
+    const WorksetArray<std::string> &
     getWsEBNames() const
     {
       return wsEBNames;
     }
     //! Retrieve Vector (length num worksets) of physics set index
-    const WorksetArray<int>::type &
+    const WorksetArray<int> &
     getWsPhysIndex() const
     {
       return wsPhysIndex;
@@ -835,15 +835,15 @@ namespace Albany
     Conn wsElNodeEqID;
 
     //! Connectivity array [workset, element, local-node] => GID
-    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type wsElNodeID;
+    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>> wsElNodeID;
 
     mutable Teuchos::ArrayRCP<double> coordinates;
     Teuchos::RCP<Thyra_MultiVector> coordMV;
-    WorksetArray<std::string>::type wsEBNames;
-    WorksetArray<int>::type wsPhysIndex;
-    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>>::type coords;
-    WorksetArray<Teuchos::ArrayRCP<double>>::type sphereVolume;
-    WorksetArray<Teuchos::ArrayRCP<double *>>::type latticeOrientation;
+    WorksetArray<std::string> wsEBNames;
+    WorksetArray<int> wsPhysIndex;
+    WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double *>>> coords;
+    WorksetArray<Teuchos::ArrayRCP<double>> sphereVolume;
+    WorksetArray<Teuchos::ArrayRCP<double *>> latticeOrientation;
 
     //! Connectivity map from elementGID to workset and LID in workset
     WsLIDList elemGIDws;

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -134,10 +134,11 @@ void GenericSTKMeshStruct::SetupFieldData(
     params->get<Teuchos::Array<std::string> >("Residual Vector Components", default_residual_vector);
 
   // Build the usual Albany fields unless the user explicitly specifies the residual or solution vector layout
-  if(user_specified_solution_components && (residual_vector.length() > 0)){
-    this->fieldContainer = Teuchos::rcp(new MultiSTKFieldContainer(params,
-        metaData, bulkData, interleavedOrdering, numDim, sis, num_params));
-  } else {
+  // if(user_specified_solution_components && (residual_vector.length() > 0)){
+  //   this->fieldContainer = Teuchos::rcp(new MultiSTKFieldContainer(params,
+  //       metaData, bulkData, interleavedOrdering, numDim, sis, num_params));
+  // } else
+  {
     this->fieldContainer = Teuchos::rcp(new OrdinarySTKFieldContainer(params,
         metaData, bulkData, req, interleavedOrdering, numDim, sis, num_params));
   }

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
@@ -69,93 +69,62 @@ class OrdinarySTKFieldContainer : public GenericSTKFieldContainer
   };
 #endif
 
-  void
-  fillSolnVector(
-      Thyra_Vector&                                soln,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  fillVector(
-      Thyra_Vector&                                field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager);
-  void
-  fillSolnMultiVector(
-      Thyra_MultiVector&                           soln,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  saveVector(
-      const Thyra_Vector&                          field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager);
-  void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      const Thyra_Vector&                          soln_dot,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  saveSolnVector(
-      const Thyra_Vector&                          soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      const Thyra_Vector&                          soln_dot,
-      const Thyra_Vector&                          soln_dotdot,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  saveResVector(
-      const Thyra_Vector&                          res,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
-  void
-  saveSolnMultiVector(
-      const Thyra_MultiVector&                     soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-      stk::mesh::Selector&                         sel,
-      const Teuchos::RCP<const Thyra_VectorSpace>& node_vs);
+  void fillSolnVector (Thyra_Vector& solution,
+                       const DOF&    solution_dof);
 
-  void
-  transferSolutionToCoords();
+  void fillVector (Thyra_Vector&      field_vector,
+                   const std::string& field_name,
+                   const DOF&         field_dof);
+
+  void fillSolnMultiVector (Thyra_MultiVector& solution,
+                            const DOF&         solution_dof);
+
+  void saveVector (const Thyra_Vector&  field_vector,
+                   const std::string&   field_name,
+                   const DOF&           field_dof);
+
+  void saveSolnVector (const Thyra_Vector&  solution,
+                       const cmv_ptr_t&     solution_dxdp,
+                       const DOF&           solution_dof);
+
+  void saveSolnVector (const Thyra_Vector&  solution,
+                       const cmv_ptr_t&     solution_dxdp,
+                       const Thyra_Vector&  solution_dot,
+                       const DOF&           solution_dof);
+
+  void saveSolnVector (const Thyra_Vector&  solution,
+                       const cmv_ptr_t&     solution_dxdp,
+                       const Thyra_Vector&  solution_dot,
+                       const Thyra_Vector&  solution_dotdot,
+                       const DOF&           solution_dof);
+
+  void saveResVector (const Thyra_Vector& residual,
+                      const DOF&          solution_dof);
+
+  void saveSolnMultiVector (const Thyra_MultiVector&  solution,
+                            const cmv_ptr_t&          solution_dxdp,
+                            const DOF&                solution_dof);
+
+  void transferSolutionToCoords();
 
 
  private:
-  void
-  fillVectorImpl(
-      Thyra_Vector&                                field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager);
-  void
-  saveVectorImpl(
-      const Thyra_Vector&                          field_vector,
-      const std::string&                           field_name,
-      stk::mesh::Selector&                         field_selection,
-      const Teuchos::RCP<const Thyra_VectorSpace>& field_node_vs,
-      const NodalDOFManager&                       nodalDofManager);
+  void fillVectorImpl (Thyra_Vector&      field_vector,
+                       const std::string& field_name,
+                       const DOF&         field_dof);
 
-  void
-  initializeProcRankField();
+  void saveVectorImpl (const Thyra_Vector&  field_vector,
+                       const std::string&   field_name,
+                       const DOF&           field_dof);
+
+  void initializeProcRankField();
 
 
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*> solution_field;
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
-                                              solution_field_dtk;
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
-                                              solution_field_dxdp;
-  AbstractSTKFieldContainer::VectorFieldType* residual_field;
+  Teuchos::Array<VectorFieldType*>  solution_field;
+  Teuchos::Array<VectorFieldType*>  solution_field_dtk;
+  Teuchos::Array<VectorFieldType*>  solution_field_dxdp;
+
+  VectorFieldType*                  residual_field;
 };
 
 }  // namespace Albany

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -231,7 +231,7 @@ class STKDiscretization : public AbstractDiscretization
     return wsElNodeEqID;
   }
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type&
+  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
   getWsElNodeID() const
   {
     return wsElNodeID;
@@ -275,7 +275,7 @@ class STKDiscretization : public AbstractDiscretization
   const Teuchos::ArrayRCP<double>&
   getCoordinates() const;
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type&
+  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>&
   getCoords() const
   {
     return coords;
@@ -307,13 +307,13 @@ class STKDiscretization : public AbstractDiscretization
   }
 
   //! Retrieve Vector (length num worksets) of element block names
-  const WorksetArray<std::string>::type&
+  const WorksetArray<std::string>&
   getWsEBNames() const
   {
     return wsEBNames;
   }
   //! Retrieve Vector (length num worksets) of physics set index
-  const WorksetArray<int>::type&
+  const WorksetArray<int>&
   getWsPhysIndex() const
   {
     return wsPhysIndex;
@@ -658,15 +658,15 @@ class STKDiscretization : public AbstractDiscretization
   Conn wsElNodeEqID;
 
   //! Connectivity array [workset, element, local-node] => GID
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type wsElNodeID;
+  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>        wsElNodeID;
 
   mutable Teuchos::ArrayRCP<double>                                 coordinates;
   Teuchos::RCP<Thyra_MultiVector>                                   coordMV;
-  WorksetArray<std::string>::type                                   wsEBNames;
-  WorksetArray<int>::type                                           wsPhysIndex;
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>::type coords;
-  WorksetArray<Teuchos::ArrayRCP<double>>::type  sphereVolume;
-  WorksetArray<Teuchos::ArrayRCP<double*>>::type latticeOrientation;
+  WorksetArray<std::string>                                         wsEBNames;
+  WorksetArray<int>                                                 wsPhysIndex;
+  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>       coords;
+  WorksetArray<Teuchos::ArrayRCP<double>>        sphereVolume;
+  WorksetArray<Teuchos::ArrayRCP<double*>>       latticeOrientation;
 
   //! Connectivity map from elementGID to workset and LID in workset
   WsLIDList elemGIDws;

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -681,12 +681,6 @@ class STKDiscretization : public AbstractDiscretization
   // Needed to pass coordinates to ML.
   Teuchos::RCP<RigidBodyModes> rigidBodyModes;
 
-  int              netCDFp;
-  size_t           netCDFOutputRequest;
-  std::vector<int> varSolns;
-
-  WorksetArray<Teuchos::ArrayRCP<std::vector<interp>>>::type interpolateData;
-
   // Storage used in periodic BCs to un-roll coordinates. Pointers saved for
   // destructor.
   std::vector<double*> toDelete;
@@ -714,18 +708,6 @@ class STKDiscretization : public AbstractDiscretization
   size_t outputFileIdx;
 #endif
   DiscType interleavedOrdering;
-
- private:
-
-  template <typename T, typename ContainerType>
-  bool
-  in_list(const T& value, const ContainerType& list)
-  {
-    for (const T& item : list) {
-      if (item == value) { return true; }
-    }
-    return false;
-  }
 
   Teuchos::RCP<AbstractSTKFieldContainer> solutionFieldContainer;
 };

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -36,75 +36,75 @@ namespace Albany {
 
 typedef shards::Array<GO, shards::NaturalOrder> GIDArray;
 
-struct DOFsStruct
-{
-  Teuchos::RCP<const Thyra_VectorSpace> node_vs;
-  Teuchos::RCP<const Thyra_VectorSpace> overlap_node_vs;
-  Teuchos::RCP<const Thyra_VectorSpace> vs;
-  Teuchos::RCP<const Thyra_VectorSpace> overlap_vs;
-  NodalDOFManager                       dofManager;
-  NodalDOFManager                       overlap_dofManager;
-  std::vector<std::vector<LO>>          wsElNodeEqID_rawVec;
-  std::vector<IDArray>                  wsElNodeEqID;
-  std::vector<std::vector<GO>>          wsElNodeID_rawVec;
-  std::vector<GIDArray>                 wsElNodeID;
+// struct DOFsStruct
+// {
+//   Teuchos::RCP<const Thyra_VectorSpace> node_vs;
+//   Teuchos::RCP<const Thyra_VectorSpace> overlap_node_vs;
+//   Teuchos::RCP<const Thyra_VectorSpace> vs;
+//   Teuchos::RCP<const Thyra_VectorSpace> overlap_vs;
+//   NodalDOFManager                       dofManager;
+//   NodalDOFManager                       overlap_dofManager;
+//   std::vector<std::vector<LO>>          wsElNodeEqID_rawVec;
+//   std::vector<IDArray>                  wsElNodeEqID;
+//   std::vector<std::vector<GO>>          wsElNodeID_rawVec;
+//   std::vector<GIDArray>                 wsElNodeID;
 
-  Teuchos::RCP<const GlobalLocalIndexer> node_vs_indexer;
-  Teuchos::RCP<const GlobalLocalIndexer> overlap_node_vs_indexer;
-  Teuchos::RCP<const GlobalLocalIndexer> vs_indexer;
-  Teuchos::RCP<const GlobalLocalIndexer> overlap_vs_indexer;
-};
+//   Teuchos::RCP<const GlobalLocalIndexer> node_vs_indexer;
+//   Teuchos::RCP<const GlobalLocalIndexer> overlap_node_vs_indexer;
+//   Teuchos::RCP<const GlobalLocalIndexer> vs_indexer;
+//   Teuchos::RCP<const GlobalLocalIndexer> overlap_vs_indexer;
+// };
 
-struct NodalDOFsStructContainer
-{
-  typedef std::map<std::pair<std::string, int>, DOFsStruct> MapOfDOFsStructs;
+// struct NodalDOFsStructContainer
+// {
+//   typedef std::map<std::pair<std::string, int>, DOFsStruct> MapOfDOFsStructs;
 
-  MapOfDOFsStructs                                        mapOfDOFsStructs;
-  std::map<std::string, MapOfDOFsStructs::const_iterator> fieldToMap;
+//   MapOfDOFsStructs                                        mapOfDOFsStructs;
+//   std::map<std::string, MapOfDOFsStructs::const_iterator> fieldToMap;
 
-  const DOFsStruct&
-  getDOFsStruct(const std::string& field_name) const
-  {
-    const auto iter = fieldToMap.find(field_name);
-    if (iter == fieldToMap.end())
-      TEUCHOS_TEST_FOR_EXCEPTION(true,
-          std::logic_error, field_name + " does not exist in fieldToMap");
-    return iter->second->second;
-  };
+//   const DOFsStruct&
+//   getDOFsStruct(const std::string& field_name) const
+//   {
+//     const auto iter = fieldToMap.find(field_name);
+//     if (iter == fieldToMap.end())
+//       TEUCHOS_TEST_FOR_EXCEPTION(true,
+//           std::logic_error, field_name + " does not exist in fieldToMap");
+//     return iter->second->second;
+//   };
 
-  // IKT: added the following function, which may be useful for debugging.
-  void
-  printFieldToMap() const
-  {
-    typedef std::map<std::string, MapOfDOFsStructs::const_iterator>::
-        const_iterator                  MapIterator;
-    Teuchos::RCP<Teuchos::FancyOStream> out =
-        Teuchos::VerboseObjectBase::getDefaultOStream();
-    for (MapIterator iter = fieldToMap.begin(); iter != fieldToMap.end();
-         iter++) {
-      std::string key = iter->first;
-      *out << "IKT Key: " << key << "\n";
-      auto vs = getDOFsStruct(key).vs;
-      *out << "IKT Vector Space \n: ";
-      describe(vs, *out, Teuchos::VERB_EXTREME);
-    }
-  }
+//   // IKT: added the following function, which may be useful for debugging.
+//   void
+//   printFieldToMap() const
+//   {
+//     typedef std::map<std::string, MapOfDOFsStructs::const_iterator>::
+//         const_iterator                  MapIterator;
+//     Teuchos::RCP<Teuchos::FancyOStream> out =
+//         Teuchos::VerboseObjectBase::getDefaultOStream();
+//     for (MapIterator iter = fieldToMap.begin(); iter != fieldToMap.end();
+//          iter++) {
+//       std::string key = iter->first;
+//       *out << "IKT Key: " << key << "\n";
+//       auto vs = getDOFsStruct(key).vs;
+//       *out << "IKT Vector Space \n: ";
+//       describe(vs, *out, Teuchos::VERB_EXTREME);
+//     }
+//   }
 
-  void
-  addEmptyDOFsStruct(
-      const std::string& field_name,
-      const std::string& meshPart,
-      int                numComps)
-  {
-    if (numComps != 1)
-      mapOfDOFsStructs.insert(make_pair(make_pair(meshPart, 1), DOFsStruct()));
+//   void
+//   addEmptyDOFsStruct(
+//       const std::string& field_name,
+//       const std::string& meshPart,
+//       int                numComps)
+//   {
+//     if (numComps != 1)
+//       mapOfDOFsStructs.insert(make_pair(make_pair(meshPart, 1), DOFsStruct()));
 
-    fieldToMap[field_name] =
-        mapOfDOFsStructs
-            .insert(make_pair(make_pair(meshPart, numComps), DOFsStruct()))
-            .first;
-  }
-};
+//     fieldToMap[field_name] =
+//         mapOfDOFsStructs
+//             .insert(make_pair(make_pair(meshPart, numComps), DOFsStruct()))
+//             .first;
+//   }
+// };
 
 class STKDiscretization : public AbstractDiscretization
 {
@@ -125,29 +125,29 @@ class STKDiscretization : public AbstractDiscretization
   void
   printConnectivity() const;
 
-  //! Get node vector space (owned and overlapped)
-  Teuchos::RCP<const Thyra_VectorSpace>
-  getNodeVectorSpace() const
-  {
-    return m_node_vs;
-  }
-  Teuchos::RCP<const Thyra_VectorSpace>
-  getOverlapNodeVectorSpace() const
-  {
-    return m_overlap_node_vs;
-  }
+  // //! Get node vector space (owned and overlapped)
+  // Teuchos::RCP<const Thyra_VectorSpace>
+  // getNodeVectorSpace() const
+  // {
+  //   return m_node_vs;
+  // }
+  // Teuchos::RCP<const Thyra_VectorSpace>
+  // getOverlapNodeVectorSpace() const
+  // {
+  //   return m_overlap_node_vs;
+  // }
 
-  //! Get solution DOF vector space (owned and overlapped).
-  Teuchos::RCP<const Thyra_VectorSpace>
-  getVectorSpace() const
-  {
-    return m_vs;
-  }
-  Teuchos::RCP<const Thyra_VectorSpace>
-  getOverlapVectorSpace() const
-  {
-    return m_overlap_vs;
-  }
+  // //! Get solution DOF vector space (owned and overlapped).
+  // Teuchos::RCP<const Thyra_VectorSpace>
+  // getVectorSpace() const
+  // {
+  //   return m_vs;
+  // }
+  // Teuchos::RCP<const Thyra_VectorSpace>
+  // getOverlapVectorSpace() const
+  // {
+  //   return m_overlap_vs;
+  // }
 
   //! Get Field node vector space (owned and overlapped)
   Teuchos::RCP<const Thyra_VectorSpace>
@@ -224,59 +224,58 @@ class STKDiscretization : public AbstractDiscretization
     return elemGIDws;
   }
 
-  //! Get map from ws, elem, node [, eq] -> [Node|DOF] GID
-  const Conn&
-  getWsElNodeEqID() const
-  {
-    return wsElNodeEqID;
-  }
+  // //! Get map from ws, elem, node [, eq] -> [Node|DOF] GID
+  // const Conn&
+  // getWsElNodeEqID() const
+  // {
+  //   return wsElNodeEqID;
+  // }
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>&
-  getWsElNodeID() const
-  {
-    return wsElNodeID;
-  }
+  // const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>::type&
+  // getWsElNodeID() const
+  // {
+  //   return wsElNodeID;
+  // }
 
   //! Get IDArray for (Ws, Local Node, nComps) -> (local) NodeLID, works for
   //! both scalar and vector fields
-  const std::vector<IDArray>&
-  getElNodeEqID(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name).wsElNodeEqID;
-  }
+  // const std::vector<IDArray>&
+  // getElNodeEqID(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name).wsElNodeEqID;
+  // }
 
-  Teuchos::RCP<const GlobalLocalIndexer>
-  getGlobalLocalIndexer(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name).vs_indexer;
-  }
+  // Teuchos::RCP<const GlobalLocalIndexer>
+  // getGlobalLocalIndexer(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name).vs_indexer;
+  // }
 
-  Teuchos::RCP<const GlobalLocalIndexer>
-  getOverlapGlobalLocalIndexer(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name)
-        .overlap_vs_indexer;
-  }
+  // Teuchos::RCP<const GlobalLocalIndexer>
+  // getOverlapGlobalLocalIndexer(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name)
+  //       .overlap_vs_indexer;
+  // }
 
-  const NodalDOFManager&
-  getDOFManager(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name).dofManager;
-  }
+  // const NodalDOFManager&
+  // getDOFManager(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name).dofManager;
+  // }
 
-  const NodalDOFManager&
-  getOverlapDOFManager(const std::string& field_name) const
-  {
-    return nodalDOFsStructContainer.getDOFsStruct(field_name)
-        .overlap_dofManager;
-  }
+  // const NodalDOFManager&
+  // getOverlapDOFManager(const std::string& field_name) const
+  // {
+  //   return nodalDOFsStructContainer.getDOFsStruct(field_name)
+  //       .overlap_dofManager;
+  // }
 
   //! Retrieve coodinate vector (num_used_nodes * 3)
   const Teuchos::ArrayRCP<double>&
   getCoordinates() const;
 
-  const WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>&
-  getCoords() const
+  const DualView<double****>& getCoords () const
   {
     return coords;
   }
@@ -618,17 +617,15 @@ class STKDiscretization : public AbstractDiscretization
   Teuchos::RCP<const Teuchos_Comm> comm;
 
   //! Unknown map and node map
-  Teuchos::RCP<const Thyra_VectorSpace> m_vs;
-  Teuchos::RCP<const Thyra_VectorSpace> m_node_vs;
+  // Teuchos::RCP<const Thyra_VectorSpace> m_vs;
+  // Teuchos::RCP<const Thyra_VectorSpace> m_node_vs;
 
   //! Overlapped unknown map and node map
-  Teuchos::RCP<const Thyra_VectorSpace> m_overlap_vs;
-  Teuchos::RCP<const Thyra_VectorSpace> m_overlap_node_vs;
+  // Teuchos::RCP<const Thyra_VectorSpace> m_overlap_vs;
+  // Teuchos::RCP<const Thyra_VectorSpace> m_overlap_node_vs;
 
   //! Jacobian matrix operator factory
   Teuchos::RCP<ThyraCrsMatrixFactory> m_jac_factory;
-
-  NodalDOFsStructContainer nodalDOFsStructContainer;
 
   //! Number of equations (and unknowns) per node
   const unsigned int neq;
@@ -660,13 +657,13 @@ class STKDiscretization : public AbstractDiscretization
   //! Connectivity array [workset, element, local-node] => GID
   WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO>>>        wsElNodeID;
 
-  mutable Teuchos::ArrayRCP<double>                                 coordinates;
-  Teuchos::RCP<Thyra_MultiVector>                                   coordMV;
-  WorksetArray<std::string>                                         wsEBNames;
-  WorksetArray<int>                                                 wsPhysIndex;
-  WorksetArray<Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*>>>       coords;
-  WorksetArray<Teuchos::ArrayRCP<double>>        sphereVolume;
-  WorksetArray<Teuchos::ArrayRCP<double*>>       latticeOrientation;
+  mutable Teuchos::ArrayRCP<double>         coordinates;
+  Teuchos::RCP<Thyra_MultiVector>           coordMV;
+  WorksetArray<std::string>                 wsEBNames;
+  WorksetArray<int>                         wsPhysIndex;
+  DualView<double****>                      coords;
+  WorksetArray<Teuchos::ArrayRCP<double>>   sphereVolume;
+  WorksetArray<Teuchos::ArrayRCP<double*>>  latticeOrientation;
 
   //! Connectivity map from elementGID to workset and LID in workset
   WsLIDList elemGIDws;

--- a/src/disc/stk/Albany_STKFieldContainerHelper.hpp
+++ b/src/disc/stk/Albany_STKFieldContainerHelper.hpp
@@ -8,33 +8,44 @@
 #define ALBANY_STK_FIELD_CONTAINER_HELPER_HPP
 
 #include "Albany_ThyraTypes.hpp"
-#include "Albany_NodalDOFManager.hpp"
+#include "Albany_DOF.hpp"
 
 #include <stk_mesh/base/Bucket.hpp>
 
 namespace Albany {
 
-class GlobalLocalIndexer;
-
 template<class FieldType>
 struct STKFieldContainerHelper
 {
-  // Fill (aka get) and save (aka set) methods
+  // FieldType can be either scalar or vector, the code is the same.
 
-  // FieldType can be either scalar or vector, the code is the same. Either way,
-  // offset must be less than the dimension of the field.
-  static void fillVector (Thyra_Vector& field_thyra,
+  // Fill (from stk to thyra) and save (from thyra to stk) routines
+  // Parameters:
+  //  - vector: the thyra vector where to read/write data from/to
+  //  - field_stk: the STK field where to write/read data to/from
+  //  - bucket: current node bucket being processed
+  //  - vector_dof: the Albany::DOF structure corresponding to the thyra vector
+  //  - offset: if reading/writing only a subfield of vector, this is
+  //            the offset to the first entry of the subfield (recall that
+  //            we always use interleaved ordering of dofs)
+  // Note on the field dimensions:
+  //  - the thyra vector stores N components, with N the return value
+  //    of vector_dof.dof_mgr->getNumFields()
+  //  - the stk field has M scalars per node (M=1 for scalar fields)
+  //    M can be computed via stk::mesh::field_scalars_per_entity(field_stk,bucket)
+  // All of this assumes that N>=M, and the thyra vector might be a
+  // "packing" of K separate fields, whose individual dimensions add up to N.
+
+  static void fillVector (      Thyra_Vector& vector,
                           const FieldType& field_stk,
-                          const Teuchos::RCP<const GlobalLocalIndexer>& node_vs,
                           const stk::mesh::Bucket& bucket,
-                          const NodalDOFManager& nodalDofManager,
+                          const DOF& vector_dof,
                           const int offset);
 
   static void saveVector (const Thyra_Vector& field_thyra,
-                          FieldType& field_stk,
-                          const Teuchos::RCP<const GlobalLocalIndexer>& node_vs,
+                                FieldType& field_stk,
                           const stk::mesh::Bucket& bucket,
-                          const NodalDOFManager& nodalDofManager,
+                          const DOF& field_dof,
                           const int offset);
 
   // Convenience function to copy one field's contents to another

--- a/src/disc/stk/STKConnManager.cpp
+++ b/src/disc/stk/STKConnManager.cpp
@@ -6,8 +6,6 @@
 
 #include "STKConnManager.hpp"
 
-#include <vector>
-
 #include <stk_util/parallel/ParallelReduce.hpp>
 #include <stk_mesh/base/GetEntities.hpp>
 #include <stk_mesh/base/Comm.hpp>       // for comm_mesh_counts
@@ -16,197 +14,144 @@
 
 namespace Albany {
 
-using Teuchos::RCP;
-using Teuchos::rcp;
-
-// Object describing how to sort a vector of elements using
-// local ID as the key
-class LocalIdCompare {
-public:
-
-  LocalIdCompare(const STKConnManager& stk_disc) : stkDisc_(stk_disc) {}
-
-  // Compares two stk mesh entities based on local ID
-  bool operator() (stk::mesh::Entity a, stk::mesh::Entity b)
-  { return stkDisc_.elementLocalId(a) < stkDisc_.elementLocalId(b);}
-
-private:
-
-  const STKConnManager&   stkDisc_;
-
-};
-
-STKConnManager::STKConnManager(const Teuchos::RCP<AbstractSTKMeshStruct>& absSTKMeshStruct)
-   : ownedElementCount_(0), metaData_(absSTKMeshStruct->metaData),
-     bulkData_(absSTKMeshStruct->bulkData), stkMeshStruct_(absSTKMeshStruct), useFieldCoordinates_(false)
+STKConnManager::
+STKConnManager(const Teuchos::RCP<const AbstractSTKMeshStruct>& stkMeshStruct)
 {
+  // Sanity check
+  TEUCHOS_TEST_FOR_EXCEPTION (stkMeshStruct.is_null(), std::runtime_error,
+      "Error! Input mesh struct pointer is null.\n");
 
-     buildEntityCounts();
-     buildMaxEntityIds();
-     buildLocalElementIDs();
+  m_stkMeshStruct = stkMeshStruct;
+  m_bulkData      = m_stkMeshStruct->bulkData;
+  m_metaData      = m_stkMeshStruct->metaData;
 
+  // buildEntityCounts();
+  buildMaxEntityIds();
+  buildLocalElementIDs();
 }
 
 Teuchos::RCP<panzer::ConnManager>
 STKConnManager::noConnectivityClone() const
 {
-  return Teuchos::rcp(new STKConnManager(stkMeshStruct_));
+  return Teuchos::rcp(new STKConnManager(m_stkMeshStruct));
 }
 
 void STKConnManager::clearLocalElementMapping()
 {
-   elements_ = Teuchos::null;
-
-   elementBlocks_.clear();
-   elmtLidToConn_.clear();
-   connSize_.clear();
-   elmtToAssociatedElmts_.clear();
+  m_elements.clear();
+  m_elementBlocks.clear();
+  m_elmtLidToConn.clear();
+  m_connSize.clear();
 }
 
 void STKConnManager::buildLocalElementMapping()
 {
-   clearLocalElementMapping(); // forget the past
+  // Start from scratch
+  clearLocalElementMapping(); // forget the past
 
-   // build element block information
-   //////////////////////////////////////////////
-   elements_ = Teuchos::rcp(new std::vector<stk::mesh::Entity>);
+  // Get blocks names
+  std::vector<std::string> blockIds;
+  getElementBlockIds(blockIds);
 
-   // defines ordering of blocks
-   std::vector<std::string> blockIds;
-//   stkDisc_->getElementBlockNames(blockIds);
-   getElementBlockNames(blockIds);
+  // Loop over element blocks, and gather elements for each block
+  for (const auto& blockId : blockIds) {
+    // 1. Grab elements on this block
+    std::vector<stk::mesh::Entity> blockElmts;
+    getMyElements(blockId,blockElmts);
 
-   std::size_t blockIndex=0;
-   for(std::vector<std::string>::const_iterator idItr=blockIds.begin();
-       idItr!=blockIds.end();++idItr,++blockIndex) {
-      std::string blockId = *idItr;
+    // 2. Concatenate them into element LID lookup table
+    m_elements.insert(m_elements.end(),blockElmts.begin(),blockElmts.end());
 
-      // grab elements on this block
-      std::vector<stk::mesh::Entity> blockElmts;
-      getMyElements(blockId,blockElmts);
+    // 3. Build block to LID map
+    auto& blockElems = m_elementBlocks[blockId];
+    blockElems.reserve(blockElmts.size());
+    for (const auto& elem : blockElmts) {
+      blockElems.push_back (elementLocalId(elem));
+    }
+  }
 
-      // concatenate them into element LID lookup table
-      elements_->insert(elements_->end(),blockElmts.begin(),blockElmts.end());
+  // this expensive operation guarantees ordering of local IDs
+  auto cmpLids = [&](stk::mesh::Entity a, stk::mesh::Entity b)->bool{
+     return elementLocalId(a) < elementLocalId(b);
+  };
+  std::sort(m_elements.begin(), m_elements.end(), cmpLids);
 
-      // build block to LID map
-      elementBlocks_[blockId] = Teuchos::rcp(new std::vector<LocalOrdinal>);
-      for(std::size_t i=0;i<blockElmts.size();i++)
-         elementBlocks_[blockId]->push_back(elementLocalId(blockElmts[i]));
-   }
+  // Pre allocate space for internal connectivity offsets/sizes
+  m_elmtLidToConn.clear();
+  m_elmtLidToConn.resize(m_elements.size(),0);
 
-   ownedElementCount_ = elements_->size();
-
-   blockIndex=0;
-   for(std::vector<std::string>::const_iterator idItr=blockIds.begin();
-       idItr!=blockIds.end();++idItr,++blockIndex) {
-      std::string blockId = *idItr;
-
-      // grab elements on this block
-      std::vector<stk::mesh::Entity> blockElmts;
-      getNeighborElements(blockId,blockElmts);
-
-      // concatenate them into element LID lookup table
-      elements_->insert(elements_->end(),blockElmts.begin(),blockElmts.end());
-
-      // build block to LID map
-      neighborElementBlocks_[blockId] = Teuchos::rcp(new std::vector<LocalOrdinal>);
-      for(std::size_t i=0;i<blockElmts.size();i++)
-         neighborElementBlocks_[blockId]->push_back(elementLocalId(blockElmts[i]));
-   }
-
-   // this expensive operation guarantees ordering of local IDs
-   std::sort(elements_->begin(), elements_->end(), LocalIdCompare(*this));
-
-   // allocate space for element LID to Connectivty map
-   // connectivity size
-   elmtLidToConn_.clear();
-   elmtLidToConn_.resize(elements_->size(),0);
-
-   connSize_.clear();
-   connSize_.resize(elements_->size(),0);
+  m_connSize.clear();
+  m_connSize.resize(m_elements.size(),0);
 }
 
-void
-STKConnManager::buildOffsetsAndIdCounts(const panzer::FieldPattern & fp,
-                                        LocalOrdinal & nodeIdCnt, LocalOrdinal & edgeIdCnt,
-                                        LocalOrdinal & faceIdCnt, LocalOrdinal & cellIdCnt,
-                                        GlobalOrdinal & nodeOffset, GlobalOrdinal & edgeOffset,
-                                        GlobalOrdinal & faceOffset, GlobalOrdinal & cellOffset) const
+void STKConnManager::
+buildOffsetsAndIdCounts(
+    const panzer::FieldPattern & fp,
+    LocalOrdinal & nodeIdCnt, LocalOrdinal & edgeIdCnt,
+    LocalOrdinal & faceIdCnt, LocalOrdinal & cellIdCnt,
+    GlobalOrdinal & nodeOffset, GlobalOrdinal & edgeOffset,
+    GlobalOrdinal & faceOffset, GlobalOrdinal & cellOffset) const
 {
-   // get the global counts for all the nodes, faces, edges and cells
-   GlobalOrdinal maxNodeId = getMaxEntityId(getNodeRank());
-   GlobalOrdinal maxEdgeId = getMaxEntityId(getEdgeRank());
-   GlobalOrdinal maxFaceId = getMaxEntityId(getFaceRank());
+  // get the global counts for all the nodes, faces, edges and cells
+  GlobalOrdinal maxNodeId = getMaxEntityId(stk::topology::NODE_RANK);
+  GlobalOrdinal maxEdgeId = getMaxEntityId(stk::topology::EDGE_RANK);
+  GlobalOrdinal maxFaceId = getMaxEntityId(stk::topology::FACE_RANK);
 
-   // compute ID counts for each sub cell type
-   int patternDim = fp.getDimension();
-   switch(patternDim) {
-   case 3:
-     faceIdCnt = fp.getSubcellIndices(2,0).size();
-     // Intentional fall-through.
-   case 2:
-     edgeIdCnt = fp.getSubcellIndices(1,0).size();
-     // Intentional fall-through.
-   case 1:
-     nodeIdCnt = fp.getSubcellIndices(0,0).size();
-     cellIdCnt = fp.getSubcellIndices(patternDim,0).size();
-     break;
-   case 0:
-   default:
-      TEUCHOS_ASSERT(false);
-   };
+  // compute ID counts for each sub cell type
+  int patternDim = fp.getDimension();
+  switch(patternDim) {
+    case 3:
+      faceIdCnt = fp.getSubcellIndices(2,0).size();
+      // Intentional fall-through.
+    case 2:
+      edgeIdCnt = fp.getSubcellIndices(1,0).size();
+      // Intentional fall-through.
+    case 1:
+      nodeIdCnt = fp.getSubcellIndices(0,0).size();
+      cellIdCnt = fp.getSubcellIndices(patternDim,0).size();
+      break;
+    case 0:
+    default:
+       TEUCHOS_ASSERT(false);
+  };
 
-   // compute offsets for each sub cell type
-   nodeOffset = 0;
-   edgeOffset = nodeOffset+(maxNodeId+1)*nodeIdCnt;
-   faceOffset = edgeOffset+(maxEdgeId+1)*edgeIdCnt;
-   cellOffset = faceOffset+(maxFaceId+1)*faceIdCnt;
+  // compute offsets for each sub cell type
+  nodeOffset = 0;
+  edgeOffset = nodeOffset+(maxNodeId+1)*nodeIdCnt;
+  faceOffset = edgeOffset+(maxEdgeId+1)*edgeIdCnt;
+  cellOffset = faceOffset+(maxFaceId+1)*faceIdCnt;
 
-   // sanity check
-   TEUCHOS_ASSERT(nodeOffset <= edgeOffset
-               && edgeOffset <= faceOffset
-               && faceOffset <= cellOffset);
+  // sanity check
+  TEUCHOS_ASSERT(nodeOffset <= edgeOffset
+              && edgeOffset <= faceOffset
+              && faceOffset <= cellOffset);
 }
 
 STKConnManager::LocalOrdinal
-STKConnManager::addSubcellConnectivities(stk::mesh::Entity element,
-                                         unsigned subcellRank,
-                                         LocalOrdinal idCnt,
-                                         GlobalOrdinal offset)
+STKConnManager::
+addSubcellConnectivities (const stk::mesh::Entity element,
+                          const stk::mesh::EntityRank subcellRank,
+                          const LocalOrdinal idCnt,
+                          const GlobalOrdinal offset)
 {
-   if(idCnt<=0)
-      return 0 ;
+  if(idCnt<=0)
+     return 0;
 
-   // loop over all relations of specified type
-   LocalOrdinal numIds = 0;
-   const stk::mesh::EntityRank rank = static_cast<stk::mesh::EntityRank>(subcellRank);
-   const size_t num_rels = bulkData_->num_connectivity(element, rank);
-   stk::mesh::Entity const* relations = bulkData_->begin(element, rank);
-   for(std::size_t sc=0; sc<num_rels; ++sc) {
-     stk::mesh::Entity subcell = relations[sc];
+  // loop over all relations of specified type
+  LocalOrdinal numIds = 0;
+  const int num_rels = m_bulkData->num_connectivity(element, subcellRank);
+  stk::mesh::Entity const* relations = m_bulkData->begin(element, subcellRank);
+  for(int sc=0; sc<num_rels; ++sc) {
+    stk::mesh::Entity subcell = relations[sc];
+    const auto subcell_id = m_bulkData->identifier(subcell);
 
-     // add connectivities: adjust for STK indexing craziness
-     for(LocalOrdinal i=0;i<idCnt;i++)
-       connectivity_.push_back(offset+idCnt*(bulkData_->identifier(subcell)-1)+i);
-
-     numIds += idCnt;
-   }
-   return numIds;
-}
-
-void
-STKConnManager::modifySubcellConnectivities(const panzer::FieldPattern & fp, stk::mesh::Entity element,
-                                            unsigned subcellRank,unsigned subcellId,GlobalOrdinal newId,
-                                            GlobalOrdinal offset)
-{
-   LocalOrdinal elmtLID = elementLocalId(element);
-   auto * conn = this->getConnectivity(elmtLID);
-   const std::vector<int> & subCellIndices = fp.getSubcellIndices(subcellRank,subcellId);
-
-   // add connectivities: adjust for STK indexing craziness
-   for(std::size_t i=0;i<subCellIndices.size();i++) {
-      conn[subCellIndices[i]] = offset+subCellIndices.size()*(newId-1)+i;
-   }
+    // add connectivities: adjust for STK indexing craziness
+    for (LocalOrdinal i=0; i<idCnt; ++i) {
+      m_connectivity.push_back(offset+idCnt*(subcell_id-1)+i);
+    }
+    numIds += idCnt;
+  }
+  return numIds;
 }
 
 void STKConnManager::buildConnectivity(const panzer::FieldPattern & fp)
@@ -216,149 +161,56 @@ void STKConnManager::buildConnectivity(const panzer::FieldPattern & fp)
   RCP<Teuchos::TimeMonitor> tM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(std::string("panzer_stk::STKConnManager::buildConnectivity"))));
 #endif
 
-   // get element info from STK_Interface
-   // object and build a local element mapping.
-   buildLocalElementMapping();
+  // get element info from STK_Interface
+  // object and build a local element mapping.
+  buildLocalElementMapping();
 
-   // Build sub cell ID counts and offsets
-   //    ID counts = How many IDs belong on each subcell (number of mesh DOF used)
-   //    Offset = What is starting index for subcell ID type?
-   //             Global numbering goes like [node ids, edge ids, face ids, cell ids]
-   LocalOrdinal nodeIdCnt=0, edgeIdCnt=0, faceIdCnt=0, cellIdCnt=0;
-   GlobalOrdinal nodeOffset=0, edgeOffset=0, faceOffset=0, cellOffset=0;
-   buildOffsetsAndIdCounts(fp, nodeIdCnt,  edgeIdCnt,  faceIdCnt,  cellIdCnt,
-                               nodeOffset, edgeOffset, faceOffset, cellOffset);
+  // Build sub cell ID counts and offsets
+  //    ID counts = How many IDs belong on each subcell (number of mesh DOF used)
+  //    Offset = What is starting index for subcell ID type?
+  //             Global numbering goes like [node ids, edge ids, face ids, cell ids]
+  LocalOrdinal nodeIdCnt=0, edgeIdCnt=0, faceIdCnt=0, cellIdCnt=0;
+  GlobalOrdinal nodeOffset=0, edgeOffset=0, faceOffset=0, cellOffset=0;
+  buildOffsetsAndIdCounts(fp, nodeIdCnt,  edgeIdCnt,  faceIdCnt,  cellIdCnt,
+                              nodeOffset, edgeOffset, faceOffset, cellOffset);
 
-    // std::cout << "node: count = " << nodeIdCnt << ", offset = " << nodeOffset << std::endl;
-    // std::cout << "edge: count = " << edgeIdCnt << ", offset = " << edgeOffset << std::endl;
-    // std::cout << "face: count = " << faceIdCnt << ", offset = " << faceOffset << std::endl;
-    // std::cout << "cell: count = " << cellIdCnt << ", offset = " << cellOffset << std::endl;
+  // loop over elements and build global connectivity
+  const int numElems = m_elements.size();
+  constexpr auto NODE_RANK = stk::topology::NODE_RANK;
+  constexpr auto EDGE_RANK = stk::topology::EDGE_RANK;
+  constexpr auto FACE_RANK = stk::topology::FACE_RANK;
+  for (int ielem=0; ielem<numElems; ++ielem) {
+     GlobalOrdinal numIds = 0;
+     stk::mesh::Entity element = m_elements[ielem];
 
-   // loop over elements and build global connectivity
-   for(std::size_t elmtLid=0;elmtLid!=elements_->size();++elmtLid) {
-      GlobalOrdinal numIds = 0;
-      stk::mesh::Entity element = (*elements_)[elmtLid];
+     // Current size of m_connectivity is the offset for this element
+     m_elmtLidToConn[ielem] = m_connectivity.size();
 
-      // get index into connectivity array
-      elmtLidToConn_[elmtLid] = connectivity_.size();
+     // add connecviities for sub cells
+     numIds += addSubcellConnectivities(element,NODE_RANK,nodeIdCnt,nodeOffset);
+     numIds += addSubcellConnectivities(element,EDGE_RANK,edgeIdCnt,edgeOffset);
+     numIds += addSubcellConnectivities(element,FACE_RANK,faceIdCnt,faceOffset);
 
-      // add connecviities for sub cells
-      numIds += addSubcellConnectivities(element,getNodeRank(),nodeIdCnt,nodeOffset);
-      numIds += addSubcellConnectivities(element,getEdgeRank(),edgeIdCnt,edgeOffset);
-      numIds += addSubcellConnectivities(element,getFaceRank(),faceIdCnt,faceOffset);
+     // add connectivity for parent cells
+     if(cellIdCnt>0) {
+        // add connectivities: adjust for STK indexing craziness
+        const auto cell_id = m_bulkData->identifier(element);
+        for(LocalOrdinal i=0; i<cellIdCnt; ++i) {
+           m_connectivity.push_back(cellOffset+cellIdCnt*(cell_id-1));
+        }
+        numIds += cellIdCnt;
+     }
 
-      // add connectivity for parent cells
-      if(cellIdCnt>0) {
-         // add connectivities: adjust for STK indexing craziness
-         for(LocalOrdinal i=0;i<cellIdCnt;i++)
-            connectivity_.push_back(cellOffset+cellIdCnt*(bulkData_->identifier(element)-1));
-
-         numIds += cellIdCnt;
-      }
-
-      connSize_[elmtLid] = numIds;
-   }
-
-//   applyPeriodicBCs( fp, nodeOffset, edgeOffset, faceOffset, cellOffset);
-
-   // This method does not modify connectivity_. But it should be called here
-   // because the data it initializes should be available at the same time as
-   // connectivity_.
-   if (hasAssociatedNeighbors())
-     applyInterfaceConditions();
+     m_connSize[ielem] = numIds;
+  }
 }
 
-std::string STKConnManager::getBlockId(STKConnManager::LocalOrdinal localElmtId) const
+std::string STKConnManager::getBlockId (LocalOrdinal localElmtId) const
 {
    // walk through the element blocks and figure out which this ID belongs to
-   stk::mesh::Entity element = (*elements_)[localElmtId];
+   stk::mesh::Entity element = m_elements[localElmtId];
 
    return containingBlockId(element);
-}
-
-#if 0
-void STKConnManager::applyPeriodicBCs(const panzer::FieldPattern & fp, GlobalOrdinal nodeOffset, GlobalOrdinal edgeOffset,
-                                      GlobalOrdinal faceOffset, GlobalOrdinal /* cellOffset */)
-{
-   using Teuchos::RCP;
-   using Teuchos::rcp;
-
-#ifdef HAVE_EXTRA_TIMERS
-  using Teuchos::TimeMonitor;
-  RCP<Teuchos::TimeMonitor> tM = rcp(new TimeMonitor(*TimeMonitor::getNewTimer(std::string("panzer_stk::STKConnManager::applyPeriodicBCs"))));
-#endif
-
-   std::pair<Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > >, Teuchos::RCP<std::vector<unsigned int> > > matchedValues
-            = getPeriodicNodePairing();
-
-   Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > > matchedNodes
-            = matchedValues.first;
-   Teuchos::RCP<std::vector<unsigned int> > matchTypes
-            = matchedValues.second;
-
-   // no matchedNodes means nothing to do!
-   if(matchedNodes==Teuchos::null) return;
-
-   for(std::size_t m=0;m<matchedNodes->size();m++) {
-      stk::mesh::EntityId oldNodeId = (*matchedNodes)[m].first;
-      std::size_t newNodeId = (*matchedNodes)[m].second;
-
-      std::vector<stk::mesh::Entity> elements;
-      std::vector<int> localIds;
-
-      GlobalOrdinal offset0 = 0; // to make numbering consistent with that in PeriodicBC_Matcher
-      GlobalOrdinal offset1 = 0; // offset for dof indexing
-      if((*matchTypes)[m] == 0)
-        offset1 = nodeOffset-offset0;
-      else if((*matchTypes)[m] == 1){
-        offset0 = getMaxEntityId(getNodeRank());
-        offset1 = edgeOffset-offset0;
-      } else if((*matchTypes)[m] == 2){
-        offset0 = getMaxEntityId(getNodeRank())+getMaxEntityId(getEdgeRank());
-        offset1 = faceOffset-offset0;
-      } else
-        TEUCHOS_ASSERT(false);
-
-      // get relevent elements and node IDs
-      getOwnedElementsSharingNode(oldNodeId-offset0,elements,localIds,(*matchTypes)[m]);
-
-      // modify global numbering already built for each element
-      for(std::size_t e=0;e<elements.size();e++){
-         modifySubcellConnectivities(fp,elements[e],(*matchTypes)[m],localIds[e],newNodeId,offset1);
-      }
-
-   }
-}
-#endif
-
-/** Get the coordinates for a specified element block and field pattern.
-  */
-void STKConnManager::getDofCoords(const std::string & blockId,
-                                  const panzer::Intrepid2FieldPattern & coordProvider,
-                                  std::vector<std::size_t> & localCellIds,
-                                  Kokkos::DynRankView<double,PHX::Device> & points) const
-{
-   int dim = coordProvider.getDimension();
-   int numIds = coordProvider.numberIds();
-
-   // grab element vertices
-   Kokkos::DynRankView<double,PHX::Device> vertices;
-   getIdsAndVertices<Kokkos::DynRankView<double, PHX::Device> >(blockId, localCellIds, vertices);
-
-   // setup output array
-   points = Kokkos::DynRankView<double,PHX::Device>("points",localCellIds.size(),numIds,dim);
-   coordProvider.getInterpolatoryCoordinates(vertices,points);
-}
-
-bool STKConnManager::hasAssociatedNeighbors() const
-{
-  return ! sidesetsToAssociate_.empty();
-}
-
-void STKConnManager::associateElementsInSideset(const std::string sideset_id)
-{
-  sidesetsToAssociate_.push_back(sideset_id);
-  sidesetYieldedAssociations_.push_back(false);
 }
 
 inline std::size_t
@@ -369,410 +221,123 @@ getElementIdx(const std::vector<stk::mesh::Entity>& elements,
     std::distance(elements.begin(), std::find(elements.begin(), elements.end(), e)));
 }
 
-void STKConnManager::applyInterfaceConditions()
-{
-  elmtToAssociatedElmts_.resize(elements_->size());
-  for (std::size_t i = 0; i < sidesetsToAssociate_.size(); ++i) {
-    std::vector<stk::mesh::Entity> sides;
-    getAllSides(sidesetsToAssociate_[i], sides);
-    sidesetYieldedAssociations_[i] = ! sides.empty();
-    for (std::vector<stk::mesh::Entity>::const_iterator si = sides.begin();
-         si != sides.end(); ++si) {
-      stk::mesh::Entity side = *si;
-      const size_t num_elements = bulkData_->num_elements(side);
-      stk::mesh::Entity const* elements = bulkData_->begin_elements(side);
-      if (num_elements != 2) {
-        // If relations.size() != 2 for one side in the sideset, then it's true
-        // for all, including the first.
-        TEUCHOS_ASSERT(si == sides.begin());
-        sidesetYieldedAssociations_[i] = false;
-        break;
-      }
-      const std::size_t ea_id = getElementIdx(*elements_, elements[0]),
-        eb_id = getElementIdx(*elements_, elements[1]);
-      elmtToAssociatedElmts_[ea_id].push_back(eb_id);
-      elmtToAssociatedElmts_[eb_id].push_back(ea_id);
-    }
-  }
-}
-
-std::size_t STKConnManager::
-get_parent_cell_id(stk::mesh::Entity side) const
-{
-   stk::mesh::Entity const* elements = bulkData_->begin_elements(side);
-   const std::size_t ea_id = getElementIdx(*elements_, elements[0]);
-   return ea_id;
-}
-
-std::vector<std::string> STKConnManager::
-checkAssociateElementsInSidesets(const Teuchos::Comm<int>& comm) const
-{
-  std::vector<std::string> sidesets;
-  for (std::size_t i = 0; i < sidesetYieldedAssociations_.size(); ++i) {
-    int sya, my_sya = sidesetYieldedAssociations_[i] ? 1 : 0;
-    Teuchos::reduceAll(comm, Teuchos::REDUCE_MAX, 1, &my_sya, &sya);
-    if (sya == 0)
-      sidesets.push_back(sidesetsToAssociate_[i]);
-  }
-  return sidesets;
-}
-
 const std::vector<STKConnManager::LocalOrdinal>&
-STKConnManager::getAssociatedNeighbors(const LocalOrdinal& el) const
+STKConnManager::getAssociatedNeighbors(const LocalOrdinal& /* el */) const
 {
-  return elmtToAssociatedElmts_[el];
-}
+  TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
+      "Error! Albany does not use elements halos in the mesh, so the method\n"
+      "       'STKConnManager::getAssociatedNeighbors' should not have been called.\n");
 
-void STKConnManager::buildEntityCounts()
-{
-   entityCounts_.clear();
-   stk::mesh::comm_mesh_counts(*bulkData_,entityCounts_);
+  static std::vector<LocalOrdinal> ret;
+  return ret;
 }
 
 void STKConnManager::buildMaxEntityIds() {
-
-      // developed to mirror "comm_mesh_counts" in stk_mesh/base/Comm.cpp
-   
-      const auto entityRankCount =  metaData_->entity_rank_count();
-      const size_t   commCount        = 10; // entityRankCount
-   
-      TEUCHOS_ASSERT(entityRankCount<10);
-   
-      stk::ParallelMachine mach = bulkData_->parallel();
-//      stk::ParallelMachine mach = stkDisc_*mpiComm_->getRawMpiComm();
-      procRank_ = stk::parallel_machine_rank(mach);
-   
-      std::vector<stk::mesh::EntityId> local(commCount,0);
-   
-      // determine maximum ID for this processor for each entity type
-      stk::mesh::Selector ownedPart = metaData_->locally_owned_part();
-      for(stk::mesh::EntityRank i=stk::topology::NODE_RANK;
-          i < static_cast<stk::mesh::EntityRank>(entityRankCount); ++i) {
-         std::vector<stk::mesh::Entity> entities;
-   
-         stk::mesh::get_selected_entities(ownedPart, bulkData_->buckets(i), entities);
-   
-         // determine maximum ID for this processor
-         std::vector<stk::mesh::Entity>::const_iterator itr;
-         for(itr=entities.begin();itr!=entities.end();++itr) {
-            stk::mesh::EntityId id = bulkData_->identifier(*itr);
-            if(id>local[i])
-               local[i] = id;
-         }
-      }
-   
-      // get largest IDs across processors
-      stk::all_reduce(mach,stk::ReduceMax<10>(&local[0]));
-      maxEntityId_.assign(local.begin(),local.begin()+entityRankCount+1);
+  // developed to mirror "comm_mesh_counts" in stk_mesh/base/Comm.cpp
+  const auto entityRankCount = m_metaData->entity_rank_count();
+  
+  stk::ParallelMachine mach = m_bulkData->parallel();
+  // procRank_ = stk::parallel_machine_rank(mach);
+  
+  std::vector<stk::mesh::EntityId> local(entityRankCount,0);
+  m_maxEntityId.resize(entityRankCount);
+  
+  // determine maximum ID for this processor for each entity type
+  stk::mesh::Selector ownedPart = m_metaData->locally_owned_part();
+  for (auto rank=stk::topology::NODE_RANK; rank<entityRankCount; ++rank) {
+    std::vector<stk::mesh::Entity> entities;
+  
+    stk::mesh::get_selected_entities(ownedPart, m_bulkData->buckets(rank), entities);
+  
+    // determine maximum ID for this processor
+    for (const auto& entity : entities) {
+      stk::mesh::EntityId id = m_bulkData->identifier(entity);
+      local[rank] = std::max(local[rank],id);
+    }
+  }
+  
+  // get largest IDs across processors
+  stk::all_reduce_max(mach,local.data(),m_maxEntityId.data(),entityRankCount);
 }
 
-
-std::size_t STKConnManager::elementLocalId(stk::mesh::Entity elmt) const
+int STKConnManager::elementLocalId(stk::mesh::Entity elmt) const
 {
-   return elementLocalId(bulkData_->identifier(elmt));
-   // const std::size_t * fieldCoords = stk::mesh::field_data(*localIdField_,*elmt);
-   // return fieldCoords[0];
+  return elementLocalId(m_bulkData->identifier(elmt));
 }
 
-std::size_t STKConnManager::elementLocalId(stk::mesh::EntityId gid) const
+int STKConnManager::elementLocalId(stk::mesh::EntityId gid) const
 {
-   // stk::mesh::EntityRank elementRank = getElementRank();
-   // stk::mesh::Entity elmt = bulkData_->get_entity(elementRank,gid);
-   // TEUCHOS_ASSERT(elmt->owner_rank()==procRank_);
-   // return elementLocalId(elmt);
-   std::unordered_map<stk::mesh::EntityId,std::size_t>::const_iterator itr = localIDHash_.find(gid);
-   TEUCHOS_ASSERT(itr!=localIDHash_.end());
-   return itr->second;
+  auto it = m_localIDHash.find(gid);
+  TEUCHOS_ASSERT(it!=m_localIDHash.end());
+  return it->second;
 }
 
 void STKConnManager::getMyElements(std::vector<stk::mesh::Entity> & elements) const
 {
-   // setup local ownership
-   stk::mesh::Selector ownedPart = metaData_->locally_owned_part();
+  // setup local ownership
+  stk::mesh::Selector ownedPart = m_metaData->locally_owned_part();
 
-   // grab elements
-   stk::mesh::EntityRank elementRank = getElementRank();
-   stk::mesh::get_selected_entities(ownedPart, bulkData_->buckets(elementRank), elements);
+  // grab elements
+  constexpr auto ELEM_RANK = stk::topology::ELEMENT_RANK;
+  stk::mesh::get_selected_entities(ownedPart, m_bulkData->buckets(ELEM_RANK), elements);
 }
 
-void STKConnManager::getMyElements(const std::string & blockID,std::vector<stk::mesh::Entity> & elements) const
+void STKConnManager::
+getMyElements (const std::string & blockID,
+               std::vector<stk::mesh::Entity> & elements) const
 {
-   stk::mesh::Part * elementBlock = getElementBlockPart(blockID);
+  stk::mesh::Part * elementBlock = getElementBlockPart(blockID);
 
-   TEUCHOS_TEST_FOR_EXCEPTION(elementBlock==0,std::logic_error,"Could not find element block \"" << blockID << "\"");
+  TEUCHOS_TEST_FOR_EXCEPTION(elementBlock==0,std::logic_error,
+      "Could not find element block \"" << blockID << "\"");
 
-   // setup local ownership
-   // stk::mesh::Selector block = *elementBlock;
-   stk::mesh::Selector ownedBlock = metaData_->locally_owned_part() & (*elementBlock);
+  // setup local ownership
+  stk::mesh::Selector ownedBlock = m_metaData->locally_owned_part() & (*elementBlock);
 
-   // grab elements
-   stk::mesh::EntityRank elementRank = getElementRank();
-   stk::mesh::get_selected_entities(ownedBlock, bulkData_->buckets(elementRank), elements);
+  // grab elements
+  constexpr auto ELEM_RANK = stk::topology::ELEMENT_RANK;
+  stk::mesh::get_selected_entities(ownedBlock, m_bulkData->buckets(ELEM_RANK), elements);
 }
 
-void STKConnManager::getNeighborElements(std::vector<stk::mesh::Entity> & elements) const
+stk::mesh::Part * STKConnManager::
+getElementBlockPart(const std::string & name) const
 {
-   // setup local ownership
-   stk::mesh::Selector neighborBlock = (!metaData_->locally_owned_part());
-
-   // grab elements
-   stk::mesh::EntityRank elementRank = getElementRank();
-   stk::mesh::get_selected_entities(neighborBlock, bulkData_->buckets(elementRank), elements);
+  auto it = m_stkMeshStruct->elementBlockParts_.find(name);
+  if(it==m_stkMeshStruct->elementBlockParts_.end()) return 0;
+  return it->second;
 }
 
-void STKConnManager::getNeighborElements(const std::string & blockID,std::vector<stk::mesh::Entity> & elements) const
+stk::mesh::EntityId STKConnManager::
+getMaxEntityId (const stk::mesh::EntityRank entityRank) const
 {
-   stk::mesh::Part * elementBlock = getElementBlockPart(blockID);
+  TEUCHOS_TEST_FOR_EXCEPTION (entityRank>=m_maxEntityId.size(),std::logic_error,
+      "[STKConnManager::getMaxEntityId] Invalid entity rank: " << entityRank << "\n");
 
-   TEUCHOS_TEST_FOR_EXCEPTION(elementBlock==0,std::logic_error,"Could not find element block \"" << blockID << "\"");
-
-   // setup local ownership
-   stk::mesh::Selector neighborBlock = (!metaData_->locally_owned_part()) & (*elementBlock);
-
-   // grab elements
-   stk::mesh::EntityRank elementRank = getElementRank();
-   stk::mesh::get_selected_entities(neighborBlock, bulkData_->buckets(elementRank), elements);
-}
-
-std::size_t STKConnManager::getEntityCounts(unsigned entityRank) const
-{
-   TEUCHOS_TEST_FOR_EXCEPTION(entityRank>=entityCounts_.size(),std::logic_error,
-                      "STKCOnnManager::getEntityCounts: Entity counts do not include rank: " << entityRank);
-
-   return entityCounts_[entityRank];
-}
-
-stk::mesh::EntityId STKConnManager::getMaxEntityId(unsigned entityRank) const
-{
-   TEUCHOS_TEST_FOR_EXCEPTION(entityRank>=maxEntityId_.size(),std::logic_error,
-                      "STK_Interface::getMaxEntityId: Max entity ids do not include rank: " << entityRank);
-
-   return maxEntityId_[entityRank];
+  return m_maxEntityId[entityRank];
 }
 
 std::string STKConnManager::containingBlockId(stk::mesh::Entity elmt) const
 {
-   for(const auto & eb_pair : stkMeshStruct_->elementBlockParts_)
-      if(bulkData_->bucket(elmt).member(*(eb_pair.second)))
-         return eb_pair.first;
-   return "";
-}
-
-#if 0
-std::pair<Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > >, Teuchos::RCP<std::vector<unsigned int> > >
-STKConnManager::getPeriodicNodePairing() const
-{
-   Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > > vec;
-   Teuchos::RCP<std::vector<unsigned int > > type_vec = rcp(new std::vector<unsigned int>);
-   const std::vector<Teuchos::RCP<const PeriodicBC_MatcherBase> > & matchers = getPeriodicBCVector();
-
-   // build up the vectors by looping over the matched pair
-   for(std::size_t m=0;m<matchers.size();m++){
-      vec = matchers[m]->getMatchedPair(*this,vec);
-      unsigned int type;
-      if(matchers[m]->getType() == "coord")
-        type = 0;
-      else if(matchers[m]->getType() == "edge")
-        type = 1;
-      else if(matchers[m]->getType() == "face")
-        type = 2;
-      else
-        TEUCHOS_ASSERT(false);
-      type_vec->insert(type_vec->begin(),vec->size()-type_vec->size(),type);
-   }
-
-   return std::make_pair(vec,type_vec);
-
-}
-#endif
-
-void STKConnManager::getOwnedElementsSharingNode(stk::mesh::Entity node,std::vector<stk::mesh::Entity> & elements,
-                                                std::vector<int> & relIds) const
-{
-   // get all relations for node
-   const size_t numElements = bulkData_->num_elements(node);
-   stk::mesh::Entity const* relations = bulkData_->begin_elements(node);
-   stk::mesh::ConnectivityOrdinal const* rel_ids = bulkData_->begin_element_ordinals(node);
-
-   // extract elements sharing nodes
-   for (size_t i = 0; i < numElements; ++i) {
-      stk::mesh::Entity element = relations[i];
-
-     // if owned by this processor
-      if(bulkData_->parallel_owner_rank(element) == static_cast<int>(procRank_)) {
-         elements.push_back(element);
-         relIds.push_back(rel_ids[i]);
-      }
-   }
-}
-
-#if 0
-void STKConnManager::getOwnedElementsSharingNode(stk::mesh::EntityId nodeId,std::vector<stk::mesh::Entity> & elements,
-                                                                           std::vector<int> & relIds, unsigned int matchType) const
-{
-   stk::mesh::EntityRank rank;
-   if(matchType == 0)
-     rank = getNodeRank();
-   else if(matchType == 1)
-     rank = getEdgeRank();
-   else if(matchType == 2)
-     rank = getFaceRank();
-   else
-     TEUCHOS_ASSERT(false);
-
-   stk::mesh::Entity node = bulkData_->get_entity(rank,nodeId);
-
-   getOwnedElementsSharingNode(node,elements,relIds);
-}
-#endif
-
-template<typename ArrayT>
-void STKConnManager::getIdsAndVertices(
-			 std::string blockId,
-			 std::vector<std::size_t>& localIds,
-			 ArrayT & vertices) const {
-  
-  std::vector<stk::mesh::Entity> elements;
-  getMyElements(blockId,elements);
-  
-  // loop over elements of this block
-  for(std::size_t elm=0;elm<elements.size();++elm) {
-    stk::mesh::Entity element = elements[elm];
-    
-    localIds.push_back(elementLocalId(element));
+  for(const auto & eb_pair : m_stkMeshStruct->elementBlockParts_) {
+    if(m_bulkData->bucket(elmt).member(*(eb_pair.second))) {
+      return eb_pair.first;
+    }
   }
-
-  // get vertices (this is slightly faster then the local id version)
-  getElementVertices(elements,blockId,vertices);
-}
-
-void STKConnManager::getAllSides(const std::string & sideName,std::vector<stk::mesh::Entity> & sides) const
-{
-   stk::mesh::Part * sidePart = getSideset(sideName);
-   TEUCHOS_TEST_FOR_EXCEPTION(sidePart==0,std::logic_error,
-                      "Unknown side set \"" << sideName << "\"");
-
-   stk::mesh::Selector side = *sidePart;
-
-   // grab elements
-   stk::mesh::get_selected_entities(side, bulkData_->buckets(getSideRank()), sides);
-}
-
-void STKConnManager::getAllSides(const std::string & sideName,const std::string & blockName,std::vector<stk::mesh::Entity> & sides) const
-{
-   stk::mesh::Part * sidePart = getSideset(sideName);
-   stk::mesh::Part * elmtPart = getElementBlockPart(blockName);
-   TEUCHOS_TEST_FOR_EXCEPTION(sidePart==0,SidesetException,
-                      "Unknown side set \"" << sideName << "\"");
-   TEUCHOS_TEST_FOR_EXCEPTION(elmtPart==0,ElementBlockException,
-                      "Unknown element block \"" << blockName << "\"");
-
-   stk::mesh::Selector side = *sidePart;
-   stk::mesh::Selector block = *elmtPart;
-   stk::mesh::Selector sideBlock = block & side;
-
-   // grab elements
-   stk::mesh::get_selected_entities(sideBlock, bulkData_->buckets(getSideRank()), sides);
-}
-
-Teuchos::RCP<const std::vector<stk::mesh::Entity> > 
-STKConnManager::getElementsOrderedByLID() const
-{
-   using Teuchos::RCP;
-   using Teuchos::rcp;
-
-   if(orderedElementVector_==Teuchos::null) {
-      // safe because essentially this is a call to modify a mutable object
-      //const_cast<STK_Interface*>(this)->buildLocalElementIDs();
-      const_cast<STKConnManager*>(this)->buildLocalElementIDs();
-      //buildLocalElementIDs();
-   }
-
-   return orderedElementVector_.getConst();
+  return "";
 }
 
 void STKConnManager::buildLocalElementIDs()
 {
-   currentLocalId_ = 0;
+  int currentLocalId = 0;
 
-   orderedElementVector_ = Teuchos::null; // forces rebuild of ordered lists
+  // might be better (faster) to do this by buckets
+  std::vector<stk::mesh::Entity> elements;
+  getMyElements(elements);
 
-   // might be better (faster) to do this by buckets
-   std::vector<stk::mesh::Entity> elements;
-   getMyElements(elements);
-
-   for(std::size_t index=0;index<elements.size();++index) {
-      stk::mesh::Entity element = elements[index];
-
-//GAH
-      // set processor rank
-//      ProcIdData * procId = stk::mesh::field_data(*processorIdField_,element);
-//      procId[0] = Teuchos::as<ProcIdData>(procRank_);
-
-      localIDHash_[bulkData_->identifier(element)] = currentLocalId_;
-
-      currentLocalId_++;
-   }
-
-   // copy elements into the ordered element vector
-   orderedElementVector_ = Teuchos::rcp(new std::vector<stk::mesh::Entity>(elements));
-
-   elements.clear();
-   getNeighborElements(elements);
-
-   for(std::size_t index=0;index<elements.size();++index) {
-      stk::mesh::Entity element = elements[index];
-
-//GAH
-      // set processor rank
-//      ProcIdData * procId = stk::mesh::field_data(*processorIdField_,element);
-//      procId[0] = Teuchos::as<ProcIdData>(procRank_);
-
-      localIDHash_[bulkData_->identifier(element)] = currentLocalId_;
-
-      currentLocalId_++;
-   }
-
-   orderedElementVector_->insert(orderedElementVector_->end(),elements.begin(),elements.end());
+  for (auto element : elements) {
+    m_localIDHash[m_bulkData->identifier(element)] = currentLocalId;
+    ++currentLocalId;
+  }
 }
 
-const double * STKConnManager::getNodeCoordinates(stk::mesh::Entity node) const
-{
-   return stk::mesh::field_data(*coordinatesField_,node);
-}
-
-stk::mesh::Field<double> * STKConnManager::getSolutionField(const std::string & fieldName,
-                                                           const std::string & blockId) const
-{
-   // look up field in map
-   std::map<std::pair<std::string,std::string>, SolutionFieldType*>::const_iterator
-         iter = fieldNameToSolution_.find(std::make_pair(fieldName,blockId));
-
-   // check to make sure field was actually found
-   TEUCHOS_TEST_FOR_EXCEPTION(iter==fieldNameToSolution_.end(),std::runtime_error,
-                      "Solution field name \"" << fieldName << "\" in block ID \"" << blockId << "\" was not found");
-
-   return iter->second;
-}
-
-/* This is done in IOSSSTKMeshStruct now
-void STKConnManager::addElementBlock(const std::string & name,const CellTopologyData * ctData)
-{
-
-   stk::mesh::Part * block = metaData_->get_part(name);
-   if(block==0) {
-     block = &metaData_->declare_part_with_topology(name, stk::mesh::get_topology(shards::CellTopology(ctData), dimension_));
-   }
-
-   // construct cell topology object for this block
-   Teuchos::RCP<shards::CellTopology> ct
-         = Teuchos::rcp(new shards::CellTopology(ctData));
-
-   // add element block part and cell topology
-   stkMeshStruct_->elementBlockParts_.insert(std::make_pair(name,block));
-   stkMeshStruct_->elementBlockCT_.insert(std::make_pair(name,ct));
-}
-*/
-
-
-}
+} // namespace Albany

--- a/src/disc/stk/STKConnManager.hpp
+++ b/src/disc/stk/STKConnManager.hpp
@@ -4,625 +4,203 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifndef __Albany_STKConnManager_hpp__
-#define __Albany_STKConnManager_hpp__
-
-#include <vector>
-
-// Teuchos includes
-#include "Teuchos_RCP.hpp"
-
-// >Kokkos includes
-#include "Kokkos_DynRankView.hpp"
-#include "Kokkos_ViewFactory.hpp"
-
-// Panzer includes
-#include "Panzer_ConnManager.hpp"
+#ifndef ALBANY_STK_CONN_MANAGER_HPP
+#define ALBANY_STK_CONN_MANAGER_HPP
 
 #include "Albany_AbstractSTKMeshStruct.hpp"
-#include "Panzer_IntrepidFieldPattern.hpp"
+
+#include "Panzer_ConnManager.hpp"
+#include "Teuchos_RCP.hpp"
+
+#include <vector>
 
 namespace Albany {
 
 class STKConnManager : public panzer::ConnManager {
 public:
-   typedef typename panzer::ConnManager::LocalOrdinal LocalOrdinal;
-   typedef typename panzer::ConnManager::GlobalOrdinal GlobalOrdinal;
+  using LocalOrdinal  = typename panzer::ConnManager::LocalOrdinal;
+  using GlobalOrdinal = typename panzer::ConnManager::GlobalOrdinal;
 
-   typedef double ProcIdData;
-   typedef stk::mesh::Field<double> SolutionFieldType;
-   typedef stk::mesh::Field<ProcIdData> ProcIdFieldType;
-   typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
+  typedef double ProcIdData;
+  typedef stk::mesh::Field<double> SolutionFieldType;
+  typedef stk::mesh::Field<ProcIdData> ProcIdFieldType;
+  typedef stk::mesh::Field<double,stk::mesh::Cartesian> VectorFieldType;
 
-   // some simple exception classes
-   struct ElementBlockException : public std::logic_error
-   { ElementBlockException(const std::string & what) : std::logic_error(what) {} };
+  STKConnManager(const Teuchos::RCP<const AbstractSTKMeshStruct>& stkMeshStruct);
 
-   struct SidesetException : public std::logic_error
-   { SidesetException(const std::string & what) : std::logic_error(what) {} };
+  ~STKConnManager() = default;
 
-   STKConnManager(const Teuchos::RCP<AbstractSTKMeshStruct>& absMeshStruct);
-
-   virtual ~STKConnManager() {}
-
-   /** Tell the connection manager to build the connectivity assuming
-     * a particular field pattern.
-     *
-     * \param[in] fp Field pattern to build connectivity for
-     */
-   virtual void buildConnectivity(const panzer::FieldPattern & fp);
-
-   /** Build a clone of this connection manager, without any assumptions
-     * about the required connectivity (e.g. <code>buildConnectivity</code>
-     * has never been called).
-     */
-   virtual Teuchos::RCP<panzer::ConnManager> noConnectivityClone() const;
-
-   /** Add an element block with a string name
-     */
-//   void addElementBlock(const std::string & name,const CellTopologyData * ctData);
-
-   /** Get ID connectivity for a particular element
-     *
-     * \param[in] localElmtId Local element ID
-     *
-     * \returns Pointer to beginning of indices, with total size
-     *          equal to <code>getConnectivitySize(localElmtId)</code>
-     */
-   virtual const panzer::GlobalOrdinal * getConnectivity(LocalOrdinal localElmtId) const
-   { return &connectivity_[elmtLidToConn_[localElmtId]]; }
-
-   /** Get ID connectivity for a particular element
-     *
-     * \param[in] localElmtId Local element ID
-     *
-     * \returns Pointer to beginning of indices, with total size
-     *          equal to <code>getConnectivitySize(localElmtId)</code>
-     */
-   virtual panzer::GlobalOrdinal * getConnectivity(LocalOrdinal localElmtId)
-   { return &connectivity_[elmtLidToConn_[localElmtId]]; }
-
-   /** How many mesh IDs are associated with this element?
-     *
-     * \param[in] localElmtId Local element ID
-     *
-     * \returns Number of mesh IDs that are associated with this element.
-     */
-   virtual LocalOrdinal getConnectivitySize(LocalOrdinal localElmtId) const
-   { return connSize_[localElmtId]; }
-
-   /** Get the block ID for a particular element.
-     *
-     * \param[in] localElmtId Local element ID
-     */
-   virtual std::string getBlockId(LocalOrdinal localElmtId) const;
-
-   /** How many element blocks in this mesh?
-     */
-   virtual std::size_t numElementBlocks() const
-   { return stkMeshStruct_->ebNames_.size(); }
-
-   /** Get block IDs from STK mesh object
-     */
-   virtual void getElementBlockIds(std::vector<std::string> & elementBlockIds) const {
-
-// Why is this different than stkDisc_->getElementBlockNames(blockIds);
-
-        elementBlockIds.clear();
-		for(std::size_t i = 0; i < stkMeshStruct_->ebNames_.size(); i++)
-
-          elementBlockIds.push_back(stkMeshStruct_->ebNames_[i]);
-   }
-
-   virtual void getElementBlockNames(std::vector<std::string> & elementBlockIds) const {
-
-// Why is this different than stkDisc_->getElementBlockNames(blockIds);
-
-        elementBlockIds.clear();
-		for(std::size_t i = 0; i < stkMeshStruct_->ebNames_.size(); i++)
-
-          elementBlockIds.push_back(stkMeshStruct_->ebNames_[i]);
-   }
-      
-   /** What are the cellTopologies linked to element blocks in this connection manager?
+  /** Tell the connection manager to build the connectivity assuming
+    * a particular field pattern.
+    *
+    * \param[in] fp Field pattern to build connectivity for
     */
-   virtual void getElementBlockTopologies(std::vector<shards::CellTopology> & elementBlockTopologies) const {
+  void buildConnectivity(const panzer::FieldPattern & fp) override;
 
-        elementBlockTopologies.clear();
-		for(std::size_t i = 0; i < stkMeshStruct_->ebNames_.size(); i++)
+  /** Build a clone of this connection manager, without any assumptions
+    * about the required connectivity (e.g. <code>buildConnectivity</code>
+    * has never been called).
+    */
+  Teuchos::RCP<panzer::ConnManager> noConnectivityClone() const override;
 
-          elementBlockTopologies.push_back(stkMeshStruct_->elementBlockTopologies_[i]);
-   }
-   /** Get the local element IDs for a paricular element
-     * block. These are only the owned element ids.
-     *
-     * \param[in] blockIndex Block Index
-     *
-     * \returns Vector of local element IDs.
-     */
-   virtual const std::vector<LocalOrdinal> & getElementBlock(const std::string & blockId) const
-   { return *(elementBlocks_.find(blockId)->second); }
+  /** Get ID connectivity for a particular element
+    *
+    * \param[in] localElmtId Local element ID
+    *
+    * \returns Pointer to beginning of indices, with total size
+    *          equal to <code>getConnectivitySize(localElmtId)</code>
+    */
+  const GlobalOrdinal * getConnectivity(LocalOrdinal localElmtId) const override {
+    return &m_connectivity[m_elmtLidToConn[localElmtId]];
+  }
 
-   /** Get the local element IDs for a paricular element
-     * block. These element ids are not owned, and the element
-     * will live on another processor.
-     *
-     * \param[in] blockIndex Block Index
-     *
-     * \returns Vector of local element IDs.
-     */
-   virtual const std::vector<LocalOrdinal> & getNeighborElementBlock(const std::string & blockId) const
-   { return *(neighborElementBlocks_.find(blockId)->second); }
+  /** How many mesh IDs are associated with this element?
+    *
+    * \param[in] localElmtId Local element ID
+    *
+    * \returns Number of mesh IDs that are associated with this element.
+    */
+  LocalOrdinal getConnectivitySize(LocalOrdinal localElmtId) const override {
+    return m_connSize[localElmtId];
+  }
 
-   /** Get the coordinates (with local cell ids) for a specified element block and field pattern.
-     *
-     * \param[in] blockId Block containing the cells
-     * \param[in] coordProvider Field pattern that builds the coordinates
-     * \param[out] localCellIds Local cell Ids (indices)
-     * \param[out] Resizable field container that contains the coordinates
-     *             of the points on exit.
-     */
-   virtual void getDofCoords(const std::string & blockId,
-                             const panzer::Intrepid2FieldPattern & coordProvider,
-                             std::vector<std::size_t> & localCellIds,
-                             Kokkos::DynRankView<double,PHX::Device> & points) const;
+  /** Get the block ID for a particular element.
+    *
+    * \param[in] localElmtId Local element ID
+    */
+  std::string getBlockId(LocalOrdinal localElmtId) const override;
 
-    /** How many elements are owned by this processor. Further,
-      * the ordering of the local ids is suct that the first
-      * <code>getOwnedElementCount()</code> elements are owned
-      * by this processor. This is true only because of the
-      * local element ids generated by the <code>STK_Interface</code>
-      * object.
-      */
-    std::size_t getOwnedElementCount() const
-    { return ownedElementCount_; }
+  /** How many element blocks in this mesh?
+    */
+  std::size_t numElementBlocks() const override {
+    return m_stkMeshStruct->ebNames_.size();
+  }
 
-    /** Before calling buildConnectivity, provide sideset IDs from which to
-      * extract associated elements.
-      */
-    void associateElementsInSideset(const std::string sideset_id);
+  /** Get block IDs from STK mesh object
+    */
+  void getElementBlockIds(std::vector<std::string> & elementBlockIds) const override {
+    elementBlockIds = m_stkMeshStruct->ebNames_;
+  }
 
-    /** After calling <code>buildConnectivity</code>, optionally check which
-      * sidesets yielded no element associations in this communicator. This is a
-      * parallel operation. In many applications, the outcome indicating
-      * correctness is that the returned vector is empty.
-      */
-    std::vector<std::string> checkAssociateElementsInSidesets(const Teuchos::Comm<int>& comm) const;
-
-    /** Get elements, if any, associated with <code>el</code>, excluding
-      * <code>el</code> itself.
-      */
-    virtual const std::vector<LocalOrdinal>& getAssociatedNeighbors(const LocalOrdinal& el) const;
-
-    /** Return whether getAssociatedNeighbors will return true for at least one
-      * input. Default implementation returns false.
-      */
-    virtual bool hasAssociatedNeighbors() const;
-
-   std::size_t elementLocalId(stk::mesh::Entity elmt) const;
-
-   std::size_t elementLocalId(stk::mesh::EntityId gid) const;
-
-   void getMyElements(std::vector<stk::mesh::Entity> & elements) const;
-
-   void getMyElements(const std::string & blockID,std::vector<stk::mesh::Entity> & elements) const;
-
-   /** Get a vector of elements that share an edge/face with an owned element. Note that these elements
-     * are not owned.
-     */
-   void getNeighborElements(std::vector<stk::mesh::Entity> & elements) const;
-
-   /** Get a vector of elements not owned by this processor but in a particular block
-     */
-   void getNeighborElements(const std::string & blockID,std::vector<stk::mesh::Entity> & elements) const;
-
-   /**  Get the containing block ID of this element.
-     */
-   std::string containingBlockId(stk::mesh::Entity elmt) const;
-
-//   std::pair<Teuchos::RCP<std::vector<std::pair<std::size_t,std::size_t> > >, Teuchos::RCP<std::vector<unsigned int> > >
-//   getPeriodicNodePairing() const;
-
-   /** Get set of element sharing a single node and its local node id.
-     */
-   void getOwnedElementsSharingNode(stk::mesh::Entity node,std::vector<stk::mesh::Entity> & elements,
-                                    std::vector<int> & relIds) const;
-
-   /** Get set of element sharing a single node and its local node id.
-     */
-//   void getOwnedElementsSharingNode(stk::mesh::EntityId nodeId,std::vector<stk::mesh::Entity> & elements,
-//                                    std::vector<int> & relIds, unsigned int matchType) const;
-
-   /** Get vertices and local cell IDs of a paricular element block.
-     *
-     * \param[in] mesh Reference to STK_Interface object
-     * \param[in] blockId Element block identifier string
-     * \param[out] localIds On processor local element IDs for the element block
-     * \param[out] vertices Abstract array type (requires resize) containing
-     *                      the coordinates of the vertices. Of size (#Cells, #Vertices, #Dim).
-     */
-   template<typename ArrayT>
-   void getIdsAndVertices(
-   		       std::string blockId,
-   		       std::vector<std::size_t>& localIds,
-   		       ArrayT& vertices) const;
-
-   /** Get Entities corresponding to the locally owned part of the side set requested.
-     * The Entites in the vector should be a dimension
-     * lower then <code>getDimension()</code>.
-     *
-     * \param[in] sideName Name of side set
-     * \param[in,out] sides Vector of entities containing the requested sides.
-     */
-   void getAllSides(const std::string & sideName,std::vector<stk::mesh::Entity> & sides) const;
-
-   /** Get Entities corresponding to the side set requested. This also limits the entities
-     * to be in a particular element block. The Entites in the vector should be a dimension
-     * lower then <code>getDimension()</code>.
-     *
-     * \param[in] sideName Name of side set
-     * \param[in] blockName Name of block
-     * \param[in,out] sides Vector of entities containing the requested sides.
-     */
-
-   void getAllSides(const std::string & sideName,const std::string & blockName,std::vector<stk::mesh::Entity> & sides) const;
-
-   //! get the block count
-   stk::mesh::Part * getElementBlockPart(const std::string & name) const
-   {
-      std::map<std::string, stk::mesh::Part*>::const_iterator itr = stkMeshStruct_->elementBlockParts_.find(name);   // Element blocks
-      if(itr==stkMeshStruct_->elementBlockParts_.end()) return 0;
-      return itr->second;
-   }
-
-   stk::mesh::Part * getSideset(const std::string & name) const
-   {
-     auto itr = stkMeshStruct_->ssPartVec.find(name);
-     return (itr != stkMeshStruct_->ssPartVec.end()) ? itr->second : nullptr;
-   }
-
-  /** Get the local element ID associated to the parent cell of a side element.
-   * 
-   * Functionality added to compute the graph associated to a block which has fields
-   * defined in the volume and on the side.
+  /** What are the cellTopologies linked to element blocks in this connection manager?
    */
-   std::size_t get_parent_cell_id(stk::mesh::Entity side) const;
+  void getElementBlockTopologies(std::vector<shards::CellTopology> & elementBlockTopologies) const override {
+    elementBlockTopologies = m_stkMeshStruct->elementBlockTopologies_;
+  }
 
-   /** Get vertices associated with a number of elements of the same geometry.
-     *
-     * \param[in] localIds Element local IDs to construct vertices
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-//   template <typename ArrayT>
-//   void getElementVertices(const std::vector<std::size_t> & localIds, ArrayT & vertices) const;
+  /** Get the local element IDs for a paricular element
+    * block. These are only the owned element ids.
+    *
+    * \param[in] blockIndex Block Index
+    *
+    * \returns Vector of local element IDs.
+    */
+  const std::vector<LocalOrdinal> & getElementBlock(const std::string & blockId) const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (m_elementBlocks.count(blockId)>=1, std::runtime_error,
+        "Error! Block '" << blockId << "' not found in the mesh.\n");
+    return m_elementBlocks.at(blockId);
+  }
 
-   /** Get vertices associated with a number of elements of the same geometry.
-     *
-     * \param[in] elements Element entities to construct vertices
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-//   template <typename ArrayT>
-//   void getElementVertices(const std::vector<stk::mesh::Entity> & elements, ArrayT & vertices) const;
+  /** Get the local element IDs for a paricular element
+    * block. These element ids are not owned, and the element
+    * will live on another processor.
+    *
+    * \param[in] blockIndex Block Index
+    *
+    * \returns Vector of local element IDs.
+    */
+  const std::vector<LocalOrdinal> & getNeighborElementBlock(const std::string & blockId) const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error,
+        "Error! Albany does not use elements halos, so the method\n"
+        "       'STKConnManager::getNeighborElementBlock' should not have been called.\n");
+    return m_neighborElementBlocks.at(blockId);
+  }
 
-   /** Get vertices associated with a number of elements of the same geometry.
-     *
-     * \param[in] localIds Element local IDs to construct vertices
-     * \param[in] eBlock Element block the elements are in
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-//   template <typename ArrayT>
-//   void getElementVertices(const std::vector<std::size_t> & localIds,const std::string & eBlock, ArrayT & vertices) const;
+  int getOwnedElementCount() const {
+    return m_elements.size();
+  }
 
-   /** Get vertices associated with a number of elements of the same geometry.
-     *
-     * \param[in] elements Element entities to construct vertices
-     * \param[in] eBlock Element block the elements are in
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-   template <typename ArrayT>
-   void getElementVertices(const std::vector<stk::mesh::Entity> & elements,const std::string & eBlock, ArrayT & vertices) const;
+  /** Get elements, if any, associated with <code>el</code>, excluding
+    * <code>el</code> itself.
+    */
+  const std::vector<LocalOrdinal>& getAssociatedNeighbors(const LocalOrdinal& el) const override;
 
-   /** Get vertices associated with a number of elements of the same geometry. This access the true mesh coordinates
-     * array.
-     *
-     * \param[in] elements Element entities to construct vertices
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-   template <typename ArrayT>
-   void getElementVertices_FromCoords(const std::vector<stk::mesh::Entity> & elements, ArrayT & vertices) const;
-
-   //! get the dimension
-   unsigned getDimension() const
-   { return dimension_; }
-
-   /** Look up a global node and get the coordinate.
-     */
-   const double * getNodeCoordinates(stk::mesh::Entity node) const;
-
-   /** Get vertices associated with a number of elements of the same geometry, note that a coordinate field
-     * will be used (if not is available an exception will be thrown).
-     *
-     * \param[in] elements Element entities to construct vertices
-     * \param[in] eBlock Element block the elements are in
-     * \param[out] vertices Output array that will be sized (<code>localIds.size()</code>,#Vertices,#Dim)
-     *
-     * \note If not all elements have the same number of vertices an exception is thrown.
-     *       If the size of <code>localIds</code> is 0, the function will silently return
-     */
-   template <typename ArrayT>
-   void getElementVertices_FromField(const std::vector<stk::mesh::Entity> & elements,
-          const std::string & eBlock, ArrayT & vertices) const;
-
-   /** Get the stk mesh field pointer associated with a particular solution value
-     * Assumes there is a field associated with "fieldName,blockId" pair. If none
-     * is found an exception (std::runtime_error) is raised.
-     */
-   stk::mesh::Field<double> * getSolutionField(const std::string & fieldName,
-                                               const std::string & blockId) const;
-
-   stk::mesh::EntityRank getElementRank() const { return stk::topology::ELEMENT_RANK; }
-   stk::mesh::EntityRank getSideRank() const { return metaData_->side_rank(); }
-   stk::mesh::EntityRank getFaceRank() const { return stk::topology::FACE_RANK; }
-   stk::mesh::EntityRank getEdgeRank() const { return stk::topology::EDGE_RANK; }
-   stk::mesh::EntityRank getNodeRank() const { return stk::topology::NODE_RANK; }
-
-   stk::mesh::EntityId getMaxEntityId(unsigned entityRank) const;
-
-      //! get the global counts for the entity of specified rank
-   std::size_t getEntityCounts(unsigned entityRank) const;
-
-   /** Setup local element IDs
-     */
-   void buildLocalElementIDs();
-
-  /** Get the EntityId associated to an element.
-   * 
-   * Functionality added to compute the graph associated to a block which has fields
-   * defined in the volume and on the side.
-   */
-   stk::mesh::EntityId elementEntityId(stk::mesh::Entity elmt) const
-   {
-     return bulkData_->identifier(elmt);
-   }
+  /** Return whether getAssociatedNeighbors will return true for at least one
+    * input. Default implementation returns false.
+    */
+  // NOTE: Albany should not use neighbors, so always false.
+  bool hasAssociatedNeighbors() const override {
+    return false;
+  }
 
 protected:
-   /** Apply periodic boundary conditions associated with the mesh object.
-     *
-     * \note This function requires global All-2-All communication IFF
-     *       periodic boundary conditions are required.
-     */
-//   void applyPeriodicBCs( const panzer::FieldPattern & fp, GlobalOrdinal nodeOffset, GlobalOrdinal edgeOffset,
-//                                                           GlobalOrdinal faceOffset, GlobalOrdinal cellOffset);
-   void applyInterfaceConditions();
 
-   void buildLocalElementMapping();
-   void clearLocalElementMapping();
-   void buildOffsetsAndIdCounts(const panzer::FieldPattern & fp,
-                                LocalOrdinal & nodeIdCnt, LocalOrdinal & edgeIdCnt,
-                                LocalOrdinal & faceIdCnt, LocalOrdinal & cellIdCnt,
-                                GlobalOrdinal & nodeOffset, GlobalOrdinal & edgeOffset,
-                                GlobalOrdinal & faceOffset, GlobalOrdinal & cellOffset) const;
+  std::string containingBlockId(stk::mesh::Entity elmt) const;
 
-   LocalOrdinal addSubcellConnectivities(stk::mesh::Entity element,unsigned subcellRank,
-                                         LocalOrdinal idCnt,GlobalOrdinal offset);
+  int elementLocalId (const stk::mesh::Entity elmt) const;
+  int elementLocalId (const stk::mesh::EntityId gid) const;
+  stk::mesh::EntityId getMaxEntityId (const stk::mesh::EntityRank entityRank) const;
 
-   void modifySubcellConnectivities(const panzer::FieldPattern & fp, stk::mesh::Entity element,
-                                    unsigned subcellRank,unsigned subcellId,GlobalOrdinal newId,GlobalOrdinal offset);
+  void getMyElements(std::vector<stk::mesh::Entity> & elements) const;
 
-   /** Compute global entity counts.
-     */
-   void buildEntityCounts();
+  void getMyElements(const std::string & blockID,std::vector<stk::mesh::Entity> & elements) const;
 
-   void buildMaxEntityIds();
+  void clearLocalElementMapping();
+  void buildLocalElementMapping();
+  void buildOffsetsAndIdCounts(
+      const panzer::FieldPattern & fp,
+      LocalOrdinal & nodeIdCnt, LocalOrdinal & edgeIdCnt,
+      LocalOrdinal & faceIdCnt, LocalOrdinal & cellIdCnt,
+      GlobalOrdinal & nodeOffset, GlobalOrdinal & edgeOffset,
+      GlobalOrdinal & faceOffset, GlobalOrdinal & cellOffset) const;
 
+   LocalOrdinal addSubcellConnectivities(
+       const stk::mesh::Entity element,
+       const stk::mesh::EntityRank subcellRank,
+       const LocalOrdinal idCnt,
+       const GlobalOrdinal offset);
 
-   Teuchos::RCP<std::vector<stk::mesh::Entity> > elements_;
+  stk::mesh::Part * getElementBlockPart(const std::string & name) const;
 
-   // element block information
-   std::map<std::string,Teuchos::RCP<std::vector<LocalOrdinal> > > elementBlocks_;
-   std::map<std::string,Teuchos::RCP<std::vector<LocalOrdinal> > > neighborElementBlocks_;
-   std::map<std::string,GlobalOrdinal> blockIdToIndex_;
+  // Compute max gid for each entity rank
+  // void buildEntityCounts();
+  void buildMaxEntityIds();
 
-   std::vector<LocalOrdinal> elmtLidToConn_; // element LID to Connectivity map
-   std::vector<LocalOrdinal> connSize_; // element LID to Connectivity map
-   std::vector<GlobalOrdinal> connectivity_; // Connectivity
+  // Assing local ids to elements
+  void buildLocalElementIDs();
 
-   std::size_t ownedElementCount_;
+  std::vector<stk::mesh::Entity>  m_elements;
 
-   std::vector<std::string> sidesetsToAssociate_;
-   std::vector<bool> sidesetYieldedAssociations_;
-   std::vector<std::vector<LocalOrdinal> > elmtToAssociatedElmts_;
+  // element block information
+  // NOTE: Albany should *never* use neighbors, since we do not require
+  //       an element halo anywhere. Keep the neighbor fcn anyways,
+  //       for simplicity in the getter functions
+  std::map<std::string,std::vector<LocalOrdinal> > m_elementBlocks;
+  std::map<std::string,std::vector<LocalOrdinal> > m_neighborElementBlocks;
+  // std::map<std::string,GlobalOrdinal> blockIdToIndex_;
+
+  // Map elemLID to offset in m_connectivity
+  std::vector<LocalOrdinal> m_elmtLidToConn;
+
+  // For each elemLID, returns size of connectivity
+  std::vector<LocalOrdinal> m_connSize;
+
+  // List of GIDs of entities in each element, spliced together
+  std::vector<GlobalOrdinal> m_connectivity;
+
+  // The max gid for each element rank, across the whole mesh.
+  std::vector<stk::mesh::EntityId> m_maxEntityId;
 
 private:
 
-   //! Stk Mesh Objects
-   const Teuchos::RCP<stk::mesh::MetaData> metaData_;
-   const Teuchos::RCP<stk::mesh::BulkData> bulkData_;
+  //! Stk Mesh Objects
+  Teuchos::RCP<const stk::mesh::MetaData>   m_metaData;
+  Teuchos::RCP<const stk::mesh::BulkData>   m_bulkData;
+  Teuchos::RCP<const AbstractSTKMeshStruct> m_stkMeshStruct;
 
-   const Teuchos::RCP<AbstractSTKMeshStruct> stkMeshStruct_;
-
-   int procRank_;
-   std::size_t currentLocalId_;
-   bool useFieldCoordinates_;
-   unsigned dimension_;
-   VectorFieldType * coordinatesField_;
-   std::map<std::string,std::vector<std::string> > meshCoordFields_; // coordinate  fields written by user
-   std::map<std::pair<std::string,std::string>,SolutionFieldType*> fieldNameToSolution_;
-
-   // uses lazy evaluation
-   mutable Teuchos::RCP<std::vector<stk::mesh::Entity> > orderedElementVector_;
-
-   ProcIdFieldType * processorIdField_;
-
-   // how many elements, faces, edges, and nodes are there globally
-   std::vector<std::size_t> entityCounts_;
-
-   // what is maximum entity ID
-   std::vector<stk::mesh::EntityId> maxEntityId_;
-
-   std::unordered_map<stk::mesh::EntityId, std::size_t> localIDHash_;
-
-   /** Get Vector of element entities ordered by their LID, returns an RCP so that
-     * it is easily stored by the caller.
-     */
-   Teuchos::RCP<const std::vector<stk::mesh::Entity> > getElementsOrderedByLID() const;
-
-
+  std::unordered_map<stk::mesh::EntityId, int> m_localIDHash;
 };
 
-#if 0
-template <typename ArrayT>
-void STKConnManager::getElementVertices(const std::vector<std::size_t> & localElementIds, ArrayT & vertices) const
-{
-   if(!useFieldCoordinates_) {
-     //
-     // gather from the intrinsic mesh coordinates (non-lagrangian)
-     //
+} // namespace Albany
 
-     const std::vector<stk::mesh::Entity> & elements = *(this->getElementsOrderedByLID());
-
-     // convert to a vector of entity objects
-     std::vector<stk::mesh::Entity> selected_elements;
-     for(std::size_t cell=0;cell<localElementIds.size();cell++)
-       selected_elements.push_back(elements[localElementIds[cell]]);
-
-     getElementVertices_FromCoords(selected_elements,vertices);
-   }
-   else {
-     TEUCHOS_TEST_FOR_EXCEPTION(true,std::invalid_argument,
-                                "STK_Interface::getElementVertices: Cannot call this method when field coordinates are used "
-                                "without specifying an element block.");
-   }
-}
-#endif
-
-template <typename ArrayT>
-void STKConnManager::getElementVertices(const std::vector<stk::mesh::Entity> & elements,const std::string & eBlock, ArrayT & vertices) const
-{
-   if(!useFieldCoordinates_) {
-     getElementVertices_FromCoords(elements,vertices);
-   }
-   else {
-     getElementVertices_FromField(elements,eBlock,vertices);
-   }
-}
-
-template <typename ArrayT>
-void STKConnManager::getElementVertices_FromCoords(const std::vector<stk::mesh::Entity> & elements, ArrayT & vertices) const
-{
-   // nothing to do! silently return
-   if(elements.size()==0) {
-     vertices = Kokkos::createDynRankView(vertices,"vertices",0,0,0);
-      return;
-   }
-
-   //
-   // gather from the intrinsic mesh coordinates (non-lagrangian)
-   //
-
-   // get *master* cell toplogy...(belongs to first element)
-   unsigned masterVertexCount
-     = stk::mesh::get_cell_topology(bulkData_->bucket(elements[0]).topology()).getCellTopologyData()->vertex_count;
-
-   // allocate space
-   vertices = Kokkos::createDynRankView(vertices,"vertices",elements.size(),masterVertexCount,getDimension());
-
-   // loop over each requested element
-   unsigned dim = getDimension();
-   for(std::size_t cell=0;cell<elements.size();cell++) {
-      stk::mesh::Entity element = elements[cell];
-      TEUCHOS_ASSERT(element!=0);
-
-      unsigned vertexCount
-        = stk::mesh::get_cell_topology(bulkData_->bucket(element).topology()).getCellTopologyData()->vertex_count;
-      TEUCHOS_TEST_FOR_EXCEPTION(vertexCount!=masterVertexCount,std::runtime_error,
-                         "In call to STK_Interface::getElementVertices all elements "
-                         "must have the same vertex count!");
-
-      // loop over all element nodes
-      const size_t num_nodes = bulkData_->num_nodes(element);
-      stk::mesh::Entity const* nodes = bulkData_->begin_nodes(element);
-      TEUCHOS_TEST_FOR_EXCEPTION(num_nodes!=masterVertexCount,std::runtime_error,
-                         "In call to STK_Interface::getElementVertices cardinality of "
-                                 "element node relations must be the vertex count!");
-      for(std::size_t node=0; node<num_nodes; ++node) {
-        const double * coord = getNodeCoordinates(nodes[node]);
-
-        // set each dimension of the coordinate
-        for(unsigned d=0;d<dim;d++)
-          vertices(cell,node,d) = coord[d];
-      }
-   }
-}
-
-template <typename ArrayT>
-void STKConnManager::getElementVertices_FromField(const std::vector<stk::mesh::Entity> & elements,const std::string & eBlock, ArrayT & vertices) const
-{
-   TEUCHOS_ASSERT(useFieldCoordinates_);
-
-   // nothing to do! silently return
-   if(elements.size()==0) {
-     vertices = Kokkos::createDynRankView(vertices,"vertices",0,0,0);
-      return;
-   }
-
-   // get *master* cell toplogy...(belongs to first element)
-   unsigned masterVertexCount
-     = stk::mesh::get_cell_topology(bulkData_->bucket(elements[0]).topology()).getCellTopologyData()->vertex_count;
-
-   // allocate space
-   vertices = Kokkos::createDynRankView(vertices,"vertices",elements.size(),masterVertexCount,getDimension());
-
-   std::map<std::string,std::vector<std::string> >::const_iterator itr = meshCoordFields_.find(eBlock);
-   if(itr==meshCoordFields_.end()) {
-     // no coordinate field set for this element block
-     TEUCHOS_ASSERT(false);
-   }
-
-   const std::vector<std::string> & coordField = itr->second;
-   std::vector<SolutionFieldType*> fields(getDimension());
-   for(std::size_t d=0;d<fields.size();d++) {
-     fields[d] = this->getSolutionField(coordField[d],eBlock);
-   }
-
-   for(std::size_t cell=0;cell<elements.size();cell++) {
-      stk::mesh::Entity element = elements[cell];
-
-      // loop over nodes set solution values
-      const size_t num_nodes = bulkData_->num_nodes(element);
-      stk::mesh::Entity const* nodes = bulkData_->begin_nodes(element);
-      for(std::size_t i=0; i<num_nodes; ++i) {
-        stk::mesh::Entity node = nodes[i];
-
-        const double * coord = getNodeCoordinates(node);
-
-        for(unsigned d=0;d<getDimension();d++) {
-          double * solnData = stk::mesh::field_data(*fields[d],node);
-
-          // recall mesh field coordinates are stored as displacements
-          // from the mesh coordinates, make sure to add them together
-          vertices(cell,i,d) = solnData[0]+coord[d];
-        }
-      }
-   }
-}
-
-
-}
-
-#endif
+#endif // ALBANY_STK_CONN_MANAGER_HPP

--- a/src/evaluators/gather/PHAL_GatherCoordinateVector_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherCoordinateVector_Def.hpp
@@ -70,14 +70,14 @@ void GatherCoordinateVector<EvalT, Traits>::evaluateFields(typename Traits::Eval
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
   unsigned int numCells = workset.numCells;
-  Teuchos::ArrayRCP<Teuchos::ArrayRCP<double*> > wsCoords = workset.wsCoords;
+  auto wsCoords = workset.wsCoords;
 
 #ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
   if( dispVecName.is_null() ){
     for (std::size_t cell=0; cell < numCells; ++cell) {
       for (std::size_t node = 0; node < numVertices; ++node) {
         for (std::size_t eq=0; eq < numDim; ++eq) { 
-          coordVec(cell,node,eq) = wsCoords[cell][node][eq]; 
+          coordVec(cell,node,eq) = wsCoords(cell,node,eq); 
         }
       }
     }
@@ -104,7 +104,7 @@ void GatherCoordinateVector<EvalT, Traits>::evaluateFields(typename Traits::Eval
     for (std::size_t cell=0; cell < numCells; ++cell) {
       for (std::size_t node = 0; node < numVertices; ++node) {
         for (std::size_t eq=0; eq < numDim; ++eq) { 
-          coordVec(cell,node,eq) = wsCoords[cell][node][eq] + dVec(cell,node,eq);
+          coordVec(cell,node,eq) = wsCoords(cell,node,eq) + dVec(cell,node,eq);
         }
       }
     }
@@ -131,7 +131,7 @@ void GatherCoordinateVector<EvalT, Traits>::evaluateFields(typename Traits::Eval
     for (std::size_t cell=0; cell < numCells; ++cell) {
       for (std::size_t node = 0; node < numVertices; ++node) {
         for (std::size_t eq=0; eq < numDim; ++eq) {
-          coordVecHost(cell,node,eq) = wsCoords[cell][node][eq];
+          coordVecHost(cell,node,eq) = wsCoords(cell,node,eq);
         }
       }
     }
@@ -155,7 +155,7 @@ void GatherCoordinateVector<EvalT, Traits>::evaluateFields(typename Traits::Eval
     for (std::size_t cell=0; cell < numCells; ++cell) {
       for (std::size_t node = 0; node < numVertices; ++node) {
         for (std::size_t eq=0; eq < numDim; ++eq) {
-          coordVecHost(cell,node,eq) = wsCoords[cell][node][eq] + dVec(cell,node,eq);
+          coordVecHost(cell,node,eq) = wsCoords(cell,node,eq) + dVec(cell,node,eq);
         }
       }
     }
@@ -172,4 +172,5 @@ void GatherCoordinateVector<EvalT, Traits>::evaluateFields(typename Traits::Eval
 
 #endif
 }
-}
+
+} // namespace PHAL

--- a/src/evaluators/pde/PHAL_HeatEqResid_Def.hpp
+++ b/src/evaluators/pde/PHAL_HeatEqResid_Def.hpp
@@ -117,10 +117,6 @@ template<typename EvalT, typename Traits>
 void HeatEqResid<EvalT, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-
-//// workset.print(std::cout);
-
-
   typedef Intrepid2::FunctionSpaceTools<PHX::Device> FST;
 
   FST::scalarMultiplyDataData (flux, ThermalCond.get_view(), TGrad.get_view());

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -662,14 +662,11 @@ evaluateFields(typename Traits::EvalData workset)
     auto hess_vec_prod_g_px_data = Albany::getNonconstLocalData(hess_vec_prod_g_px);
 
     int num_deriv = this->numNodes;
-    auto nodeID = workset.wsElNodeEqID;
     int fieldLevel = level_it->second;
 
     const Albany::LayeredMeshNumbering<GO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
     const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
     auto overlap_p_vs = workset.distParamLib->get(workset.dist_param_deriv_name)->overlap_vector_space();
-    auto overlapNodeVS = workset.disc->getOverlapNodeVectorSpace();
-    auto ov_node_indexer = Albany::createGlobalLocalIndexer(overlapNodeVS);
     auto ov_p_indexer = Albany::createGlobalLocalIndexer(overlap_p_vs);
 
     // Loop over cells in workset
@@ -698,14 +695,11 @@ evaluateFields(typename Traits::EvalData workset)
     auto hess_vec_prod_g_pp_data = Albany::getNonconstLocalData(hess_vec_prod_g_pp);
 
     int num_deriv = this->numNodes;
-    auto nodeID = workset.wsElNodeEqID;
     int fieldLevel = level_it->second;
 
     const Albany::LayeredMeshNumbering<GO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
     const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
     auto overlap_p_vs = workset.distParamLib->get(workset.dist_param_deriv_name)->overlap_vector_space();
-    auto overlapNodeVS = workset.disc->getOverlapNodeVectorSpace();
-    auto ov_node_indexer = Albany::createGlobalLocalIndexer(overlapNodeVS);
     auto ov_p_indexer = Albany::createGlobalLocalIndexer(overlap_p_vs);
 
     // Loop over cells in workset

--- a/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
+++ b/src/responses/Albany_FieldManagerScalarResponseFunction.cpp
@@ -223,8 +223,7 @@ template<typename EvalT>
 void FieldManagerScalarResponseFunction::
 evaluate(PHAL::Workset& workset)
 {
-  const WorksetArray<int>::type&
-    wsPhysIndex = application->getDiscretization()->getWsPhysIndex();
+  const auto& wsPhysIndex = application->getDiscretization()->getWsPhysIndex();
   rfm->preEvaluate<EvalT>(workset);
   for (int ws = 0, numWorksets = application->getNumWorksets();
        ws < numWorksets; ws++) {

--- a/src/utility/Albany_Hessian.cpp
+++ b/src/utility/Albany_Hessian.cpp
@@ -45,72 +45,158 @@ createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
     return H;
 }
 
+// Teuchos::RCP<Thyra_LinearOp>
+// createSparseHessianLinearOp(
+//     Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+//     Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+//     const std::vector<IDArray> vElDofs)
+// {
+//     Teuchos::RCP<const Tpetra_Map> p_overlapped_map = getTpetraMap(p_overlapped_vs);
+//     Teuchos::RCP<const Tpetra_Map> p_owned_map = getTpetraMap(p_owned_vs);
+//     Teuchos::RCP<Thyra_LinearOp> H;
+
+//     std::size_t num_elem = 0;
+//     const std::size_t num_elem_per_ws = vElDofs[0].dimension(0);
+//     const std::size_t nws = vElDofs.size();
+
+//     bool same_num_elem_per_ws = true;
+
+//     for (std::size_t wsIndex = 0; wsIndex < nws; ++wsIndex)
+//     {
+//         const std::size_t num_elem_per_ws_i = vElDofs[wsIndex].dimension(0);
+//         if (num_elem_per_ws != num_elem_per_ws_i && wsIndex + 1 < nws)
+//             same_num_elem_per_ws = false;
+//         num_elem += vElDofs[wsIndex].dimension(0);
+//     }
+
+//     TEUCHOS_TEST_FOR_EXCEPTION(
+//         same_num_elem_per_ws == false,
+//         std::logic_error,
+//         std::endl
+//             << "Error!  Albany::createHessianCrsGraph():  "
+//             << "Not implemented yet"
+//             << std::endl);
+
+//     const std::size_t NN = vElDofs[0].dimension(1);
+
+//     Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Teuchos::rcp(new Tpetra_CrsGraph(p_owned_map, 30));
+
+//     Tpetra_GO cols[1];
+
+//     for (std::size_t ielem=0; ielem<num_elem; ++ielem) {
+//         IDArray wsElDofs = vElDofs[floor(ielem / num_elem_per_ws)];
+//         const Tpetra_LO ielem_ws = ielem % num_elem_per_ws;
+//         for (std::size_t i = 0; i < NN; ++i)
+//         {
+//             const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem_ws, (int)i, 0);
+//             if (lcl_overlapped_node1 < 0)
+//                 continue;
+
+//             const GO row = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
+
+//             for (std::size_t j = 0; j < NN; ++j)
+//             {
+//                 const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem_ws, (int)j, 0);
+//                 if (lcl_overlapped_node2 < 0)
+//                     continue;
+
+//                 cols[0] = p_overlapped_map->getGlobalElement(lcl_overlapped_node2);
+
+//                 Hgraph->insertGlobalIndices(row, 1, cols);
+//             }
+//         }
+//     }
+
+//     Hgraph->fillComplete();
+//     Teuchos::RCP<Tpetra_CrsMatrix> Ht = Teuchos::rcp(new Tpetra_CrsMatrix(Hgraph));
+
+//     H = createThyraLinearOp(Ht);
+//     assign(H, 0.0);
+
+//     return H;
+// }
+
 Teuchos::RCP<Thyra_LinearOp>
 createSparseHessianLinearOp(
-    Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
-    Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
-    const std::vector<IDArray> vElDofs)
+    const Teuchos::RCP<const DistributedParameter>& param,
+    const Teuchos::RCP<const AbstractDiscretization>& disc)
+
+    // return createSparseHessianLinearOp(distParamLib->get(param_name),
+    //                                    app->getDisc());
+    // Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+    // Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+    // Teuchos::RCP<const panzer::DOFManager> p_dof_mgr,
+    // const WorksetArray<int>& ws_sizes,
+    // const DualView<int*>& ws_elem_lids)
 {
-    Teuchos::RCP<const Tpetra_Map> p_overlapped_map = getTpetraMap(p_overlapped_vs);
-    Teuchos::RCP<const Tpetra_Map> p_owned_map = getTpetraMap(p_owned_vs);
-    Teuchos::RCP<Thyra_LinearOp> H;
+    auto p_space    = param->vector_space();
+    auto p_ov_space = param->overlap_vector_space();
+    // Teuchos::RCP<const Tpetra_Map> p_overlapped_map = getTpetraMap(p_overlapped_vs);
+    // Teuchos::RCP<const Tpetra_Map> p_owned_map = getTpetraMap(p_owned_vs);
 
-    std::size_t num_elem = 0;
-    const std::size_t num_elem_per_ws = vElDofs[0].dimension(0);
-    const std::size_t nws = vElDofs.size();
+    // Teuchos::RCP<Thyra_LinearOp> H;
 
-    bool same_num_elem_per_ws = true;
+    // int num_elem = 0;
+    // const int num_elem_per_ws = ws_sizes[0];
+    // const int nws = ws_sizes.size();
 
-    for (std::size_t wsIndex = 0; wsIndex < nws; ++wsIndex)
-    {
-        const std::size_t num_elem_per_ws_i = vElDofs[wsIndex].dimension(0);
-        if (num_elem_per_ws != num_elem_per_ws_i && wsIndex + 1 < nws)
-            same_num_elem_per_ws = false;
-        num_elem += vElDofs[wsIndex].dimension(0);
-    }
+    // bool same_num_elem_per_ws = true;
 
-    TEUCHOS_TEST_FOR_EXCEPTION(
-        same_num_elem_per_ws == false,
-        std::logic_error,
-        std::endl
-            << "Error!  Albany::createHessianCrsGraph():  "
-            << "Not implemented yet"
-            << std::endl);
+    // for (int iws = 0; iws < nws; ++iws) {
+    //     const int num_elem_per_ws_i = ws_sizes[iws];
+    //     if (num_elem_per_ws != num_elem_per_ws_i && iws + 1 < nws)
+    //         same_num_elem_per_ws = false;
+    //     num_elem += ws_sizes[iws];
+    // }
 
-    const std::size_t NN = vElDofs[0].dimension(1);
+    // TEUCHOS_TEST_FOR_EXCEPTION(
+    //     same_num_elem_per_ws == false,
+    //     std::logic_error,
+    //     std::endl
+    //         << "Error!  Albany::createHessianCrsGraph():  "
+    //         << "Not implemented yet"
+    //         << std::endl);
 
-    Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Teuchos::rcp(new Tpetra_CrsGraph(p_owned_map, 30));
+    ThyraCrsMatrixFactory H_factory (p_space,p_space,p_ov_space,p_ov_space);
+    
+    // Teuchos::RCP<Tpetra_CrsGraph> Hgraph = Teuchos::rcp(new Tpetra_CrsGraph(p_owned_map, 30));
+    Teuchos::Array<GO> cols(1);
 
-    Tpetra_GO cols[1];
+    // Loop over all elems in the param dof mgr
+    const auto& p_dof_mgr = param->dof_mgr();
+    const auto& conn_mgr  = p_dof_mgr()->getConnManager();
 
-    for (std::size_t ielem=0; ielem<num_elem; ++ielem) {
-        IDArray wsElDofs = vElDofs[floor(ielem / num_elem_per_ws)];
-        const Tpetra_LO ielem_ws = ielem % num_elem_per_ws;
-        for (std::size_t i = 0; i < NN; ++i)
-        {
-            const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem_ws, (int)i, 0);
-            if (lcl_overlapped_node1 < 0)
-                continue;
+    // Local ids of elements
+    const auto& elem_lids = conn_mgr->getElementBlock(param->ebName());
+    // const int   num_elem  = elem_lids.size();
 
-            const GO row = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
+    const auto p_ov_gids = getGlobalElements(p_ov_space);
 
-            for (std::size_t j = 0; j < NN; ++j)
-            {
-                const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem_ws, (int)j, 0);
-                if (lcl_overlapped_node2 < 0)
-                    continue;
-
-                cols[0] = p_overlapped_map->getGlobalElement(lcl_overlapped_node2);
-
-                Hgraph->insertGlobalIndices(row, 1, cols);
-            }
+    // Global ids of dofs in the element
+    for (const auto elem_lid : elem_lids) {
+        // int ws       = ielem / num_elem_per_ws;
+        // int ielem_ws = ielem % num_elem_per_ws; 
+        // int elem_lid = ws_elem_lids(ws,ielem_ws);
+        // IDArray wsElDofs = vElDofs[floor(ielem / num_elem_per_ws)];
+        // const Tpetra_LO ielem_ws = ielem % num_elem_per_ws;
+      std::vector<Tpetra_GO> elem_gids;
+      p_dof_mgr->getElementGIDs(elem_lid,elem_gids);
+      std::vector<Tpetra_GO> param_elem_gids;
+      for (const auto gid : elem_gids) {
+        if (std::find(p_ov_gids.begin(),p_ov_gids.end(),gid)!=p_ov_gids.end()) {
+          param_elem_gids.push_back(gid);
         }
+      }
+      for (const auto row : param_elem_gids) {
+        for (const auto col : param_elem_gids) {
+          cols[0] = col;
+          H_factory.insertGlobalIndices(row,cols());
+        }
+      }
     }
 
-    Hgraph->fillComplete();
-    Teuchos::RCP<Tpetra_CrsMatrix> Ht = Teuchos::rcp(new Tpetra_CrsMatrix(Hgraph));
-
-    H = createThyraLinearOp(Ht);
+    H_factory.fillComplete();
+    auto H = H_factory.createOp ();
     assign(H, 0.0);
 
     return H;

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -1,6 +1,11 @@
 #ifndef ALBANY_HESSIAN_HPP
 #define ALBANY_HESSIAN_HPP
 
+#include "Albany_AbstractDiscretization.hpp"
+#include "Albany_DistributedParameter.hpp"
+
+#include "Albany_ThyraTypes.hpp"
+
 namespace Albany
 {
     /**
@@ -26,10 +31,18 @@ namespace Albany
      *
      * \param wsElDofs [in] Vector of IDArray associated to the mesh used.
      */
+    // Teuchos::RCP<Thyra_LinearOp> createSparseHessianLinearOp(
+    //     Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+    //     Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+    //     const std::vector<IDArray> wsElDofs);
     Teuchos::RCP<Thyra_LinearOp> createSparseHessianLinearOp(
-        Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
-        Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
-        const std::vector<IDArray> wsElDofs);
+        const Teuchos::RCP<const DistributedParameter>& param,
+        const Teuchos::RCP<const AbstractDiscretization>& disc);
+        // Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+        // Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+        // Teuchos::RCP<const panzer::DOFManager> p_dof_mgr,
+        // const WorksetArray<int>& ws_sizes,
+        // const DualView<int*>& ws_elem_lids);
 
     /**
      * \brief getHessianBlockIDs function

--- a/src/utility/Albany_UnivariateDistribution.hpp
+++ b/src/utility/Albany_UnivariateDistribution.hpp
@@ -7,6 +7,8 @@
 #ifndef ALBANY_UNIVARIATE_DISTRIBUTION_HPP
 #define ALBANY_UNIVARIATE_DISTRIBUTION_HPP
 
+#include "Teuchos_ParameterList.hpp"
+
 #include <boost/math/special_functions/erf.hpp>
 
 namespace Albany
@@ -19,7 +21,7 @@ namespace Albany
       {
         // Nothing to be done here
       }
-      UnivariatDistribution(const Teuchos::ParameterList &distributionParams)
+      UnivariatDistribution(const Teuchos::ParameterList &/* distributionParams */)
       {
         // Nothing to be done here
       }
@@ -83,15 +85,15 @@ namespace Albany
         return 2*sqrt(2)*M_PI * sigma * exp(2*pow(boost::math::erf_inv(-1+2*x),2))*boost::math::erf_inv(2*x-1);
       }
 
-      double ppf(const double x, const double v) {
+      double ppf(const double /* x */, const double v) {
         return mu + sigma * v;
       }
 
-      double ppf_dx(const double x, const double v) {
+      double ppf_dx(const double /* x */, const double v) {
         return sqrt(2*M_PI) * sigma * exp(pow(v/sqrt(2),2));
       }
 
-      double ppf_dx_dx(const double x, const double v) {
+      double ppf_dx_dx(const double /* x */, const double v) {
         return 2*sqrt(2)*M_PI * sigma * exp(2*pow(v/sqrt(2),2))*v/sqrt(2);
       }
 
@@ -167,15 +169,15 @@ namespace Albany
         return sqrt(2)*M_PI*sigma*(2*boost::math::erf_inv(2*x-1)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*boost::math::erf_inv(2*x-1)+2*pow(boost::math::erf_inv(2*x-1),2)+mu);
       }
 
-      double ppf(const double x, const double v) {
+      double ppf(const double /* x */, const double v) {
         return exp(mu + sqrt(2) * sigma * v/sqrt(2));
       }
 
-      double ppf_dx(const double x, const double v) {
+      double ppf_dx(const double /* x */, const double v) {
         return sqrt(2*M_PI)*sigma*exp(sqrt(2)*sigma*v/sqrt(2)+pow(v/sqrt(2),2)+mu);
       }
 
-      double ppf_dx_dx(const double x, const double v) {
+      double ppf_dx_dx(const double /* x */, const double v) {
         return sqrt(2)*M_PI*sigma*(2*v/sqrt(2)+sqrt(2)*sigma) * exp(sqrt(2)*sigma*v/sqrt(2)+2*pow(v/sqrt(2),2)+mu);
       }
 
@@ -241,11 +243,11 @@ namespace Albany
         return (x-a)/(b-a);
       }
 
-      double cdf_dx(const double x) {
+      double cdf_dx(const double /* x */) {
         return 1./(b-a);
       }
 
-      double cdf_dx_dx(const double x) {
+      double cdf_dx_dx(const double /* x */) {
         return 0;
       }
       
@@ -253,11 +255,11 @@ namespace Albany
         return (b-a) * x + a;
       }
 
-      double ppf_dx(const double x) {
+      double ppf_dx(const double /* x */) {
         return (b-a);
       }
 
-      double ppf_dx_dx(const double x) {
+      double ppf_dx_dx(const double /* x */) {
         return 0;
       }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -35,5 +35,5 @@ add_test(NAME StringUtils_Serial_Unit_Test
 #####################################################################
 
 add_subdirectory(evaluators)
-add_subdirectory(disc)
+# add_subdirectory(disc)
 


### PR DESCRIPTION
This means that, inside cells, we will call the dof mgr method `getElementGIDs` and `getElementLIDs` to get a DOF's node lids/gids.

This should get rid of several arrays stored in the discretization, and (hopefully) make life easier for a) block discretizations and b) different mesh structs backends. The latter is intended for the upcoming Omega_h mesh struct, which will have to simply provide a ConnManager implementation, along the line of what's done in STKConnManager (which has been significantly trimmed down to match Albany's needs/uses).