### PR TITLE
Comply with changes in STK

### DIFF
--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -103,7 +103,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
   mesh_data->add_mesh_database(file_name, mesh_type, stk::io::READ_MESH);
   mesh_data->create_input_mesh();
 
-  metaData = mesh_data->meta_data_rcp();//Teuchos::rcpFromRef(mesh_data->meta_data());
+  metaData = Teuchos::rcp(mesh_data->meta_data_ptr());
 
   // End of creating input mesh
 

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -2309,7 +2309,7 @@ STKDiscretization::setupExodusOutput()
 
     mesh_data = Teuchos::rcp(
         new stk::io::StkMeshIoBroker(getMpiCommFromTeuchosComm(comm)));
-    mesh_data->set_bulk_data(bulkData);
+    mesh_data->set_bulk_data(Teuchos::get_shared_ptr(bulkData));
     //IKT, 8/16/19: The following is needed to get correct output file for Schwarz problems
     //Please see: https://github.com/trilinos/Trilinos/issues/5479
     mesh_data->property_add(Ioss::Property("FLUSH_INTERVAL", 1));


### PR DESCRIPTION
Fixes issue #814. 
Obtain `BulkData` class using `MeshBuilder` class instead of using `BulkData` constructor which is deprecated.