### PR TITLE
Fix various typos

### DIFF
--- a/doc/LandIce/FO_MMS/FELIX_Examples_Summary.txt
+++ b/doc/LandIce/FO_MMS/FELIX_Examples_Summary.txt
@@ -183,7 +183,7 @@ input_fo_dome.xml
    Other parameters: 
      A and n (Glen's law params): same as ISMIP-HOM test cases
      rho = 910 kg/m^3 (ice density)
-     g = 9.8 m/s^2 (gravitational costant)
+     g = 9.8 m/s^2 (gravitational constant)
 
 input_fo_sincos2D.xml
     dofs: u,v  viscosity = Glen,  20x20 elements, 21 x 21 mesh 

--- a/doc/LandIce/FO_Test/FELIX_Examples_Summary.txt
+++ b/doc/LandIce/FO_Test/FELIX_Examples_Summary.txt
@@ -22,7 +22,7 @@ input_fo_dome.xml
    Other parameters: 
      A and n (Glen's law params): same as ISMIP-HOM test cases
      rho = 910 kg/m^3 (ice density)
-     g = 9.8 m/s^2 (gravitational costant)
+     g = 9.8 m/s^2 (gravitational constant)
 
 input_fo_dome_interpSurf.xml
    Same as input_fo_dome.xml except the source terms are evaluated 

--- a/doc/LandIce/Stokes_Test/FELIX_Examples_Summary.txt
+++ b/doc/LandIce/Stokes_Test/FELIX_Examples_Summary.txt
@@ -22,5 +22,5 @@ input_dome.xml
    Other parameters: 
      A and n (Glen's law params): same as ISMIP-HOM test cases
      rho = 910 kg/m^3 (ice density)
-     g = 9.8 m/s^2 (gravitational costant)
+     g = 9.8 m/s^2 (gravitational constant)
 

--- a/doc/LandIce/build/albany-config.sh
+++ b/doc/LandIce/build/albany-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # WARNING: This file is generated automatically. Any changes made here
-# will be lost when the package is configured again.  Any permament
+# will be lost when the package is configured again.  Any permanent
 # changes should go into the corresponding template at the top level
 # LCM directory.
 

--- a/doc/LandIce/build/env-single.sh
+++ b/doc/LandIce/build/env-single.sh
@@ -9,12 +9,12 @@ INTEL_DIR=/opt/intel
 
 # Some basic error checking.
 if [ -z "$PACKAGE" ]; then
-    echo "Specifiy package [trilinos|albany]"
+    echo "Specify package [trilinos|albany]"
     exit 1
 fi
 
 if [ -z "$ARCH" ]; then
-    echo "Specifiy architecture [serial|openmp|pthreads|cuda]"
+    echo "Specify architecture [serial|openmp|pthreads|cuda]"
     exit 1
 fi
 

--- a/doc/LandIce/build/trilinos-config.sh
+++ b/doc/LandIce/build/trilinos-config.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # WARNING: This file is generated automatically. Any changes made here
-# will be lost when the package is configured again.  Any permament
+# will be lost when the package is configured again.  Any permanent
 # changes should go into the corresponding template at the top level
 # LCM directory.
 

--- a/doc/LandIce/edison-scripts/edison-seacas-trilinos-cmake
+++ b/doc/LandIce/edison-scripts/edison-seacas-trilinos-cmake
@@ -4,7 +4,7 @@
 #  They are currently only built for serial (non-mpi) builds so are
 #  not created with the same script as the general Trilinos build.
 #
-#  1. Download Trilinos, make a build directort, e.g.  Trilinos/seacas-build
+#  1. Download Trilinos, make a build directory, e.g.  Trilinos/seacas-build
 #  2. Put this file in that subdirectory of Trilinos
 #  3. Modify the NETCDF path below to point to your installed netcdf
 #  4. Execute this script;  make -j 4; make install

--- a/doc/LandIce/perlmutter/nvcc_wrapper_a100
+++ b/doc/LandIce/perlmutter/nvcc_wrapper_a100
@@ -149,7 +149,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/build-netcdf-hdf5-boost.doc
+++ b/doc/build-netcdf-hdf5-boost.doc
@@ -7,7 +7,7 @@ hdf5 and netcdf and boost_1_49. This includes Dakota build
 within Trilinos, which needs boost libraries.
 
 1) Download boost 1_49
-Build with this sciript (sice Dakota needs libraries not just headers)
+Build with this script (sice Dakota needs libraries not just headers)
 
 ./bootstrap.sh --with-libraries=signals,regex,filesystem,system,serialization  --prefix=.
 ./bjam install  

--- a/doc/caballo/do-cmake-trilinos-static-lib
+++ b/doc/caballo/do-cmake-trilinos-static-lib
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/caballo/seacas-cmake-static-lib
+++ b/doc/caballo/seacas-cmake-static-lib
@@ -7,7 +7,7 @@
 #  They are currently only built for serial (non-mpi) builds so are
 #  not created with the same script as the general Trilinos build.
 #
-#  1. Download Trilinos, make a build directort, e.g.  Trilinos/seacas-build
+#  1. Download Trilinos, make a build directory, e.g.  Trilinos/seacas-build
 #  2. Put this file in that subdirectory of Trilinos
 #  3. Modify the NETCDF path below to point to your installed netcdf
 #  4. Execute this script;  make -j 4; make install

--- a/doc/dashboards/camobap.ca.sandia.gov/do-cmake-trilinos-mpi-camobap-extended-sts
+++ b/doc/dashboards/camobap.ca.sandia.gov/do-cmake-trilinos-mpi-camobap-extended-sts
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/dashboards/camobap.ca.sandia.gov/do-cmake-trilinos-mpi-camobap-longdouble-eti
+++ b/doc/dashboards/camobap.ca.sandia.gov/do-cmake-trilinos-mpi-camobap-longdouble-eti
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/dashboards/cee-compute011.sandia.gov/albany_macro.cmake
+++ b/doc/dashboards/cee-compute011.sandia.gov/albany_macro.cmake
@@ -105,7 +105,7 @@ macro(do_albany CONFIGURE_OPTIONS BTYPE)
   #
 
   # IKT, 2/14/2020: for some reason, in the clang dbg build, warnings 
-  # are intepreted as errors.  Therfore modifying the logic to run tests 
+  # are interpreted as errors.  Therefore modifying the logic to run tests 
   # in that build even if errors were present. Not a nice solution...
 
   IF((BUILD_SUCCESS) OR (BTYPE MATCHES "Albany64BitClangDbg")) 

--- a/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-clang
+++ b/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-clang
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-gcc
+++ b/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-gcc
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-intel
+++ b/doc/dashboards/cee-compute011.sandia.gov/do-cmake-trilinos-mpi-sems-intel
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/dashboards/ride.sandia.gov/nvcc_wrapper_p100
+++ b/doc/dashboards/ride.sandia.gov/nvcc_wrapper_p100
@@ -144,7 +144,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/dashboards/skybridge-login5.sandia.gov/env-single.sh
+++ b/doc/dashboards/skybridge-login5.sandia.gov/env-single.sh
@@ -9,12 +9,12 @@ INTEL_DIR=/opt/intel
 
 # Some basic error checking.
 if [ -z "$PACKAGE" ]; then
-    echo "Specifiy package [trilinos|albany]"
+    echo "Specify package [trilinos|albany]"
     exit 1
 fi
 
 if [ -z "$ARCH" ]; then
-    echo "Specifiy architecture [serial|openmp|pthreads|cuda]"
+    echo "Specify architecture [serial|openmp|pthreads|cuda]"
     exit 1
 fi
 

--- a/doc/dashboards/weaver.sandia.gov/nvcc_wrapper_volta
+++ b/doc/dashboards/weaver.sandia.gov/nvcc_wrapper_volta
@@ -144,7 +144,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/developersGuide/SANDreport.cls
+++ b/doc/developersGuide/SANDreport.cls
@@ -214,7 +214,7 @@
 %    - Paragraph indent is set to 0 for cover pages, but never restored (Daniel Dolan)
 %    - Use "Lorem ipsum" instead of "bla bla bla" in the examples (Stephanie Phillips)
 %        (There is a LaTeX package, lipsum.sty, that does it, but it is not always installed.
-%        Therefore, I included the text verbaitm, instead of generating it.)
+%        Therefore, I included the text verbatim, instead of generating it.)
 %    - If the report is an OUO document, some text on the back cover needs to disappear.
 %         Thanks to Marcia Cooper for discovering it, and providing the necessary LaTeX code.
 %    - A lot of changes from Michael Kaneshige to better match the formatting of the official
@@ -275,7 +275,7 @@
 %    - Per management request, remove all references in the examples to Harry Potter and magic
 %
 % 04/30/2009 v1.32
-%    - When strict is used, section refernces do not work, since sections are
+%    - When strict is used, section references do not work, since sections are
 %        not numbered. Not sure how to deal with this. For now just print a
 %        warning during compile and update the strict examples not to use \ref.
 %        (Problem reported by Eric Chu)
@@ -290,7 +290,7 @@
 %        option now indents the first paragraph as well. (Suggested by Tammy Kolda)
 %    - Some people don't like their blank pages to be blank. Added the "blank"
 %        option which adds "Page intentionally blank" to blank pages
-%    - Shared text bewteen examples is now in seperate files and \input into the
+%    - Shared text between examples is now in separate files and \input into the
 %        examples
 %
 % 07/02/2010 v1.33
@@ -869,7 +869,7 @@
 	    {\normalfont\Large\bfseries\centering}%			% new 4
 	}								% \section from article.cls
 
-	% This is basicaly the same as above, but without the clearpage. We want that
+	% This is basically the same as above, but without the clearpage. We want that
 	% for \listof... in article.cls to conserve some paper.
 	\newcommand\SANDTOCsection{%					% new 3
 	    \@startsection {section}{1}{\z@}%				% \section from article.cls

--- a/doc/developersGuide/gettingStarted.tex
+++ b/doc/developersGuide/gettingStarted.tex
@@ -98,7 +98,7 @@ Albany is also the home for several application and algorithm
 projects that use and contribute to the overall infrastructure.
 These include the LCM (Laboratory for Computatinal Mechanics),
 QCAD (Quantum Computer Aided Design) and FELIX (Finite Element for
-Land Ice eXperiments) applications, as well as algorthmic projects
+Land Ice eXperiments) applications, as well as algorithmic projects
 in embedded uncertainty quantification, model order reduction, and
 maturation of the templated software stack in Trilinos.
 \end{abstract}
@@ -172,7 +172,7 @@ Albany is also the home for several application and algorithm
 projects that use and contribute to the overall infrastructure.
 These include the LCM (Laboratory for Computatinal Mechanics),
 QCAD (Quantum Computer Aided Design) and FELIX (Finite Element for
-Land Ice eXperiments) applications, as well as algorthmic projects
+Land Ice eXperiments) applications, as well as algorithmic projects
 in embedded uncertainty quantification, model order reduction, and
 maturation of the templated software stack in Trilinos.
 
@@ -204,7 +204,7 @@ database, IO, and will be growing soon to include mesh changes for
 stk\_rebalance and stk\_adapt.  
 
 Also of note is that Albany is, and intends to remain, a 
-Publically Available code base, free of export control 
+Publicly Available code base, free of export control 
 restrictions. This allows it to serve freely as a collaboration
 vehicle with universities and other labs, and as a template
 for building applications from Trilinos.
@@ -217,15 +217,15 @@ are difficult to change, and less by the physics set. Much of Albany
 was developed in FY08-10 for solving simple heat transfer and poisson
 equations. With nonlinear source terms, this was adequate for
 developing and verifying all the hooks for analysis algorithms from
-sensitivity analysis to UQ. Recenty, Navier-Stokes equations have been
+sensitivity analysis to UQ. Recently, Navier-Stokes equations have been
 added to the general Albany physics set. In FY11, two new projects
 (LCM and QCAD) were funded to develop application codes on Albany. These physics sets
 are developed in the Albany code, yet are distinct in many ways as
 well: C++ namespace, project teams, and funding sources.  
-More recenlty, other applications and algorithm research projects
+More recently, other applications and algorithm research projects
 have chose Albany as their home. 
 
-\section{LCM: Labratory for Computational Mechanics}
+\section{LCM: Laboratory for Computational Mechanics}
 
 The first application project build on Albany is the LCM, or
 Laboratory for Computational Mechanics [Ostien-PI, Salinger, Mota,
@@ -296,11 +296,11 @@ design LDRD (Schrodinger-Poisson) [Muller-PI, Gao, Nielsen,
 distribution is coupled to a Schrodinger region for quantum effects.
 Embedded UQ
 
-\section {Uncertainity Quantification (UQ)}
+\section {Uncertainty Quantification (UQ)}
 Albany is also serving as a main development and demonstration
 environment for embedded UQ research [Phipps-PI, Wildey]. By
 leveraging the templated fill environment, polynomial representations
-can be directly propogated through the physics assembly. Many issues
+can be directly propagated through the physics assembly. Many issues
 with data structures, parallelization, and linear algebra are being
 addressed.  
 
@@ -317,7 +317,7 @@ formulation plus $2-3$ other models that are simplifications of Stokes.
 This project will drive much development in UQ through interactions 
 with Dakota. One unique feature of this project is that it will be able
 to use a mesh from LANL's MPAS framework, putting to test the abstraction
-layer that we put between the finite element asembly and the concrete
+layer that we put between the finite element assembly and the concrete
 STK Mesh implementation. Long term plans include adjoint for distributed
 boundary condition parameters, coupled temperature solves, and implicit
 advection of the Ice Sheet. The plan is for this code to be integrated
@@ -383,7 +383,7 @@ directory.
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.
@@ -531,7 +531,7 @@ cmake  \
     ../
 \end{verbatim}
 Note that the \texttt{<location\_of\_trilinos\_install>} needs to be
-exacly the path in the \texttt{CMAKE\_INSTALL\_PREFIX} in the Trilinos
+exactly the path in the \texttt{CMAKE\_INSTALL\_PREFIX} in the Trilinos
 build above.  This is typically executed from a subdirectory of Albany such as
 \texttt{build} or \texttt{build\_linux\_mpi\_20120920} depending on
 your personal directory-naming style.
@@ -544,7 +544,7 @@ the following command.
 \begin{verbatim}
 % make -j 4 && ctest
 \end{verbatim}
-If everyting is well, all the tests should pass. 
+If everything is well, all the tests should pass. 
 
 Numerous parts of the build process are taken from the Trilinos install.
 For instance, the compilers, compiler flags, and any paths to netcdf,
@@ -563,7 +563,7 @@ SEACASIoss (for reading exodus files), and MPI (versus serial).
 There are other CMake configuration options recognized by the
 Albany build system. (In addition, CMake has a standard set that
 can be found at the CMake websote.) Many of these are experimental
-options and not generally supported, but currrently include [default]:
+options and not generally supported, but currently include [default]:
 \begin{verbatim}
 ENABLE_DEMO_PDES       & Bool flag to enable Albany PDES such as Navier-Stokes [on] \\
 ENABLE_LCM             & Bool flag to enable LCM physics sets [off] \\
@@ -624,7 +624,7 @@ Details of this implementation are in the \texttt{PHAL\_AlbanyTraits} class. The
 that needs to span these two realms is packed in the \texttt{PHAL\_Workset} struct.
 
 Also in the \texttt{src} directory are classes to handle states (fields besides the
-solution vector that persist between subseqent solves), "observers" that control
+solution vector that persist between subsequent solves), "observers" that control
 the output and postrprocessing of solutions, and utility functions (such as a single
 file to manage different parallel communicator abstractions and serial code).
 
@@ -700,7 +700,7 @@ These include several common responses that involve norms of the solution vector
 Responses that required finite element information, such as integrals of quantites
 over the mesh, are all hooked up through the
 \texttt{FieldManagerScalarResponseFunction} function. This triggers an assembly
-phase, using evaluators, much like the Residual and Jacobian evalutations, and 
+phase, using evaluators, much like the Residual and Jacobian evaluations, and 
 also make use of template-based generic programming.
 
 \item{\texttt{Albany/src/LCM}}  The \texttt{LCM} source code directory contains 
@@ -715,7 +715,7 @@ option \texttt{-D ENABLE\_LCM:=ON} needed to enable this code base (POC: Ostien)
 
 \item{\texttt{Albany/src/QCAD}}  The \texttt{QCAD} directory contains source code specific
 to the quantum device simulation and design project. It contains \texttt{problems}, 
-\texttt{evaluators}, and \texttt{respones} subdirectors for code that only effects
+\texttt{evaluators}, and \texttt{responses} subdirectors for code that only effects
 QCAD applciations. Currently there are several classes in the QCAD namespace that live
 in the Albany code base since their usage has grown beyond QCAD applications.
 (POC: Nielsen). 
@@ -773,7 +773,7 @@ starting with \texttt{Albany\_SolverFactory}.
 "\texttt{.hpp}" and "\texttt{.cpp}" suffixes. For the templated code base, which is primarily the
 code in the \texttt{evaluators} directories, we use the following naming conventions.
 There is a tiny "\texttt{{\em file}.cpp}" file for
-explicit template instatiation, a file with "\texttt{{\em file}\_Def.hpp}" extension
+explicit template instantiation, a file with "\texttt{{\em file}\_Def.hpp}" extension
 for the definition files with the source code in it, and "\texttt{{\em file}.hpp}" for
 the header file.
 
@@ -787,7 +787,7 @@ Each directory holds one or more \texttt{xml} file that is
 the input file for the run. Separate problems do {\em not} run off of separate executables. 
 The physics set and solution method are set in the input file. The
 large majority of examples run of of the same \texttt{Albany} executable, which performs simulations and
-linearized sensititivity anaysis. Problems that perform optimization or Dakota-based UQ 
+linearized sensitivity anaysis. Problems that perform optimization or Dakota-based UQ 
 use the \texttt{AlbanyDakota} or \texttt{AlbanyAnalysis} executables, while intrusive UQ
 using the Stokhos package use the \texttt{AlbanySG} executable. Other \texttt{Main*.cpp} files
 can exist to create other executables, but these are currently experimental only.
@@ -982,7 +982,7 @@ conditional ENABLE\_MYCRUD compile option.
 
 The following are some general steps to add new evaluators or problems, as well as new test problems to Albany CMakeLists. As an example, there are two newly created source and header files belonging to Albany LCM \verb+ myNewProblem.cpp, myNewProblem.hpp+ that you would like to add to the CMakeLists (same steps apply for other types of Albany problems or evaluators). 
 \begin{itemize}
-\item Add new problem files in \verb+<path_to_Albany_directory>/src/CMakeList.txt+ at the correspoinding section (in this example \verb+ALBANY_LCM+)
+\item Add new problem files in \verb+<path_to_Albany_directory>/src/CMakeList.txt+ at the corresponding section (in this example \verb+ALBANY_LCM+)
 \begin{verbatim}
 # LCM
 IF(ALBANY_LCM)
@@ -1044,7 +1044,7 @@ might not be part of your workflow.
 \chapter{Albany Copyright and Licensing Info}
 
 \texttt{Albany 2.0} has been approved for open source release with a
-Publically Available designation. There is a file \texttt{license.txt} 
+Publicly Available designation. There is a file \texttt{license.txt} 
 with the full text. All other source code has a short banner that should
 be added to the top of any new source code files. We will re-assert 
 copyright for major releases, but not minor releases. 

--- a/doc/nightlyTestHarness/README
+++ b/doc/nightlyTestHarness/README
@@ -41,7 +41,7 @@ scripts in the order listed.
   dakota_checkout.sh
   ----------------
   Fetches the Dakota_votd tarball with the "wget" command,
-  and untars all of Dakota withing Trilinos/packages/TriKota
+  and untars all of Dakota within Trilinos/packages/TriKota
 
   trilinos_build_all.sh
   ----------------
@@ -77,7 +77,7 @@ scripts in the order listed.
 =========================================================
 Note:
 The standard output of the builds and test are sent
-to seperate files in the nightly test directory: 
+to separate files in the nightly test directory: 
 under sub-driectories Albany_out, Trilinos_out,
 and Dakota_out. (These paths are specified in the
 file with environmental variables.)

--- a/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-camobap
+++ b/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-camobap
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-debug-camobap
+++ b/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-debug-camobap
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-openmp-camobap
+++ b/doc/nightlyTestHarness/camobap/do-cmake-trilinos-mpi-openmp-camobap
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/nightlyTestHarness/mockba/do-cmake-trilinos-mpi-mockba
+++ b/doc/nightlyTestHarness/mockba/do-cmake-trilinos-mpi-mockba
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/pantera/do-cmake-trilinos
+++ b/doc/pantera/do-cmake-trilinos
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/pantera/seacas-cmake
+++ b/doc/pantera/seacas-cmake
@@ -7,7 +7,7 @@
 #  They are currently only built for serial (non-mpi) builds so are
 #  not created with the same script as the general Trilinos build.
 #
-#  1. Download Trilinos, make a build directort, e.g.  Trilinos/seacas-build
+#  1. Download Trilinos, make a build directory, e.g.  Trilinos/seacas-build
 #  2. Put this file in that subdirectory of Trilinos
 #  3. Modify the NETCDF path below to point to your installed netcdf
 #  4. Execute this script;  make -j 4; make install

--- a/doc/release_version
+++ b/doc/release_version
@@ -1,6 +1,6 @@
 
 Albany revision number 540 in svn is compatible
-with released Trilinos 10.4, and refered to as
+with released Trilinos 10.4, and referred to as
 Albany v0.5 in copyright paperwork.
 
 Albany_release_1_0 is a branch in the git repository 

--- a/doc/seacas-cmake
+++ b/doc/seacas-cmake
@@ -4,7 +4,7 @@
 #  They are currently only built for serial (non-mpi) builds so are
 #  not created with the same script as the general Trilinos build.
 #
-#  1. Download Trilinos, make a build directort, e.g.  Trilinos/seacas-build
+#  1. Download Trilinos, make a build directory, e.g.  Trilinos/seacas-build
 #  2. Put this file in that subdirectory of Trilinos
 #  3. Modify the NETCDF path below to point to your installed netcdf
 #  4. Execute this script;  make -j 4; make install

--- a/doc/solo-ecn/do-cmake-trilinos
+++ b/doc/solo-ecn/do-cmake-trilinos
@@ -20,7 +20,7 @@
 # not compiled. Version _1_40 or newer.
 #
 # There are two optional build choices, commented below
-#   these are for Dakota and Exodus I/O capabilites.
+#   these are for Dakota and Exodus I/O capabilities.
 #
 # Albany automatically queries the Trilinos build to 
 # know if these capabilities are enabled or disabled.

--- a/doc/solo-ecn/seacas-cmake
+++ b/doc/solo-ecn/seacas-cmake
@@ -7,7 +7,7 @@
 #  They are currently only built for serial (non-mpi) builds so are
 #  not created with the same script as the general Trilinos build.
 #
-#  1. Download Trilinos, make a build directort, e.g.  Trilinos/seacas-build
+#  1. Download Trilinos, make a build directory, e.g.  Trilinos/seacas-build
 #  2. Put this file in that subdirectory of Trilinos
 #  3. Modify the NETCDF path below to point to your installed netcdf
 #  4. Execute this script;  make -j 4; make install

--- a/doc/summit/LandIce/nvcc_wrapper70
+++ b/doc/summit/LandIce/nvcc_wrapper70
@@ -149,7 +149,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/summit/LandIce/old/nvcc_wrapper70
+++ b/doc/summit/LandIce/old/nvcc_wrapper70
@@ -132,7 +132,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/summit/example/nvcc_wrapper_volta
+++ b/doc/summit/example/nvcc_wrapper_volta
@@ -132,7 +132,7 @@ do
   *.cpp|*.cxx|*.cc|*.C|*.c++|*.cu)
     cpp_files="$cpp_files $1"
     ;;
-   # Ensure we only have one optimization flag because NVCC doesn't allow muliple
+   # Ensure we only have one optimization flag because NVCC doesn't allow multiple
   -O*)
     if [ -n "$optimization_flag" ]; then
        echo "nvcc_wrapper - *warning* you have set multiple optimization flags (-O*), only the last is used because nvcc can only accept a single optimization setting."

--- a/doc/user-guide/common/scripts/plHTML.py
+++ b/doc/user-guide/common/scripts/plHTML.py
@@ -28,7 +28,7 @@ def parse_file(fname):
  
         if line.startswith("validPL->"):
             
-            # valid paramater list may be split onto multiple lines
+            # valid parameter list may be split onto multiple lines
             while not ( ");" in line ):
                 nextline = lines[i+1]
                 nextline = nextline.strip()

--- a/doc/user-guide/pages/about/description.html
+++ b/doc/user-guide/pages/about/description.html
@@ -48,7 +48,7 @@
 
     The third main strength
     is the early adoption of STK, the sierra toolkit libraries. 
-    This includes the mesh database, IO, and willl be growing soon 
+    This includes the mesh database, IO, and will be growing soon 
     to include mesh changes for stk_rebalance and stk_adapt.
     
     <h3> Physics Sets: what PDEs </h3>
@@ -63,7 +63,7 @@
     and poisson equations. With nonlinear source terms, this was
     adequate for developing and verifying all the hooks for
     analysis algorithms from sensitivity analysis to UQ.
-    Recenty, Navier-Stokes equations have been added to 
+    Recently, Navier-Stokes equations have been added to 
     the general Albany physics set.
     
     <br>
@@ -74,7 +74,7 @@
     distinct in many ways as well: C++ namespace,
     project teams, and funding sources.
     
-    <h3> LCM: Labratory for Computational Mechanics </h3>
+    <h3> LCM: Laboratory for Computational Mechanics </h3>
     
     The first application project build on Albany is the LCM,
     or Laboratory for Computational Mechanics 
@@ -107,7 +107,7 @@
     demonstration environment for embedded UQ research
     [Phipps-PI, Wildey]. By leveraging the templated
     fill environment, polynomial representations can
-    be directly propogated through the physics assembly.
+    be directly propagated through the physics assembly.
     Many issues with data structures, parallelization, 
     and linear algebra are being addressed.
     

--- a/doc/user-guide/pages/problem/adapt/rpiunif/rpiunif.html
+++ b/doc/user-guide/pages/problem/adapt/rpiunif/rpiunif.html
@@ -25,7 +25,7 @@
     
     SCOREC
 
-    <h3><a name="parameters">Paramters</h3>
+    <h3><a name="parameters">Parameters</h3>
     <ul>
 <li>Max Number of Mesh Adapt Iterations
 <ul>

--- a/doc/webpage/faq.html
+++ b/doc/webpage/faq.html
@@ -43,7 +43,7 @@
         Is Albany available?
         
       </p>
-        Albany is Publically Available software. However, we have not made it generally
+        Albany is Publicly Available software. However, we have not made it generally
         downloadable from the web at this point. 
         For Sandians, it can be pulled from a git repository: 
         software.sandia.gov:/space/git/Albany.

--- a/doc/webpage/index.html
+++ b/doc/webpage/index.html
@@ -53,7 +53,7 @@ are exposed by the Stratimikos layer.
 
 The third main strength
 is the early adoption of STK, the sierra toolkit libraries. 
-This includes the mesh database, IO, and willl be growing soon 
+This includes the mesh database, IO, and will be growing soon 
 to include mesh changes for stk_rebalance and stk_adapt.
 
 <p class="section"> Physics Sets: what PDEs </p>
@@ -66,7 +66,7 @@ Much of Albany was developed in FY08-10 for solving simple heat transfer
 and poisson equations. With nonlinear source terms, this was
 adequate for developing and verifying all the hooks for
 analysis algorithms from sensitivity analysis to UQ.
-Recenty, Navier-Stokes equations have been added to 
+Recently, Navier-Stokes equations have been added to 
 the general Albany physics set.
 
 In FY11, two new projects were funded to
@@ -75,7 +75,7 @@ sets are developed in the Albany code, yet are
 distinct in many ways as well: C++ namespace,
 project teams, and funding sources.
 
-<p class="sub section"> LCM: Labratory for Computational Mechanics </p>
+<p class="sub section"> LCM: Laboratory for Computational Mechanics </p>
 
 The first application project build on Albany is the LCM,
 or Laboratory for Computational Mechanics 
@@ -107,7 +107,7 @@ Albany is also serving as a main development and
 demonstration environment for embedded UQ research
 [Phipps-PI, Wildey]. By leveraging the templated
 fill environment, polynomial representations can
-be directly propogated through the physics assembly.
+be directly propagated through the physics assembly.
 Many issues with data structures, parallelization, 
 and linear algebra are being addressed.
 

--- a/src/Albany_StateInfoStruct.hpp
+++ b/src/Albany_StateInfoStruct.hpp
@@ -9,7 +9,7 @@
 
 // The StateInfoStruct contains information from the Problem
 // (via the State Manager) that is used by STK to define Fields.
-// This includes name, number of quantitites (scalar,vector,tensor),
+// This includes name, number of quantities (scalar,vector,tensor),
 // Element vs Node location, etc.
 
 #include <map>

--- a/src/Albany_ThyraTypes.hpp
+++ b/src/Albany_ThyraTypes.hpp
@@ -38,7 +38,7 @@
 #include "Thyra_ProductMultiVectorBase.hpp"
 #include "Thyra_ProductVectorBase.hpp"
 
-// Basic linar algebra types
+// Basic linear algebra types
 typedef Thyra::VectorSpaceBase<ST>                Thyra_VectorSpace;
 typedef Thyra::MultiVectorBase<ST>                Thyra_MultiVector;
 typedef Thyra::VectorBase<ST>                     Thyra_Vector;

--- a/src/Albany_TpetraTypes.hpp
+++ b/src/Albany_TpetraTypes.hpp
@@ -39,11 +39,11 @@ typedef int Tpetra_LO;
 typedef long long Tpetra_GO;
 #elif defined( HAVE_TPETRA_INST_INT_LONG )
 static_assert(sizeof(long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is long but thats not 64 bit");
+    "Tpetra's biggest enabled GlobalOrdinal is long but that is not 64 bit");
 typedef long Tpetra_GO;
 #elif defined( HAVE_TPETRA_INST_INT_UNSIGNED_LONG )
 static_assert(sizeof(unsigned long) == sizeof(GO),
-    "Tpetra's biggest enabled GlobalOrdinal is unsigned long but thats not 64 bit");
+    "Tpetra's biggest enabled GlobalOrdinal is unsigned long but that is not 64 bit");
 typedef unsigned long Tpetra_GO;
 #else
 #error "Albany needs a 64-bit GlobalOrdinal enabled in Tpetra"

--- a/src/LandIce/evaluators/LandIce_ScatterResidual2D.hpp
+++ b/src/LandIce/evaluators/LandIce_ScatterResidual2D.hpp
@@ -12,7 +12,7 @@
 
 namespace PHAL {
 /** \brief Scatters result from the residual fields into the
-    global (epetra) data structurs.  This includes the
+    global (epetra) data structures.  This includes the
     post-processing of the AD data type for all evaluation
     types besides Residual.
 

--- a/src/LandIce/evaluators/LandIce_StokesContravarientMetricTensor_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_StokesContravarientMetricTensor_Def.hpp
@@ -48,7 +48,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   jacobian = Kokkos::createDynRankView(coordVec.get_view(), "XXX", numCells, numQPs, numDims, numDims);
   jacobian_inv = Kokkos::createDynRankView(coordVec.get_view(), "XXX", numCells, numQPs, numDims, numDims);
 
-  // Pre-Calculate reference element quantitites
+  // Pre-Calculate reference element quantities
   cubature->getCubature(refPoints, refWeights);
 }
 

--- a/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
+++ b/src/LandIce/evaluators/LandIce_ThicknessResid_Def.hpp
@@ -176,7 +176,7 @@ evaluateFields(typename Traits::EvalData workset)
       H0_Side = Kokkos::createDynRankView(Residual.get_view(), "XXX", numQPsSide);
       V_Side = Kokkos::createDynRankView(Residual.get_view(), "XXX", numQPsSide, numVecFODims);
 
-      // Pre-Calculate reference element quantitites
+      // Pre-Calculate reference element quantities
       cubatureSide->getCubature(cubPointsSide, cubWeightsSide);
 
       // Copy the coordinate data over to a temp container

--- a/src/LandIce/evaluators/hydrology/LandIce_HydrologyWaterDischarge_Def.hpp
+++ b/src/LandIce/evaluators/hydrology/LandIce_HydrologyWaterDischarge_Def.hpp
@@ -37,7 +37,7 @@ HydrologyWaterDischarge (const Teuchos::ParameterList& p,
    *  We assume h is in [m], Phi in [kPa], the mesh is in [km], and k has units
    *     [k] =  m^(2*beta-alpha) s^(2*beta-3) kg^(1-beta).
    *  In the common case of beta=2, alpha=1, we have [k] = m^3 s kg^-1
-   *  Putting everything togeter, we get
+   *  Putting everything together, we get
    *     [q] = m^2/s
    */
 

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -594,7 +594,7 @@ void GenericSTKMeshStruct::setSideSetFieldData (
         auto& sis = (it_sis==side_set_sis.end() ? dummy_sis : it_sis->second);
 
         params_ss = Teuchos::rcp(new Teuchos::ParameterList(ssd_list.sublist(it.first)));
-        it.second->setFieldData(comm,req,sis,worksetSize);  // Cell equations are also defined on the side, but not viceversa
+        it.second->setFieldData(comm,req,sis,worksetSize);  // Cell equations are also defined on the side, but not vice-versa
       }
     }
   }
@@ -632,7 +632,7 @@ void GenericSTKMeshStruct::setSideSetBulkData (
         auto& sis = (it_sis==side_set_sis.end() ? dummy_sis : it_sis->second);
 
         params_ss = Teuchos::rcp(new Teuchos::ParameterList(ssd_list.sublist(it.first)));
-        it.second->setBulkData(comm,req,sis,worksetSize);  // Cell equations are also defined on the side, but not viceversa
+        it.second->setBulkData(comm,req,sis,worksetSize);  // Cell equations are also defined on the side, but not vice-versa
       }
     }
   }

--- a/src/disc/stk/Albany_GmshSTKMeshStruct.hpp
+++ b/src/disc/stk/Albany_GmshSTKMeshStruct.hpp
@@ -152,17 +152,17 @@ class GmshSTKMeshStruct : public GenericSTKMeshStruct
                                 std::map< std::string, int>&            physical_names);
 
   // Reads a single physical name from ifile.
-  // Prepends with an undescore and remove quotation marks.
+  // Prepends with an underscore and remove quotation marks.
   void get_name_for_physical_names( std::string& name, int& id, std::ifstream& ifile, int& dim);
 
   // Reads ifile to map surface tags to physical tags.
-  // Reports error if any surface is associted with more than one tag.
+  // Reports error if any surface is associated with more than one tag.
   void get_physical_tag_to_surface_tag_map( std::ifstream&      ifile, 
                                             std::map<int, int>& physical_surface_tags,
                                             int                 num_surfaces);
 
   // Reads ifile to map volume tags to physical tags.
-  // Reports error if any volume is associted with more than one tag.
+  // Reports error if any volume is associated with more than one tag.
   void get_physical_tag_to_volume_tag_map( std::ifstream&      ifile, 
                                            std::map<int, int>& physical_volume_tags,
                                            int                 num_volumes);

--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -852,7 +852,7 @@ Albany::IossSTKMeshStruct::loadOrSetCoordinates3d(int index)
       // The 3d coords field exists in the input mesh, but the restart index was
       // not set in the input file. We issue a warning, and load default coordinates
       *out << "WARNING! The field 'coordinates3d' was found in the input mesh, but no restart index was specified.\n"
-           << "         Albany will set the 3d coordinates to the 'default' ones (filling native coordinates with trailins zeros).\n";
+           << "         Albany will set the 3d coordinates to the 'default' ones (filling native coordinates with trailing zeros).\n";
     }
     // The input mesh does not store the 'coordinates3d' field
     // (perhaps the mesh does not come from a previous Albany run).

--- a/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
+++ b/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
@@ -853,7 +853,7 @@ TmplSTKMeshStruct<2>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& /* commT
     const GO upper_right =  x_GIDplus1 + nodes_x * y_GIDplus1;
     const GO upper_left  =  x_GID      + nodes_x * y_GIDplus1;
 
-    // get ID of quadrilateral -- will be doubled for trianlges below
+    // get ID of quadrilateral -- will be doubled for triangles below
     stk::mesh::EntityId elem_id = (stk::mesh::EntityId) elem_GID;
 
     // Calculate elemNumber of element

--- a/src/disc/stk/STKConnManager.cpp
+++ b/src/disc/stk/STKConnManager.cpp
@@ -117,7 +117,7 @@ void STKConnManager::buildLocalElementMapping()
    // this expensive operation guarantees ordering of local IDs
    std::sort(elements_->begin(), elements_->end(), LocalIdCompare(*this));
 
-   // allocate space for element LID to Connectivty map
+   // allocate space for element LID to Connectivity map
    // connectivity size
    elmtLidToConn_.clear();
    elmtLidToConn_.resize(elements_->size(),0);

--- a/src/disc/stk/STKConnManager.hpp
+++ b/src/disc/stk/STKConnManager.hpp
@@ -133,7 +133,7 @@ public:
 
           elementBlockTopologies.push_back(stkMeshStruct_->elementBlockTopologies_[i]);
    }
-   /** Get the local element IDs for a paricular element
+   /** Get the local element IDs for a parricular element
      * block. These are only the owned element ids.
      *
      * \param[in] blockIndex Block Index
@@ -143,7 +143,7 @@ public:
    virtual const std::vector<LocalOrdinal> & getElementBlock(const std::string & blockId) const
    { return *(elementBlocks_.find(blockId)->second); }
 
-   /** Get the local element IDs for a paricular element
+   /** Get the local element IDs for a parricular element
      * block. These element ids are not owned, and the element
      * will live on another processor.
      *
@@ -233,7 +233,7 @@ public:
 //   void getOwnedElementsSharingNode(stk::mesh::EntityId nodeId,std::vector<stk::mesh::Entity> & elements,
 //                                    std::vector<int> & relIds, unsigned int matchType) const;
 
-   /** Get vertices and local cell IDs of a paricular element block.
+   /** Get vertices and local cell IDs of a parricular element block.
      *
      * \param[in] mesh Reference to STK_Interface object
      * \param[in] blockId Element block identifier string

--- a/src/disc/stk/STKConnManager.hpp
+++ b/src/disc/stk/STKConnManager.hpp
@@ -133,7 +133,7 @@ public:
 
           elementBlockTopologies.push_back(stkMeshStruct_->elementBlockTopologies_[i]);
    }
-   /** Get the local element IDs for a parricular element
+   /** Get the local element IDs for a particular element
      * block. These are only the owned element ids.
      *
      * \param[in] blockIndex Block Index
@@ -143,7 +143,7 @@ public:
    virtual const std::vector<LocalOrdinal> & getElementBlock(const std::string & blockId) const
    { return *(elementBlocks_.find(blockId)->second); }
 
-   /** Get the local element IDs for a parricular element
+   /** Get the local element IDs for a particular element
      * block. These element ids are not owned, and the element
      * will live on another processor.
      *
@@ -233,7 +233,7 @@ public:
 //   void getOwnedElementsSharingNode(stk::mesh::EntityId nodeId,std::vector<stk::mesh::Entity> & elements,
 //                                    std::vector<int> & relIds, unsigned int matchType) const;
 
-   /** Get vertices and local cell IDs of a parricular element block.
+   /** Get vertices and local cell IDs of a particular element block.
      *
      * \param[in] mesh Reference to STK_Interface object
      * \param[in] blockId Element block identifier string

--- a/src/disc/stk/percept/stk_rebalance/ZoltanPartition.cpp
+++ b/src/disc/stk/percept/stk_rebalance/ZoltanPartition.cpp
@@ -625,7 +625,7 @@ void Zoltan::init( const vector< pair<std::string,std::string> >
   }
 
   /**
-   * Register the Zoltan/SIERRA "call-back" (querry) functions.
+   * Register the Zoltan/SIERRA "call-back" (query) functions.
    */
   if ( ZOLTAN_OK != register_callbacks() )
     throw runtime_error ("zoltan->Register_Callbacks error. ");
@@ -770,7 +770,7 @@ const std::string &Zoltan::parameter_entry_name() const
 int Zoltan::register_callbacks()
 {
   /*
-   * Register the Zoltan/SIERRA "call-back" (querry) functions.
+   * Register the Zoltan/SIERRA "call-back" (query) functions.
    * Use ONLY THE BARE ESSENTIALS for decompositions:
    *
    *    Zoltan_Set_Num_Obj_Fn      

--- a/src/disc/stk/percept/stk_rebalance/ZoltanPartition.hpp
+++ b/src/disc/stk/percept/stk_rebalance/ZoltanPartition.hpp
@@ -28,7 +28,7 @@
 #include <stk_mesh/base/Types.hpp>
 #include <percept/stk_rebalance/GeomDecomp.hpp>
 
-//Forward declaration for pointer to a Zoltan structrue.
+//Forward declaration for pointer to a Zoltan structure.
 struct Zoltan_Struct;
 
 /** \addtogroup stk_rebalance_module
@@ -61,7 +61,7 @@ public:
    *  \brief A structure to organize the mesh entity data.
    *
    * \param mesh_entities  Vector of mesh entities to balance
-   *                       these can span multiple regons.
+   *                       these can span multiple regions.
    *
    * \param nodal_coord_ref Coordinate reference defined on the
    *                        nodes of the entities in \a mesh_entities.
@@ -203,7 +203,7 @@ public:
   ////////////////////////////////////////////////////////////
 
   /** \brief Name Conversion Functions.
-   * Long friendly string prarameters
+   * Long friendly string parameters
    * need to be converted into short Zoltan names.  The
    * \a merge_default_values and \a convert_names_and_values
    * functions do that.  Merge_Default_Values should be called

--- a/src/evaluators/pde/PHAL_NSContravarientMetricTensor_Def.hpp
+++ b/src/evaluators/pde/PHAL_NSContravarientMetricTensor_Def.hpp
@@ -45,7 +45,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   this->utils.setFieldData(coordVec,fm);
   this->utils.setFieldData(Gc,fm);
 
-  // Pre-Calculate reference element quantitites
+  // Pre-Calculate reference element quantities
   refPoints = Kokkos::DynRankView<RealType, PHX::Device>("XXX", numQPs, numDims);
   refWeights = Kokkos::DynRankView<RealType, PHX::Device>("XXX", numQPs);
   cubature->getCubature(refPoints, refWeights);

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -28,7 +28,7 @@
 
 namespace PHAL {
 /** \brief Scatters result from the residual fields into the
-    global (epetra) data structurs.  This includes the
+    global (epetra) data structures.  This includes the
     post-processing of the AD data type for all evaluation
     types besides Residual.
 

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
@@ -28,7 +28,7 @@
 namespace PHAL {
 /** \brief Scatters result from the residual fields of equations
     defined on one or more side sets into the global (epetra/tpetra)
-    data structurs.
+    data structures.
     This includes the post-processing of the AD data type for all evaluation
     types besides Residual.
 */

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
@@ -53,7 +53,7 @@ protected:
 /** \brief Handles scattering of separable scalar response functions into epetra
  * data structures.
  *
- * A separable response function is one that is a sum of respones across cells.
+ * A separable response function is one that is a sum of responses across cells.
  * In this case we can compute the Jacobian in a generic fashion.
  */
 template <typename EvalT, typename Traits>

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
@@ -107,7 +107,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   grad_at_cub_points = Kokkos::DynRankView<RealType, PHX::Device>("XXX", numSideNodes, numSideQPs, numSideDims);
   cub_weights = Kokkos::DynRankView<RealType, PHX::Device>("XXX", numSideQPs);
 
-  // Pre-Calculate reference element quantitites
+  // Pre-Calculate reference element quantities
   cubature->getCubature(cub_points, cub_weights);
 
   intrepidBasis->getValues(val_at_cub_points, cub_points, Intrepid2::OPERATOR_VALUE);

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctions_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctions_Def.hpp
@@ -74,7 +74,7 @@ postRegistrationSetup(typename Traits::SetupData d,
   refPoints = Kokkos::DynRankView<RealType, PHX::Device>("refPoints", numQPs, numDims);
   refWeights = Kokkos::DynRankView<RealType, PHX::Device>("refWeights", numQPs);
 
-  // Pre-Calculate reference element quantitites
+  // Pre-Calculate reference element quantities
   cubature->getCubature(refPoints, refWeights);
   intrepidBasis->getValues(val_at_cub_points, refPoints, Intrepid2::OPERATOR_VALUE);
   intrepidBasis->getValues(grad_at_cub_points, refPoints, Intrepid2::OPERATOR_GRAD);

--- a/src/utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
+++ b/src/utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
@@ -45,7 +45,7 @@ namespace Albany
                                  const int nonzeros_per_row = -1); //currently not used
 
     // Inserts global indices in a temporary local graph.
-    // Indices that are not owned by callig processor are ignored
+    // Indices that are not owned by calling processor are ignored
     // The actual graph is created when FillComplete is called
     void insertGlobalIndices(const GO row, const Teuchos::ArrayView<const GO> &indices,
                              const size_t i_block = 0, const size_t j_block = 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -68,7 +68,7 @@ IF (ALBANY_MPI)
   set(SerialAlbany.exe                 ${SERIAL_CALL} ${AlbanyPath})
   set(SerialAlbanyAnalysis.exe         ${SERIAL_CALL} ${AlbanyAnalysisPath})
   # Do not test on greater than Trilinos_MPI_EXEC_MAX_NUMPROCS configured in Trilinos build
-  # or explicity given at Albany configure time -D ALBANY_MPI_EXEC_MAX_NUMPROCS
+  # or explicitly given at Albany configure time -D ALBANY_MPI_EXEC_MAX_NUMPROCS
   IF(DEFINED MPIMNP)
     IF(MPIMNP LESS 8)
       SET(MAX_MPI_RANKS ${MPIMNP})

--- a/tests/large/LandIce/CismAlbany/HandsOn/CHECKLIST
+++ b/tests/large/LandIce/CismAlbany/HandsOn/CHECKLIST
@@ -1,6 +1,6 @@
 1. Make sure to use same physical parameters (g, rho_i, rho_w) in both cism-albanyT.config and in input_standalone-albanyT.yaml input files.
 
-2. make sure that the "ice_limit" value is the same in the cism-albany.confing and in the scripts
+2. make sure that the "ice_limit" value is the same in the cism-albany.config and in the scripts
     build_cism_msh_from_nc.m and print_exo_fields_into_nc.m
 
 2. set to zero the use_glissade_surf_height_grad option in cism-albanyT.config file.

--- a/tests/large/LandIce/CismAlbany/mFiles/build_cism_msh_from_nc.m
+++ b/tests/large/LandIce/CismAlbany/mFiles/build_cism_msh_from_nc.m
@@ -320,7 +320,7 @@ sigmaVel = max(max(sigmaVel, 0.05*abs(vel)),0.05);
 thicknessRMS = max(0.1,thicknessRMS');
 
 
-%% write fieds into ascii files
+%% write fields into ascii files
 numComponents = size(thickness,1);
 
 if(~isempty(tempr))

--- a/tests/small/HeatQuadTri/quad_tri.jou
+++ b/tests/small/HeatQuadTri/quad_tri.jou
@@ -9,7 +9,7 @@ create vertex 0 {yExtent/2} 0
 create vertex {xExtent} {yExtent} 0
 create vertex 0 {yExtent} 0
 
-# create the recangle
+# create the rectangle
 create surface vertex 1 2 3 4
 create surface vertex 3 5 6 4
 merge all

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_opt.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_opt.yaml
@@ -26,7 +26,7 @@ ANONYMOUS:
         Cubature Degree: 3
         Side Set Name: basalside
         Basal Friction Coefficient:
-          Type: Fied
+          Type: Field
           Beta Field Name: basal_friction
       BC 1:
         Type: Lateral

--- a/tests/unit/UnitTest_StringUtils.cpp
+++ b/tests/unit/UnitTest_StringUtils.cpp
@@ -34,7 +34,7 @@ TEUCHOS_UNIT_TEST(StringUtils,ParseList)
 
   using namespace util;
 
-  // Ensure we can tell valid from unvalid strings
+  // Ensure we can tell valid from invalid strings
   TEST_ASSERT (validNestedListFormat(valid_1));
   TEST_ASSERT (validNestedListFormat(valid_2));
   TEST_ASSERT (validNestedListFormat(valid_3));

--- a/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
+++ b/tests/unit/disc/UnitTest_BlockedDOFManager.cpp
@@ -222,7 +222,7 @@ tests are a beginning, "work in progress."
 
             TEST_EQUALITY(conn1[3], conn2[1]);
 
-            // Need to look at the exodus file and do a few of these sort of comparions
+            // Need to look at the exodus file and do a few of these sort of comparisons
             //      TEST_EQUALITY(conn1[8],nodeCount+(maxEdgeId+1)+2);
             //      TEST_EQUALITY(conn2[8],nodeCount+(maxEdgeId+1)+3);
          }

--- a/tests/unit/evaluators/gatherDistributedParameters.cpp
+++ b/tests/unit/evaluators/gatherDistributedParameters.cpp
@@ -61,7 +61,7 @@ PHX_EXTENT(R)
 * - If phxWorkset.hessianWorkset.hess_vec_prod_g_xp or phxWorkset.hessianWorkset.hess_vec_prod_g_pp is set,
 *   the direction phxWorkset.hessianWorkset.direction_p is set and its entries are set to 0.4,
 * - The evaluator is then evaluated,
-* - A 2D MDField called solution_out is created with the expected ouput of the GatherScalarNodalParameter,
+* - A 2D MDField called solution_out is created with the expected output of the GatherScalarNodalParameter,
 * - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
 * - Depending on whether phxWorkset.hessianWorkset.hess_vec_prod_g_** is set, the values of the derivatives
 *   of solution_out are set accordingly,

--- a/tests/unit/evaluators/gatherSolution.cpp
+++ b/tests/unit/evaluators/gatherSolution.cpp
@@ -52,7 +52,7 @@ PHX_EXTENT(R)
 * - A PHAL::Workset phxWorkset is created for a 2x2x2 hexahedral mesh,
 * - The entries of the vector phxWorkset.x are set to the value 6,
 * - The evaluator is then evaluated,
-* - A 2D MDField called solution_out is created with the expected ouput of the GatherSolution,
+* - A 2D MDField called solution_out is created with the expected output of the GatherSolution,
 * - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
 * - The output of the evaluator is compared to the solution_out MDField comparing every entry one by one.
 */
@@ -153,7 +153,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, gatherSolutionResidual)
 * - If phxWorkset.hessianWorkset.hess_vec_prod_g_xp or phxWorkset.hessianWorkset.hess_vec_prod_g_pp is set,
 *   the direction phxWorkset.hessianWorkset.direction_p is set and its entries are set to 0.4,
 * - The evaluator is then evaluated,
-* - A 2D MDField called solution_out is created with the expected ouput of the GatherSolution,
+* - A 2D MDField called solution_out is created with the expected output of the GatherSolution,
 * - The entries of solution_out are set to 6: solution_out.deep_copy(6.0);
 * - Depending on whether phxWorkset.hessianWorkset.hess_vec_prod_g_** is set, the values of the derivatives
 *   of solution_out are set accordingly,

--- a/tests/unit/evaluators/scatterResidual.cpp
+++ b/tests/unit/evaluators/scatterResidual.cpp
@@ -62,7 +62,7 @@ PHX_EXTENT(R)
 *                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_px,
 *                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_f_pp,
 * - The evaluator is then evaluated,
-* - A Thyra vector is created with the expected ouput of the ScatterResidual based on the 2D MDField residual,
+* - A Thyra vector is created with the expected output of the ScatterResidual based on the 2D MDField residual,
 * - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
@@ -452,7 +452,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
 *                            only setting phxWorkset.hessianWorkset.hess_vec_prod_f_px,
 *                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_f_pp,
 * - The evaluator is then evaluated,
-* - A Thyra vector is created with the expected ouput of the ScatterResidual based on the 3D MDField residual,
+* - A Thyra vector is created with the expected output of the ScatterResidual based on the 3D MDField residual,
 * - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank1)

--- a/tests/unit/evaluators/scatterScalarResponse.cpp
+++ b/tests/unit/evaluators/scatterScalarResponse.cpp
@@ -62,7 +62,7 @@ PHX_EXTENT(R)
 *                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
 *                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
 * - The evaluator is then evaluated,
-* - A Thyra vector is created with the expected ouput of the ScatterScalarResponse based on the 2D MDField local_response,
+* - A Thyra vector is created with the expected output of the ScatterScalarResponse based on the 2D MDField local_response,
 * - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank0)
@@ -443,7 +443,7 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVe
 *                            only setting phxWorkset.hessianWorkset.hess_vec_prod_g_px,
 *                            and only setting phxWorkset.hessianWorkset.hess_vec_prod_g_pp,
 * - The evaluator is then evaluated,
-* - A Thyra vector is created with the expected ouput of the ScatterScalarResponse based on the 2D MDField local_response,
+* - A Thyra vector is created with the expected output of the ScatterScalarResponse based on the 2D MDField local_response,
 * - The output of the evaluator is compared to the Thyra vector comparing the relative norm of their difference.
 */
 TEUCHOS_UNIT_TEST(evaluator_unit_tester, separableScatterScalarResponseHessianVecTensorRank1)

--- a/tools/LCM/postprocessing/plot_convergence_Albany.m
+++ b/tools/LCM/postprocessing/plot_convergence_Albany.m
@@ -47,7 +47,7 @@ legend('Simulation data','orientation','horizontal','location','northoutside')
 
 
 
-% Plot displacment increment norm convergence
+% Plot displacement increment norm convergence
 handleFigure = figure(116);
 
 stepPlot = numel(normDu);


### PR DESCRIPTION
Found via `codespell -q 3 -L eles,fo,nd,smaple,syntetic,thck`