### PR TITLE
Replace "-l-L" with "-L" in albany export file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -814,9 +814,10 @@ if (INSTALL_ALBANY)
 
   message("-- Exporting link libs to: ${CMAKE_INSTALL_PREFIX}/export_albany.in")
   string(REGEX REPLACE ";/" " /" TMP2 "${TMP1}")
-  string(REPLACE ";" " -l" ALBANY_LINK_LIBS
+  string(REPLACE ";" " -l" TMP3
         "-L${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}"
         " -L${Trilinos_LIBRARY_DIRS}" " -l${TMP2}")
+  string(REPLACE "-l-L" "-L" ALBANY_LINK_LIBS ${TMP3})
   configure_file(export_albany.in ${CMAKE_INSTALL_PREFIX}/export_albany.in)
 
 endif()


### PR DESCRIPTION
This fixes the issue where `-l-L` shows up in the albany export file. It was safer just to replace it with `-L` since the extra `-l` might be needed for some other configuration I'm not aware of.

I tested it by adding `-D Trilinos_EXTRA_LINK_FLAGS:STRING="-L/some/lib" ` in a trilinos build. It works fine.