### PR TITLE
Make Albany build with a Epetra free Trilinos build

### DIFF
--- a/src/utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
+++ b/src/utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
@@ -5,7 +5,10 @@
 #include "Albany_ThyraTypes.hpp"
 
 #include "Albany_TpetraThyraUtils.hpp"
+
+#ifdef ALBANY_EPETRA
 #include "Albany_EpetraThyraUtils.hpp"
+#endif
 
 #include "Albany_ThyraCrsMatrixFactory.hpp"
 

--- a/src/utility/Albany_ThyraCrsMatrixFactory.cpp
+++ b/src/utility/Albany_ThyraCrsMatrixFactory.cpp
@@ -2,10 +2,10 @@
 
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_TpetraThyraUtils.hpp"
-#include "Albany_EpetraThyraUtils.hpp"
 
 #ifdef ALBANY_EPETRA
 #include "Albany_Epetra_FECrsMatrix.hpp"
+#include "Albany_EpetraThyraUtils.hpp"
 #include "Epetra_Export.h"
 #include "Epetra_IntVector.h"
 #endif

--- a/src/utility/Albany_ThyraUtils.cpp
+++ b/src/utility/Albany_ThyraUtils.cpp
@@ -7,7 +7,6 @@
 #include "Albany_Utils.hpp"
 #include "Albany_Macros.hpp"
 
-#include "Petra_Converters.hpp"
 #include "Tpetra_RowMatrixTransposer.hpp"
 
 #include "Thyra_VectorStdOps.hpp"
@@ -18,6 +17,7 @@
 #include "Teuchos_RCP.hpp"
 
 #if defined(ALBANY_EPETRA)
+#include "Petra_Converters.hpp"
 #include "Thyra_EpetraLinearOp.hpp"
 #include "AztecOO_ConditionNumber.h"
 #include "Albany_EpetraThyraUtils.hpp"

--- a/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_ascii.yaml
+++ b/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_ascii.yaml
@@ -125,16 +125,7 @@ ANONYMOUS:
             NOX Stratimikos Options: { }
             Stratimikos: 
               Linear Solver Type: Belos
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-06
+              Linear Solver Types:
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 

--- a/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_restart.yaml
+++ b/tests/small/LandIce/AsciiMeshes/Dome/input_fo_dome_restart.yaml
@@ -128,15 +128,6 @@ ANONYMOUS:
             Stratimikos: 
               Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-06
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 

--- a/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/small/LandIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -378,22 +378,13 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
-                    Tolerance: 1.0e-07
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
                     Block GMRES:
-                      Convergence Tolerance: 1.0=e-04
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 20
                       Output Style: 1
                       Verbosity: 33
@@ -403,11 +394,11 @@ ANONYMOUS:
                       Flexible Gmres: false
               Preconditioner Type: Ifpack2
               Preconditioner Types:
-                Ifpack:
+                Ifpack2:
                   Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
+                  Prec Type: RILUK
+                  Ifpack2 Settings:
+                    'fact: iluk level-of-fill': 0
 #                 FROSch:
 #                   FROSch Preconditioner Type: TwoLevelPreconditioner        # FROSch preconditioner type. Options: OneLevelPreconditioner, TwoLevelPreconditioner
 #                   OverlappingOperator Type: AlgebraicOverlappingOperator    # First Level: AlgebrAlgebraicOverlappingOperator determines the overlap based on the graph of the matrix
@@ -446,31 +437,6 @@ ANONYMOUS:
 #                     CoarseSolver:                                           # Solver for the coarse problem
 #                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
 #                       Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_AIS/inputMueLu.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLu.yaml
@@ -165,15 +165,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 400
-                    Tolerance: 1.0e-6
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -338,31 +329,6 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 5
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_AIS/inputMueLuShort.yaml
+++ b/tests/small/LandIce/FO_AIS/inputMueLuShort.yaml
@@ -165,15 +165,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 400
-                    Tolerance: 1.0e-6
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/tests/small/LandIce/FO_AIS/input_FROSch.yaml
+++ b/tests/small/LandIce/FO_AIS/input_FROSch.yaml
@@ -165,15 +165,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 400
-                    Tolerance: 1.0e-6
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -228,31 +219,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/CMakeLists.txt
+++ b/tests/small/LandIce/FO_GIS/CMakeLists.txt
@@ -322,12 +322,14 @@ if (ALBANY_IFPACK2)
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_beta_memT.yaml)
     add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_memT.yaml)
     set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
-
-    set (testName ${testNameRoot}_Analysis_BasalFriction_Hessian)
-    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_beta_hessianT.yaml
+   
+    if(ALBANY_TEKO)
+      set (testName ${testNameRoot}_Analysis_BasalFriction_Hessian)
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_beta_hessianT.yaml
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_beta_hessianT.yaml)
-    add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_hessianT.yaml)
-    set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
+      add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_hessianT.yaml)
+      set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
+    endif()
   endif()
 endif()
 
@@ -347,7 +349,7 @@ if (ALBANY_IFPACK2)
   add_test(${testName}_Tpetra ${Albany.exe} input_fo_gis_analysis_stiffeningT.yaml)
   set_tests_properties(${testName}_Tpetra PROPERTIES LABELS "LandIce;Tpetra;Forward")
 
-  if (ALBANY_ROL)
+  if (ALBANY_ROL AND ALBANY_TEKO)
     set (testName ${testNameRoot}_Analysis_StiffeningBasalFriction)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_analysis_stiffeningT.yaml
                    ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_analysis_stiffeningT.yaml)

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivityT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivityT.yaml
@@ -189,22 +189,13 @@ ANONYMOUS:
             Stratimikos: 
               Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999955e-07
                 Belos: 
                   VerboseObject: 
                     Verbosity Level: medium
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Maximum Iterations: 100
@@ -218,13 +209,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings: 
                     'fact: iluk level-of-fill': 0
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_bed_and_topT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_bed_and_topT.yaml
@@ -291,17 +291,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -322,13 +313,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
       Line Search:
         Full Step:
           Full Step: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thicknessT.yaml
@@ -252,17 +252,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -283,13 +274,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
       Line Search:
         Full Step:
           Full Step: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeightT.yaml
@@ -214,24 +214,15 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
                   Solver Type: Block GMRES
                   Solver Types:
                     Block GMRES:
-                      Convergence Tolerance: 9.99999999999999954e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Maximum Iterations: 100
@@ -245,13 +236,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
       Line Search:
         Full Step:
           Full Step: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -298,17 +298,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-06
                 Belos:
                   VerboseObject:
                     Verbosity Level: high
@@ -330,13 +321,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -344,17 +344,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-06
                 Belos:
                   VerboseObject:
                     Verbosity Level: high
@@ -376,13 +367,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -294,17 +294,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-06
                 Belos:
                   VerboseObject:
                     Verbosity Level: high
@@ -326,13 +317,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -372,15 +372,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -402,31 +393,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -310,15 +310,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -339,31 +330,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_two_paramsT.yaml
@@ -316,17 +316,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -347,13 +338,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
       Line Search:
         Full Step:
           Full Step: 1.00000000000000000e+00

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_beta_smbT.yaml
@@ -208,17 +208,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -239,13 +230,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupledT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupledT.yaml
@@ -172,24 +172,15 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
                   Solver Type: Block GMRES
                   Solver Types:
                     Block GMRES:
-                      Convergence Tolerance: 9.99999999999999954e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Maximum Iterations: 100
@@ -203,13 +194,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_optT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_coupled_shape_optT.yaml
@@ -181,17 +181,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -212,13 +203,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_forward_sensitivityT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_forward_sensitivityT.yaml
@@ -179,15 +179,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium
@@ -208,13 +199,6 @@ ANONYMOUS:
                   Prec Type: RILUK
                   Ifpack2 Settings:
                     'fact: iluk level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT.yaml
@@ -175,17 +175,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: { }
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999955e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstructT_FROSch.yaml
@@ -182,15 +182,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999955e-07
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_memT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_unstruct_memT.yaml
@@ -175,17 +175,8 @@ ANONYMOUS:
           Stratimikos Linear Solver:
             NOX Stratimikos Options: { }
             Stratimikos:
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-6
                 Belos:
                   VerboseObject:
                     Verbosity Level: medium

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
@@ -446,14 +446,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -510,31 +502,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_fluxdiv.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_fluxdiv.yaml
@@ -464,14 +464,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -529,31 +521,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
@@ -441,14 +441,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -505,31 +497,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_GIS/input_fo_humboldt_muelu.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_humboldt_muelu.yaml
@@ -444,14 +444,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -615,31 +607,31 @@ ANONYMOUS:
                       A: myRebalanceAFact
                       Coordinates: myRebalanceProlongatorFact
                       Importer: myRepartitionFact
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
+#                 ML:
+#                   Base Method Defaults: none
+#                   ML Settings:
+#                     default values: SA
+#                     ML output: 0
+#                     'repartition: enable': 1
+#                     'repartition: max min ratio': 1.327e+00
+#                     'repartition: min per proc': 600
+#                     'repartition: Zoltan dimensions': 2
+#                     'repartition: start level': 4
+#                     'semicoarsen: number of levels': 2
+#                     'semicoarsen: coarsen rate': 12
+#                     'smoother: sweeps': 4
+#                     'smoother: type': Chebyshev
+#                     'smoother: Chebyshev eig boost': 1.2e+00
+#                     'smoother: sweeps (level 0)': 1
+#                     'smoother: sweeps (level 1)': 4
+#                     'smoother: type (level 0)': line Jacobi
+#                     'smoother: type (level 1)': line Jacobi
+#                     'smoother: damping factor': 5.5e-01
+#                     'smoother: pre or post': both
+#                     'coarse: type': Amesos-KLU
+#                     'coarse: pre or post': pre
+#                     'coarse: sweeps': 4
+#                     max levels: 7
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testAT.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testAT.yaml
@@ -104,15 +104,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-03
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -131,15 +122,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings:
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testCT.yaml
+++ b/tests/small/LandIce/FO_ISMIP/input_fo_ismip-hom_testCT.yaml
@@ -124,15 +124,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 200
-                    Tolerance: 1.0e-6
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -151,15 +142,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings:
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basalT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basalT.yaml
@@ -104,15 +104,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings: 
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLawT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_cosexp_basal_all_glensLawT.yaml
@@ -171,15 +171,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings: 
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_MMS/input_fo_sincos2DT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sincos2DT.yaml
@@ -125,15 +125,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings: 
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_MMS/input_fo_sincoszT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sincoszT.yaml
@@ -105,15 +105,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings: 
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumannT.yaml
+++ b/tests/small/LandIce/FO_MMS/input_fo_sinexp_neumannT.yaml
@@ -105,15 +105,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: ILUT
                   Ifpack2 Settings: 
-                    'fact: ilut level-of-fill': 2.00000000000000000e+00
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 2.0
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_Test/input_fo_circularShelfT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_circularShelfT.yaml
@@ -104,15 +104,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 1000
-                    Tolerance: 1.0e-06
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelfT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelfT.yaml
@@ -115,15 +115,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 1000
-                    Tolerance: 1.0e-06
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_confinedShelf_depthIntBCT.yaml
@@ -109,15 +109,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 1000
-                    Tolerance: 1.0e-06
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/tests/small/LandIce/FO_Test/input_fo_dome.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_dome.yaml
@@ -122,15 +122,7 @@ ANONYMOUS:
                   Overlap: 0
                   Prec Type: ILUT
                   Ifpack2 Settings:
-                    'fact: ilut level-of-fill': 1.00000000000000000e+00
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                    'fact: ilut level-of-fill': 1.0
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_Test/input_fo_domeAnalysis.yaml
+++ b/tests/small/LandIce/FO_Test/input_fo_domeAnalysis.yaml
@@ -114,19 +114,11 @@ ANONYMOUS:
                       Flexible Gmres: false
               Preconditioner Type: Ifpack
               Preconditioner Types:
-                Ifpack:
+                Ifpack2:
                   Overlap: 0
-                  Prec Type: ILU
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+                  Prec Type: ILUT
+                  Ifpack2 Settings:
+                    'fact: ilut level-of-fill': 1.0
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LandIce/FO_Thermo/CMakeLists.txt
+++ b/tests/small/LandIce/FO_Thermo/CMakeLists.txt
@@ -76,7 +76,7 @@ if (ALBANY_FROSCH)
 endif()
 
 if(${PYTHON_TEST})
-if (ALBANY_FROSCH)
+if (ALBANY_FROSCH AND ALBNAY_TEKO)
   set(TESTFILES hessian_comparison.py humboldt_analysis.yaml humboldt_analysis_contiguous.yaml H-ref-000.mm H-ref-000_contiguous.mm ${PYTHON_TEST_HELPERS_DIR}/__init__.py ${PYTHON_TEST_HELPERS_DIR}/matrix_reader.py)
   file(COPY ${TESTFILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
+++ b/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
@@ -477,17 +477,8 @@ ANONYMOUS:
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
-                    Tolerance: 1.0e-07
+              Linear Solver Type: Belos
+              Linear Solver Types:
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
@@ -502,11 +493,6 @@ ANONYMOUS:
                       Flexible Gmres: false
               Preconditioner Type: FROSch
               Preconditioner Types:
-                Ifpack: 
-                  Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
                 Ifpack2:
                   Overlap: 0
                   Prec Type: Amesos2
@@ -556,31 +542,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_Thermo/humboldt_analysis_contiguous.yaml
+++ b/tests/small/LandIce/FO_Thermo/humboldt_analysis_contiguous.yaml
@@ -477,17 +477,8 @@ ANONYMOUS:
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
-                    Tolerance: 1.0e-07
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
@@ -502,11 +493,6 @@ ANONYMOUS:
                       Flexible Gmres: false
               Preconditioner Type: FROSch
               Preconditioner Types:
-                Ifpack: 
-                  Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
                 Ifpack2:
                   Overlap: 0
                   Prec Type: Amesos2
@@ -556,31 +542,6 @@ ANONYMOUS:
                     CoarseSolver:                                           # Solver for the coarse problem
                       SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
                       Solver: klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
-                ML: 
-                  Base Method Defaults: none
-                  ML Settings: 
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
           Rescue Bad Newton Solve: true
       Line Search: 
         Full Step: 

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -503,14 +503,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -527,36 +519,6 @@ ANONYMOUS:
                     Verbosity Level: low
               Preconditioner Type: FROSch
               Preconditioner Types:
-                Ifpack:
-                  Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.327e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.2e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.5e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
                 FROSch:
                   FROSch Preconditioner Type: OneLevelPreconditioner        # FROSch preconditioner type. Options: OneLevelPreconditioner, TwoLevelPreconditioner
                   OverlappingOperator Type: AlgebraicOverlappingOperator    # First Level: AlgebrAlgebraicOverlappingOperator determines the overlap based on the graph of the matrix

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
@@ -190,15 +190,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
-                    Tolerance: 9.99999999999999954e-08
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
@@ -194,14 +194,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -218,36 +210,6 @@ ANONYMOUS:
                     Verbosity Level: low
               Preconditioner Type: FROSch
               Preconditioner Types:
-                Ifpack:
-                  Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    ML output: 0
-                    'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
-                    'repartition: min per proc': 600
-                    'repartition: Zoltan dimensions': 2
-                    'repartition: start level': 4
-                    'semicoarsen: number of levels': 2
-                    'semicoarsen: coarsen rate': 12
-                    'smoother: sweeps': 4
-                    'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
-                    'smoother: sweeps (level 0)': 1
-                    'smoother: sweeps (level 1)': 4
-                    'smoother: type (level 0)': line Jacobi
-                    'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    'coarse: pre or post': pre
-                    'coarse: sweeps': 4
-                    max levels: 7
                 FROSch:
                   FROSch Preconditioner Type: TwoLevelPreconditioner        # FROSch preconditioner type. Options: OneLevelPreconditioner, TwoLevelPreconditioner
                   OverlappingOperator Type: AlgebraicOverlappingOperator    # First Level: AlgebrAlgebraicOverlappingOperator determines the overlap based on the graph of the matrix

--- a/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_fea.yaml
+++ b/tests/small/LandIce/FO_Thermo/input_FO_Thermo_wet_bed_test_fea.yaml
@@ -164,15 +164,6 @@ ANONYMOUS:
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 20
-                    Max Iterations: 500
-                    Tolerance: 9.99999999999999954e-08
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -186,12 +177,6 @@ ANONYMOUS:
                       Num Blocks: 1
                       Flexible Gmres: false
               Preconditioner Type: None
-              Preconditioner Types:
-                Ifpack:
-                  Overlap: 0
-                  Prec Type: Amesos
-                  Ifpack Settings:
-                    'fact: level-of-fill': 0
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:

--- a/tests/small/LinComprNS/input2Dunsteady.yaml
+++ b/tests/small/LinComprNS/input2Dunsteady.yaml
@@ -116,17 +116,22 @@ ANONYMOUS:
                 Test Type: MaxIters
                 Maximum Iterations: 20
       Stratimikos:
-        Linear Solver Type: AztecOO
+        Linear Solver Type: Belos
         Linear Solver Types:
-          AztecOO:
-            Forward Solve:
-              AztecOO Settings:
-                Aztec Solver: GMRES
-                Convergence Test: r0
-                Size of Krylov Subspace: 200
-                Output Frequency: 1
-              Max Iterations: 100
-              Tolerance: 1.00000000000000002e-08
+          Belos: 
+            VerboseObject: 
+              Verbosity Level: medium
+            Solver Type: Block GMRES
+            Solver Types: 
+              Block GMRES: 
+                Convergence Tolerance: 1.0e-08
+                Output Frequency: 10
+                Output Style: 1
+                Verbosity: 33
+                Maximum Iterations: 100
+                Block Size: 1
+                Num Blocks: 50
+                Flexible Gmres: false
         Preconditioner Type: Ifpack2
         Preconditioner Types:
           Ifpack2:

--- a/tests/small/NSPoiseuille2D/inputT.yaml
+++ b/tests/small/NSPoiseuille2D/inputT.yaml
@@ -53,25 +53,17 @@ ANONYMOUS:
           Forcing Term Method: Constant
           Linear Solver:
             Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver:
             NOX Stratimikos Options: {}
             Stratimikos:
               Linear Solver Type: Belos
               Linear Solver Types:
-                AztecOO:
-                  Forward Solve:
-                    AztecOO Settings:
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 50
-                      Output Frequency: 20
-                    Max Iterations: 250
-                    Tolerance: 9.99999999999999954e-07
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
                     Block GMRES:
-                      Convergence Tolerance: 9.99999999999999954e-07
+                      Convergence Tolerance: 1.0e-06
                       Output Frequency: 20
                       Output Style: 1
                       Verbosity: 33
@@ -80,19 +72,17 @@ ANONYMOUS:
                       Num Blocks: 50
                       Flexible Gmres: false
               Preconditioner Type: Ifpack2
-              Preconditioner Types:
-                ML:
-                  Base Method Defaults: none
-                  ML Settings:
-                    default values: SA
-                    'smoother: type': ML symmetric Gauss-Seidel
-                    'smoother: pre or post': both
-                    'coarse: type': Amesos-KLU
-                    PDE equations: 4
+              Preconditioner Types: 
+                Ifpack2: 
+                  Overlap: 1
+                  Prec Type: RILUK
+                  Ifpack2 Settings: 
+                    'fact: drop tolerance': 0.0
+                    'fact: iluk level-of-fill': 0              
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:
-          Full Step: 1.00000000000000000e+00
+          Full Step: 1.0
         Method: Full Step
       Nonlinear Solver: Line Search Based
       Printing:
@@ -102,6 +92,6 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:
-    Test Value: 1.37102561000000000e+00
-    Relative Tolerance: 1.00000000000000002e-03
+    Test Value: 1.37102561
+    Relative Tolerance: 1.0
 ...

--- a/tests/small/SteadyHeatConstrainedOpt2D/CMakeLists.txt
+++ b/tests/small/SteadyHeatConstrainedOpt2D/CMakeLists.txt
@@ -131,7 +131,7 @@ set_tests_properties(${testName}_Tpetra PROPERTIES LABELS "Basic;Tpetra;Forward"
 ### Hessian Mixed Scalar Distributed Params tests ###
 ####################################
 
-if (ALBANY_ROL)
+if (ALBANY_ROL AND ALBANY_TEKO)
   set(testName ${testNameRoot}_Scalar_And_Dist_Param_Hessian)
 
   # Copy Input file from source to binary dir

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_paramT.yaml
@@ -256,25 +256,19 @@ ANONYMOUS:
         Newton: 
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 1.0e-07
+              Linear Solver Type: Belos
+              Linear Solver Types:
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33
@@ -282,13 +276,15 @@ ANONYMOUS:
                       Block Size: 1
                       Num Blocks: 50
                       Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
               Preconditioner Type: Ifpack2
               Preconditioner Types: 
                 Ifpack2: 
                   Overlap: 1
                   Prec Type: RILUK
                   Ifpack2 Settings: 
-                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: drop tolerance': 0.0
                     'fact: iluk level-of-fill': 0
       Line Search: 
         Full Step: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_conductivity_dist_param_restartT.yaml
@@ -149,27 +149,21 @@ ANONYMOUS:
         Newton: 
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
               Linear Solver Type: Belos
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 9.99999999999999955e-08
+              Linear Solver Types:
                 Belos: 
                   VerboseObject: 
                     Verbosity Level: medium
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-7
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33
@@ -183,11 +177,11 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: RILUK
                   Ifpack2 Settings: 
-                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: drop tolerance': 0.0
                     'fact: iluk level-of-fill': 0
       Line Search: 
         Full Step: 
-          Full Step: 1.00000000000000000e+00
+          Full Step: 1.0
         Method: Full Step
       Nonlinear Solver: Line Search Based
       Printing: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -220,27 +220,21 @@ ANONYMOUS:
         Newton: 
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
               Linear Solver Type: Belos
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 1e-07
+              Linear Solver Types:
                 Belos: 
                   VerboseObject: 
                     Verbosity Level: medium
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33
@@ -254,11 +248,11 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: RILUK
                   Ifpack2 Settings: 
-                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: drop tolerance': 0.0
                     'fact: iluk level-of-fill': 0
       Line Search: 
         Full Step: 
-          Full Step: 1.00000000000000000e+00
+          Full Step: 1.0
         Method: Full Step
       Nonlinear Solver: Line Search Based
       Printing: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -231,25 +231,19 @@ ANONYMOUS:
         Newton: 
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 1.0e-07
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33
@@ -263,7 +257,7 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: RILUK
                   Ifpack2 Settings: 
-                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: drop tolerance': 0.0
                     'fact: iluk level-of-fill': 0
       Line Search: 
         Full Step: 

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
@@ -244,25 +244,19 @@ ANONYMOUS:
         Newton: 
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
-              Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 1.0e-07
+              Linear Solver Type: Belos
+              Linear Solver Types:
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -316,22 +316,13 @@ ANONYMOUS:
           Stratimikos Linear Solver: 
             NOX Stratimikos Options: { }
             Stratimikos: 
-              Linear Solver Type: AztecOO
+              Linear Solver Type: Belos
               Linear Solver Types: 
-                AztecOO: 
-                  Forward Solve: 
-                    AztecOO Settings: 
-                      Aztec Solver: GMRES
-                      Convergence Test: r0
-                      Size of Krylov Subspace: 200
-                      Output Frequency: 10
-                    Max Iterations: 200
-                    Tolerance: 1.0e-07
                 Belos: 
                   Solver Type: Block GMRES
                   Solver Types: 
                     Block GMRES: 
-                      Convergence Tolerance: 9.99999999999999955e-08
+                      Convergence Tolerance: 1.0e-07
                       Output Frequency: 10
                       Output Style: 1
                       Verbosity: 33
@@ -345,11 +336,11 @@ ANONYMOUS:
                   Overlap: 1
                   Prec Type: RILUK
                   Ifpack2 Settings: 
-                    'fact: drop tolerance': 0.00000000000000000e+00
+                    'fact: drop tolerance': 0.0
                     'fact: iluk level-of-fill': 0
       Line Search: 
         Full Step: 
-          Full Step: 1.00000000000000000e+00
+          Full Step: 1.0
         Method: Full Step
       Nonlinear Solver: Line Search Based
       Printing: 


### PR DESCRIPTION
Trilinos can now be built Epetra free (no Epetra, AztecOO, Amesos, Ifpack, ML, etc.).
After the minor changes in this PR, Albany can build against an Epetra-free Trilinos install. 
Unfortunately Teko still has a required dependency on Epetra, so we had to disable a few analysis test that use Teko (for computing Hessian based dot-product).

@ikalash,  when you get a chance it would be good to make one of the nightly tests Epetra free. 