### PR TITLE
Fix creation of export_albany.in when CMAKE_GENERATOR=Ninja

### DIFF
--- a/cmake/CreateExportAlbany
+++ b/cmake/CreateExportAlbany
@@ -6,72 +6,156 @@ import sys, os, argparse, pathlib
 ###############################################################################
 def parse_command_line(args, description):
 ###############################################################################
-  parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser()
 
-  parser.add_argument ("--bin-dir", help="binary dir", default=None)
-  parser.add_argument ("--install-lib-dir", help="albany install lib dir", default=None)
+    parser.add_argument ("--bin-dir", help="binary dir", default=None)
+    parser.add_argument ("--install-lib-dir", help="albany install lib dir", default=None)
+    parser.add_argument ("--cmake-generator", help="generator used by cmake", default=None)
 
-  return parser.parse_args(args[1:])
+    return parser.parse_args(args[1:])
 
 ###############################################################################
-def _main_func(description):
+def get_link_line_ninja(bin_dir):
 ###############################################################################
-    args = vars(parse_command_line(sys.argv, description))
+    infile  = bin_dir / "build.ninja"
 
-    bin_dir = pathlib.Path(args["bin_dir"]).resolve()
-    install_lib_dir = pathlib.Path(args["install_lib_dir"]).resolve()
+    with infile.open('r') as fd:
+        break_in_two = False
+        break_next = False
+        for line_no,line in enumerate(fd):
+            if break_next:
+                break
+            if break_in_two:
+                break_next = True
+            if 'build dummy/dummy: CXX_EXECUTABLE_LINKER' in line:
+                break_in_two = True
 
+    tokens = line.strip().split('=')
+    if len(tokens)!=2:
+        print(f"ERROR! Unexpected format of LINK_LIBRARIES line in build.ninja")
+        print(f"link line: {line}")
+        raise RuntimeError
+    if tokens[0].strip() != "LINK_LIBRARIES":
+        print(f"ERROR! Unexpected format of LINK_LIBRARIES line in build.ninja")
+        raise RuntimeError
+    return tokens[1].split()
+
+###############################################################################
+def get_link_line_make(bin_dir):
+###############################################################################
     infile  = bin_dir / "dummy" / "CMakeFiles" / "dummy.dir" / "link.txt"
-    libs = []
-    libs_dirs = [install_lib_dir]
 
-    bin_src_dir = bin_dir / "src"
     with infile.open('r') as fd:
         line = fd.read().strip()
         items = line.split()
         index = items.index('dummy')
         items = items[index+1:]
-        for item in items:
-            if "," in item:
-                # This are link options, so process them one by one
-                tokens = item.split(',')
-                for i,t in enumerate(tokens):
-                    if ':' in t:
-                      paths = t.split(':')
-                      # Loop over all paths, replace them with install dir
-                      for j,p in enumerate(paths):
-                        path = pathlib.Path(p).resolve()
-                        paths[j] = str(install_lib_dir)
 
-                      # Replace the rpath list with the unique list
-                      tokens[i] = ':'.join(list(set(paths)))
-                    else:
-                      # Just a link flag, keep it
-                      tokens[i] = t
+    return items
 
-                # Re-join proecessed tokens with commas
-                libs.append(",".join(tokens))
-            elif item.startswith("-l"):
-                # It's either a -lXYZ lib or a link flag. Keep it as is.
-                libs.append(item)
-            else:
-                # We want to get an abs path, with symlinks resolved *except* for symlinks
-                # in the file name, to avoid an error we're seeing where libdl.so points
-                # to the file libdl-2.28.so (an odd name: usually we see libdl.so.2.28)
-                lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
-                if not lib_file_full.exists():
-                    print (f"could not locate lib: {lib_file_full}")
-                    print (f"cwd: {os.getcwd()}")
-                    raise ValueError
-                lib_file      = lib_file_full.name
-                lib_path      = lib_file_full.parent
-                # Remove all extensions (such as .so.5), and remove first 3 chars (lib)
-                lib_name = str(lib_file).split('.')[0][3:]
-                libs.append (f"-l{lib_name}")
-                if not lib_path in libs_dirs and not str(lib_path).startswith(str(bin_dir)):
-                    libs_dirs.append(lib_path)
+###############################################################################
+def parse_link_line(items,install_lib_dir,bin_dir,make_dir):
+###############################################################################
+    libs = []
+    libs_dirs = [install_lib_dir]
+    for item in items:
+        if "," in item:
+            # This are link options, so process them one by one
+            tokens = item.split(',')
+            for i,t in enumerate(tokens):
+                if ':' in t:
+                  paths = t.split(':')
+                  # Loop over all paths, replace them with install dir
+                  for j,p in enumerate(paths):
+                    path = pathlib.Path(p).resolve()
+                    paths[j] = str(install_lib_dir)
+
+                  # Replace the rpath list with the unique list
+                  tokens[i] = ':'.join(list(set(paths)))
+                else:
+                  # Just a link flag, keep it
+                  tokens[i] = t
+
+            # Re-join proecessed tokens with commas
+            libs.append(",".join(tokens))
+        elif item.startswith("-l"):
+            # It's either a -lXYZ lib or a link flag. Keep it as is.
+            libs.append(item)
+        else:
+            # We want to get an abs path, with symlinks resolved *except* for symlinks
+            # in the file name, to avoid an error we're seeing where libdl.so points
+            # to the file libdl-2.28.so (an odd name: usually we see libdl.so.2.28)
+            lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
+            if not lib_file_full.exists():
+                print (f"could not locate lib: {lib_file_full}")
+                print (f"cwd: {os.getcwd()}")
+                raise ValueError
+            lib_file      = lib_file_full.name
+            lib_path      = lib_file_full.parent
+            # Remove all extensions (such as .so.5), and remove first 3 chars (lib)
+            lib_name = str(lib_file).split('.')[0][3:]
+            libs.append (f"-l{lib_name}")
+            if not lib_path in libs_dirs and not str(lib_path).startswith(str(bin_dir)):
+                libs_dirs.append(lib_path)
+
+    return libs_dirs, libs
+
+###############################################################################
+def run (bin_dir,install_lib_dir, cmake_generator):
+###############################################################################
+
+    if cmake_generator=="Unix Makefiles":
+        items = get_link_line_make (bin_dir)
+    elif cmake_generator=="Ninja":
+        items = get_link_line_ninja (bin_dir)
+    else:
+        print(f"ERROR! Unknown/unsupported cmake generator '{cmake_generator}'")
+        raise RuntimeError
+
+    libs = []
+    libs_dirs = [install_lib_dir]
+
+    for item in items:
+        if "," in item:
+            # This are link options, so process them one by one
+            tokens = item.split(',')
+            for i,t in enumerate(tokens):
+                if ':' in t:
+                  paths = t.split(':')
+                  # Loop over all paths, replace them with install dir
+                  for j,p in enumerate(paths):
+                    path = pathlib.Path(p).resolve()
+                    paths[j] = str(install_lib_dir)
+
+                  # Replace the rpath list with the unique list
+                  tokens[i] = ':'.join(list(set(paths)))
+                else:
+                  # Just a link flag, keep it
+                  tokens[i] = t
+
+            # Re-join proecessed tokens with commas
+            libs.append(",".join(tokens))
+        elif item.startswith("-l"):
+            # It's either a -lXYZ lib or a link flag. Keep it as is.
+            libs.append(item)
+        else:
+            # We want to get an abs path, with symlinks resolved *except* for symlinks
+            # in the file name, to avoid an error we're seeing where libdl.so points
+            # to the file libdl-2.28.so (an odd name: usually we see libdl.so.2.28)
+            lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
+            if not lib_file_full.exists():
+                print (f"could not locate lib: {lib_file_full}")
+                print (f"cwd: {os.getcwd()}")
+                raise ValueError
+            lib_file      = lib_file_full.name
+            lib_path      = lib_file_full.parent
+            # Remove all extensions (such as .so.5), and remove first 3 chars (lib)
+            lib_name = str(lib_file).split('.')[0][3:]
+            libs.append (f"-l{lib_name}")
+            if not lib_path in libs_dirs and not str(lib_path).startswith(str(bin_dir)):
+                libs_dirs.append(lib_path)
                 
-    outfile = pathlib.Path(args["bin_dir"]) / "export_albany.in"
+    outfile = pathlib.Path(bin_dir) / "export_albany.in"
 
     link_line = ""
     for dir in libs_dirs:
@@ -82,6 +166,16 @@ def _main_func(description):
 
     with outfile.open('w') as fd:
         fd.write(f'ALBANY_LINK_LIBS="{link_line.strip()}"')
+
+###############################################################################
+def _main_func(description):
+###############################################################################
+    args = vars(parse_command_line(sys.argv, description))
+
+    bin_dir = pathlib.Path(args["bin_dir"]).resolve()
+    install_lib_dir = pathlib.Path(args["install_lib_dir"]).resolve()
+    generator = args["cmake_generator"]
+    run (bin_dir,install_lib_dir,generator)
         
     sys.exit(0)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -834,12 +834,19 @@ install(EXPORT albany-export DESTINATION ${CMAKE_INSTALL_LIBDIR}/Albany/cmake  F
 add_subdirectory (${CMAKE_SOURCE_DIR}/cmake/dummy
                   ${CMAKE_BINARY_DIR}/dummy)
 
+if (CMAKE_GENERATOR STREQUAL "Ninja")
+  set (WORK_DIR ${CMAKE_BINARY_DIR})
+elseif(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  set (WORK_DIR ${CMAKE_BINARY_DIR}/dummy)
+endif()
+
 add_custom_command (OUTPUT ${CMAKE_BINARY_DIR}/export_albany.in
                     COMMAND ${CMAKE_SOURCE_DIR}/cmake/CreateExportAlbany
                     ARGS --bin-dir ${CMAKE_BINARY_DIR}
                          --install-lib-dir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                         --cmake-generator ${CMAKE_GENERATOR}
                     DEPENDS ${CMAKE_BINARY_DIR}/src/Albany_GitVersion.h
-                    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/dummy)
+                    WORKING_DIRECTORY ${WORK_DIR})
 
 add_custom_target (create_export_albany ALL
                    DEPENDS ${CMAKE_BINARY_DIR}/export_albany.in)


### PR DESCRIPTION
This should allow to use Ninja as cmake generator, and produce a valid `export_albany.in` file. I tested it on my machine, and the generated file is equivalent to that generated when using Unix Makefiles.

This will have to be tested on some other machines, to make sure a) it works for Ninja, and b) doesn't break Unix Makefiles. Unfortunately, the way cmake generates the build/link files is not always consistent (e.g., absolute paths vs relative paths, link with full filepath vs -l$libname, etc), so it's likely I did not cover certain cases.

Further note: I based my implementation on whatever file ninja generated for me on my laptop, which is `build.ninja` in the binary root dir. I _think_ this is indeed the general case, but will have to keep an eye out to make sure of it.