### PR TITLE
Fix evaluate response

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -1344,13 +1344,6 @@ Application::computeGlobalResidualImpl(
   // Scatter distributed parameters
   distParamLib->scatter();
 
-  // Set parameters
-  for (int i = 0; i < p.size(); i++) {
-    for (unsigned int j = 0; j < p[i].size(); j++) {
-      p[i][j].family->setRealValueForAllTypes(p[i][j].baseValue);
-    }
-  }
-
   // Zero out overlapped residual
   overlapped_f->assign(0.0);
   f->assign(0.0);
@@ -1566,13 +1559,6 @@ Application::computeGlobalJacobianImpl(
 
   // Scatter distributed parameters
   distParamLib->scatter();
-
-  // Set parameters
-  for (int i = 0; i < p.size(); i++) {
-    for (unsigned int j = 0; j < p[i].size(); j++) {
-      p[i][j].family->setRealValueForAllTypes(p[i][j].baseValue);
-    }
-  }
 
   // Zero out overlapped residual
   if (Teuchos::nonnull(f)) {
@@ -1907,6 +1893,8 @@ Application::computeGlobalTangent(
   }
 
   // Set parameters
+  // We have to reset the parameters here to be sure to zero out the
+  // previously used derivatives.
   for (int i = 0; i < par.size(); i++) {
     for (unsigned int j = 0; j < par[i].size(); j++) {
       par[i][j].family->setRealValueForAllTypes(par[i][j].baseValue);
@@ -2109,13 +2097,6 @@ Application::applyGlobalDistParamDerivImpl(
 
   // Scatter distributed parameters
   distParamLib->scatter();
-
-  // Set parameters
-  for (int i = 0; i < p.size(); i++) {
-    for (unsigned int j = 0; j < p[i].size(); j++) {
-      p[i][j].family->setRealValueForAllTypes(p[i][j].baseValue);
-    }
-  }
 
   Teuchos::RCP<Thyra_MultiVector> overlapped_fpV;
   if (trans) {
@@ -3464,6 +3445,8 @@ Application::setupBasicWorksetInfo(
   distParamLib->scatter();
 
   // Set parameters
+  // We have to reset the parameters here to be sure to zero out the
+  // previously used derivatives.
   for (int i = 0; i < p.size(); i++) {
     for (unsigned int j = 0; j < p[i].size(); j++) {
       p[i][j].family->setRealValueForAllTypes(p[i][j].baseValue);

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -1172,8 +1172,10 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
       if(l<num_param_vecs){
         auto p_constView = getLocalData(p);
         ParamVec& sacado_param_vector = sacado_param_vec[l];
-        for (unsigned int k = 0; k < sacado_param_vector.size(); ++k)
+        for (unsigned int k = 0; k < sacado_param_vector.size(); ++k) {
           sacado_param_vector[k].baseValue = p_constView[k];
+          sacado_param_vector[k].family->setRealValueForAllTypes(sacado_param_vector[k].baseValue);
+        }
       } else {
         distParamLib->get(dist_param_names[l-num_param_vecs])->vector()->assign(*p);
       }

--- a/src/Albany_ObserverImpl.cpp
+++ b/src/Albany_ObserverImpl.cpp
@@ -68,11 +68,11 @@ void ObserverImpl::
 parameterChanged(const std::string& param)
 {
   //! If a parameter has changed in value, saved/unsaved fields must be updated
+  // TO DO: in the future, it would be great to only unsave parameters that have changed.
   if (app_->getAppPL()->sublist("Debug Output").get("Report Parameter Changes",true)) {
     auto out = Teuchos::VerboseObjectBase::getDefaultOStream();
     if (app_->getParamLib()->isParameter(param)) {
-      *out << "Scalar parameter '" << param << "' has changed! New value: "
-           << app_->getParamLib()->getRealValue<PHAL::AlbanyTraits::Residual>(param) << std::endl;
+      *out << "Scalar parameter '" << param << "' has changed! " << std::endl;
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION (! app_->getDistributedParameterLibrary()->has(param), std::runtime_error,
           "Error! Parameter '" + param + "' is not a scalar nor a distributed parameter. Please, contact developers.\n");

--- a/src/responses/Albany_WeightedMisfitResponseFunction.cpp
+++ b/src/responses/Albany_WeightedMisfitResponseFunction.cpp
@@ -320,7 +320,8 @@ evaluate_HessVecProd_pp(
       tmp1(i) = Thyra::get_ele(*v->col(0),i);
     }
 
-    tmp2.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, 1.0, *invC, tmp1, 0.0 );
+    tmp2.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, 0.5, *invC, tmp1, 0.0 );
+    tmp2.multiply( Teuchos::TRANS, Teuchos::NO_TRANS, 0.5, *invC, tmp1, 1.0 );
 
     for (int i=0; i<total_dimension; i++) {
       Thyra::set_ele(i, tmp2(i), Hv_dp->col(0).ptr());

--- a/src/responses/Albany_WeightedMisfitResponseFunction.cpp
+++ b/src/responses/Albany_WeightedMisfitResponseFunction.cpp
@@ -135,7 +135,7 @@ evaluateResponseImpl (
 }
 
 void WeightedMisfitResponse::
-evaluateGradientImpl (
+evaluateTangentImpl (
     const Teuchos::Array<ParamVec> &p,
 		SerialDenseVector<int, double>& dgdp)
 {
@@ -158,7 +158,8 @@ evaluateGradientImpl (
     tmp1(i) = theta(i) - (*theta_0)(i);
   }
 
-  dgdp.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, 1.0, *invC, tmp1, 0.0 );
+  dgdp.multiply( Teuchos::NO_TRANS, Teuchos::NO_TRANS, 0.5, *invC, tmp1, 0.0 );
+  dgdp.multiply( Teuchos::TRANS, Teuchos::NO_TRANS, 0.5, *invC, tmp1, 1.0 );
 }
 
 void WeightedMisfitResponse::
@@ -212,7 +213,7 @@ evaluateTangent(const double /*alpha*/,
     if (parameter_index < n_parameters) {
       // dgdp = dg/dp
       SerialDenseVector<int, double> dgdp(total_dimension);
-      evaluateGradientImpl (p, dgdp);
+      evaluateTangentImpl (p, dgdp);
 
       int offset = 0;
       for (int j=0; j<parameter_index; j++) {
@@ -362,7 +363,7 @@ evaluateGradient(const double /*current_time*/,
     if (parameter_index < n_parameters) {
       // dgdp = dg/dp
       SerialDenseVector<int, double> dgdp(total_dimension);
-      evaluateGradientImpl (p, dgdp);
+      evaluateTangentImpl (p, dgdp);
 
       for (int i=0; i<total_dimension; i++) {
         dg_dp->col(i)->assign(dgdp(i));

--- a/src/responses/Albany_WeightedMisfitResponseFunction.hpp
+++ b/src/responses/Albany_WeightedMisfitResponseFunction.hpp
@@ -143,7 +143,7 @@ namespace Albany
     void evaluateResponseImpl (const Teuchos::Array<ParamVec> &p,
                               Thyra_Vector& g);
 
-    void evaluateGradientImpl (const Teuchos::Array<ParamVec> &p,
+    void evaluateTangentImpl (const Teuchos::Array<ParamVec> &p,
 		                           Teuchos::SerialDenseVector<int, double>& dgdp);
 
     Teuchos::RCP<const Application> app_;


### PR DESCRIPTION
This PR makes sure the scalar parameter values are updated before calling evaluateResponse.

All the tests passed on my workstation except:

```
         44 - MPNIQuad2D_Epetra (Failed)
         45 - MPNIQuad2D_Tpetra (Failed)
```
but they failed on the master branch too.

The branch compiles warning free.