### PR TITLE
Remove finalize_all()

### DIFF
--- a/src/LandIce/interface_with_mpas/Interface.cpp
+++ b/src/LandIce/interface_with_mpas/Interface.cpp
@@ -382,7 +382,7 @@ void velocity_solver_finalize() {
 
   mpiCommMPAS = Teuchos::null;
   if(kokkosInitializedByAlbany)
-    Kokkos::finalize_all();
+    Kokkos::finalize();
 }
 
 /*duality:

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -111,7 +111,7 @@ int main(int argc, char *argv[]) {
     stackedTimer->report(std::cout, Teuchos::DefaultComm<int>::getComm(), options);
   }
 
-  Kokkos::finalize_all();
+  Kokkos::finalize();
 
   return failures;
 }

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -387,7 +387,7 @@ int main(int argc, char *argv[])
     stackedTimer->report(std::cout, Teuchos::DefaultComm<int>::getComm(), options);
   }
 
-  Kokkos::finalize_all();
+  Kokkos::finalize();
 
   return failures;
 }


### PR DESCRIPTION
@mperego This is the only deprecated warning I saw for Kokkos 3.7