### PR TITLE
Replace private Kokkos headers with Kokkos_Core.hpp

### DIFF
--- a/src/disc/stk/Albany_STKFieldContainerHelper_Def.hpp
+++ b/src/disc/stk/Albany_STKFieldContainerHelper_Def.hpp
@@ -9,8 +9,7 @@
 #include "Albany_GlobalLocalIndexer.hpp"
 #include "Albany_ThyraUtils.hpp"
 
-#include <Kokkos_HostSpace.hpp>
-#include <Kokkos_Layout.hpp>
+#include <Kokkos_Core.hpp>
 #include <stk_mesh/base/FieldBase.hpp>
 #include <type_traits>
 


### PR DESCRIPTION
Including private Kokkos headers is now deprecated as of 3.7, replacing existing private headers with Kokkos_Core.hpp