### PR TITLE
Refactor of the Hessian response for allowing for custom solvers

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -395,6 +395,45 @@ Application::initialSetUp(const RCP<Teuchos::ParameterList>& params)
 #endif
   }
 
+  //validate Hessian parameters
+  if(problemParams->isSublist("Hessian")) {
+    Teuchos::RCP<Teuchos::ParameterList> validHessianParams = Teuchos::rcp(new Teuchos::ParameterList("validHessianParams"));
+    validHessianParams->set<bool>("Write Hessian MatrixMarket", false);
+    validHessianParams->set<bool>("Use AD for Hessian-vector products (default)", true);
+
+    validHessianParams->sublist("Residual").set<bool>("Use AD for Hessian-vector products (default)", false);
+    validHessianParams->sublist("Residual").set<std::string>("Enable AD for Hessian-vector product contributions of", "(x,x) (p0,p0) (p0,p1) (p1,p0) (p1,p1)");
+    validHessianParams->sublist("Residual").set<std::string>("Disable AD for Hessian-vector product contributions of", "(x,p0) (x,p1) (p0,x) (p1,x)");
+
+    // We want to allow the user to add hessian settings for responses (parameters) even if those responses (parameters) are not used.
+    int maxNumResonses(3),maxNumParameters(3);
+
+    //Make sure that the problem does not require more responses (parameters) than anticipated. 
+    if (problemParams->isSublist("Response Functions")) 
+      maxNumResonses = std::max(maxNumResonses, problemParams->sublist("Response Functions").get<int>("Number Of Responses"));
+    if (problemParams->isSublist("Parameters")) 
+      maxNumParameters = std::max(maxNumParameters, problemParams->sublist("Parameters").get<int>("Number Of Parameters"));
+
+    for(int response_index = 0;  response_index < maxNumResonses; response_index++) {
+      auto& validHessianResponseParams = validHessianParams->sublist(util::strint("Response", response_index));
+      validHessianResponseParams.set<bool>("Use AD for Hessian-vector products (default)", false);
+      validHessianResponseParams.set<bool>("Reconstruct H_pp", false);
+      validHessianResponseParams.set<std::string>("Enable AD for Hessian-vector product contributions of", "(x,x) (p0,p0) (p0,p1) (p1,p0) (p1,p1)");
+      validHessianResponseParams.set<std::string>("Disable AD for Hessian-vector product contributions of", "(x,p0) (x,p1) (p0,x) (p1,x)");
+      for (int i=0; i<maxNumParameters; ++i) {
+        auto& pl = validHessianResponseParams.sublist(util::strint("Parameter", i), false,"");
+        pl.set<bool>("Replace H_pp with Identity",false);
+        pl.set<bool>("Reconstruct H_pp using Hessian-vector products",true);
+        pl.sublist("H_pp Solver",false,"");
+      }
+    }
+
+    auto hessianParams = problemParams->sublist("Hessian");
+    hessianParams.validateParameters(*validHessianParams,2);
+  }
+
+
+
   // Create debug output object
   RCP<Teuchos::ParameterList> debugParams =
       Teuchos::sublist(params, "Debug Output", true);
@@ -2485,16 +2524,8 @@ Application::evaluateResponseHessian_pp(
   RCP<Tpetra_CrsMatrix> Ht = Albany::getTpetraMatrix(H);
   Ht->resumeFill();
 
-  Teuchos::RCP<Teuchos::ParameterList> validHessianResponseParams = Teuchos::rcp(new Teuchos::ParameterList("validHessianResponseParams"));;
-  validHessianResponseParams->set<bool>("Use AD for Hessian-vector products (default)", false);
-  validHessianResponseParams->set<bool>("Reconstruct H_pp", false);
-
-  for (int i=0; i<problemParams->sublist("Parameters").get<int>("Number Of Parameters"); ++i)
-    validHessianResponseParams->set<bool>(util::strint("Replace H_pp with Identity for Parameter", i), false);
-
   auto hessianResponseParams = problemParams->sublist("Hessian").sublist(util::strint("Response", response_index));
-  hessianResponseParams.validateParametersAndSetDefaults(*validHessianResponseParams, 0);
-  bool replace_by_I = hessianResponseParams.get<bool>(util::strint("Replace H_pp with Identity for Parameter", parameter_index));
+  bool replace_by_I = hessianResponseParams.sublist(util::strint("Parameter", parameter_index)).get("Replace H_pp with Identity", false);
 
   if (replace_by_I) {
     auto rangeMap = Ht->getRangeMap();

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -567,10 +567,19 @@ ModelEvaluator::create_hess_g_pp( int j, int l1, int l2 ) const
           << "l2 = " << l2
           << std::endl);
 
+  auto pl = app->getProblemPL()->sublist("Hessian").sublist(util::strint("Response",j)).sublist(util::strint("Parameter",l1));
+  bool HessVecProdBasedOp = pl.get("Reconstruct H_pp using Hessian-vector products",true);
+
   if (l1 < num_param_vecs) {
+    TEUCHOS_TEST_FOR_EXCEPTION(!HessVecProdBasedOp, std::logic_error, 
+            std::endl
+                << "Error!  Albany::ModelEvaluator::create_hess_g_pp():  "
+                << "Hessian pp operator for scalar response " << j << " and parameter " << l1 << " can only be reconstructed via Hessian-vector products"
+                << std::endl); 
     return Albany::createDenseHessianLinearOp(param_vss[l1]);
   }
   else {
+
     // distributed parameters
     TEUCHOS_TEST_FOR_EXCEPTION(
         l1 >= num_param_vecs + num_dist_param_vecs || l1 < num_param_vecs,
@@ -580,13 +589,24 @@ ModelEvaluator::create_hess_g_pp( int j, int l1, int l2 ) const
             << "Invalid parameter index l1 = "
             << l1
             << std::endl);
+    const Teuchos::ParameterList& rList = app->getProblemPL()->sublist("Response Functions").sublist(util::strint("Response", j));
+    const std::string& name = rList.isParameter("Name") ? rList.get<std::string>("Name") : std::string("");
 
-    Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOverlappedVectorSpace();
-    Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOwnedVectorSpace();
-    std::vector<IDArray> vElDofs =
-      distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs();
-
-    return Albany::createSparseHessianLinearOp(p_owned_vs, p_overlapped_vs, vElDofs);
+    if(HessVecProdBasedOp) {
+      Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOverlappedVectorSpace();
+      Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs = distParamLib->get(dist_param_names[l1 - num_param_vecs])->get_cas_manager()->getOwnedVectorSpace();
+      std::vector<IDArray> vElDofs =
+        distParamLib->get(dist_param_names[l1 - num_param_vecs])->workset_elem_dofs();
+      return Albany::createSparseHessianLinearOp(p_owned_vs, p_overlapped_vs, vElDofs);
+    } else {
+      Teuchos::RCP<Thyra_LinearOp> linOp = app->getResponse(j)->get_Hess_pp_operator(dist_param_names[l1 - num_param_vecs]);
+      TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(linOp), std::logic_error, 
+            std::endl
+                << "Error!  Albany::ModelEvaluator::create_hess_g_pp():  "
+                << "Hessian pp operator not defined for response " << j << " and parameter " << dist_param_names[l1 - num_param_vecs]
+                << std::endl); 
+      return linOp;
+    }
   }
 }
 
@@ -1515,14 +1535,26 @@ evalModelImpl(const Thyra_InArgs&  inArgs,
       const Teuchos::RCP<Thyra_LinearOp> g_hess_pp =
         outArgs.supports(Thyra_ModelEvaluator::OUT_ARG_hess_g_pp, j, l1, l1) ?
         outArgs.get_hess_g_pp(j, l1, l1) : Teuchos::null;
-
       if (Teuchos::nonnull(g_hess_pp)) {
-        app->evaluateResponseHessian_pp(j, l1, curr_time, x, x_dot, x_dotdot,
-                  sacado_param_vec,
-                  all_param_names[l1],
-                  g_hess_pp);
-        if(appParams->sublist("Problem").sublist("Hessian").get<bool>("Write Hessian MatrixMarket", false))
-          Albany::writeMatrixMarket(Albany::getTpetraMatrix(g_hess_pp).getConst(), "H", l1);
+        auto hessParams = appParams->sublist("Problem").sublist("Hessian");
+        auto hess_pp_matrix_op = Teuchos::rcp_dynamic_cast<MatrixBased_LOWS>(g_hess_pp);
+        if(Teuchos::nonnull(hess_pp_matrix_op)) {
+          app->evaluateResponseHessian_pp(j, l1, curr_time, x, x_dot, x_dotdot,
+                    sacado_param_vec,
+                    all_param_names[l1],
+                    hess_pp_matrix_op->getMatrix());
+          if(hessParams.get<bool>("Write Hessian MatrixMarket", false))
+            Albany::writeMatrixMarket(Albany::getTpetraMatrix(hess_pp_matrix_op->getMatrix()).getConst(), "H", l1);
+        }
+
+        //Initialize Solver only if Solver sublist is present
+        if(hessParams.sublist(util::strint("Response",j)).sublist(util::strint("Parameter",l1)).isSublist("H_pp Solver")) {
+          auto hess_pp = Teuchos::rcp_dynamic_cast<Init_LOWS>(g_hess_pp);
+          TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(hess_pp), std::runtime_error, 
+                  "hess_g_pp(" << j <<","<< l1  <<","<< l1 << ") is not derived from Hessian_LOWS.\n");
+          auto pl = hessParams.sublist(util::strint("Response",j)).sublist(util::strint("Parameter",l1)).sublist("H_pp Solver");
+          hess_pp->initializeSolver(Teuchos::rcpFromRef(pl));        
+        }
       }
 
       for (int l2 = 0; l2 < num_params; l2++) {

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -574,7 +574,7 @@ ModelEvaluator::create_hess_g_pp( int j, int l1, int l2 ) const
     TEUCHOS_TEST_FOR_EXCEPTION(!HessVecProdBasedOp, std::logic_error, 
             std::endl
                 << "Error!  Albany::ModelEvaluator::create_hess_g_pp():  "
-                << "Hessian pp operator for scalar response " << j << " and parameter " << l1 << " can only be reconstructed via Hessian-vector products"
+                << "Hessian pp operator for response " << j << " and non-distributed parameter " << l1 << " can only be reconstructed via Hessian-vector products"
                 << std::endl); 
     return Albany::createDenseHessianLinearOp(param_vss[l1]);
   }

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -63,7 +63,7 @@ enableMueLu(
     Stratimikos::DefaultLinearSolverBuilder&    linearSolverBuilder)
 {
 #ifdef ALBANY_MUELU
-  Stratimikos::enableMueLu<LO, Tpetra_GO, KokkosNode>(linearSolverBuilder);
+  Stratimikos::enableMueLu<ST, LO, Tpetra_GO, KokkosNode>(linearSolverBuilder);
 #endif
 }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,6 +142,7 @@ list (APPEND SOURCES
   utility/Albany_Gather.cpp
   utility/Albany_GlobalLocalIndexer.cpp
   utility/Albany_Hessian.cpp
+  utility/Albany_LinearOpWithSolveDecorators.cpp
   utility/Albany_StringUtils.cpp
   utility/Albany_ThyraCrsMatrixFactory.cpp
   utility/Albany_ThyraBlockedCrsMatrixFactory.cpp
@@ -167,6 +168,7 @@ list (APPEND HEADERS
   utility/Albany_GlobalLocalIndexer.hpp
   utility/Albany_GlobalLocalIndexerTpetra.hpp
   utility/Albany_Hessian.hpp
+  utility/Albany_LinearOpWithSolveDecorators.hpp
   utility/Albany_ThyraCrsMatrixFactory.hpp
   utility/Albany_ThyraBlockedCrsMatrixFactory.hpp
   utility/Albany_ThyraUtils.hpp

--- a/src/responses/Albany_AbstractResponseFunction.hpp
+++ b/src/responses/Albany_AbstractResponseFunction.hpp
@@ -140,6 +140,9 @@ namespace Albany {
       const std::string& dist_param_name,
       const std::string& dist_param_direction_name,
       const Teuchos::RCP<Thyra_MultiVector>& Hv_dp) = 0;
+
+    //! Returns a linear operator for the Hessian of the response with respect of the parameter param_name
+    virtual Teuchos::RCP<Thyra_LinearOp> get_Hess_pp_operator(const std::string& param_name) {return Teuchos::null;}
     //@}
 
     virtual void printResponse(

--- a/src/utility/Albany_Hessian.cpp
+++ b/src/utility/Albany_Hessian.cpp
@@ -1,5 +1,4 @@
-#include "Albany_TpetraTypes.hpp"
-#include "Albany_StateInfoStruct.hpp"
+
 #include "Albany_Hessian.hpp"
 #include "Albany_KokkosUtils.hpp"
 #include "Albany_Utils.hpp"
@@ -7,18 +6,12 @@
 #include "Albany_TpetraThyraUtils.hpp"
 #include "Albany_StringUtils.hpp"
 
-#include <Teuchos_RCP.hpp>
-#include <Kokkos_UnorderedMap.hpp>
-#include <Kokkos_Sort.hpp>
-
-#include <math.h>
-
 namespace Albany
 {
 
-Teuchos::RCP<Thyra_LinearOp>
-createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
-{
+  Teuchos::RCP<MatrixBased_LOWS>
+  createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
+  {
     Teuchos::RCP<const Tpetra_Map> p_map = getTpetraMap(p_vs);
     Teuchos::RCP<Thyra_LinearOp> H;
 
@@ -28,12 +21,14 @@ createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
 
     Teuchos::Array<Tpetra_GO> cols(num_params);
 
-    for (Tpetra_GO iparam=0; iparam<num_params; ++iparam) {
-        cols[iparam] = p_map->getGlobalElement(iparam);
+    for (Tpetra_GO iparam = 0; iparam < num_params; ++iparam)
+    {
+      cols[iparam] = p_map->getGlobalElement(iparam);
     }
 
-    for (Tpetra_GO iparam=0; iparam<num_params; ++iparam) {
-        Hgraph->insertGlobalIndices(cols[iparam], num_params, cols.getRawPtr());
+    for (Tpetra_GO iparam = 0; iparam < num_params; ++iparam)
+    {
+      Hgraph->insertGlobalIndices(cols[iparam], num_params, cols.getRawPtr());
     }
 
     Hgraph->fillComplete();
@@ -42,15 +37,15 @@ createDenseHessianLinearOp(Teuchos::RCP<const Thyra_VectorSpace> p_vs)
     H = createThyraLinearOp(Ht);
     assign(H, 0.0);
 
-    return H;
-}
+    return Teuchos::rcp(new MatrixBased_LOWS(H));
+  }
 
-Teuchos::RCP<Thyra_LinearOp>
-createSparseHessianLinearOp(
-    Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
-    Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
-    const std::vector<IDArray> vElDofs)
-{
+  Teuchos::RCP<MatrixBased_LOWS>
+  createSparseHessianLinearOp(
+      Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+      Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+      const std::vector<IDArray> vElDofs)
+  {
     Teuchos::RCP<const Tpetra_Map> p_overlapped_map = getTpetraMap(p_overlapped_vs);
     Teuchos::RCP<const Tpetra_Map> p_owned_map = getTpetraMap(p_owned_vs);
     Teuchos::RCP<Thyra_LinearOp> H;
@@ -63,10 +58,10 @@ createSparseHessianLinearOp(
 
     for (std::size_t wsIndex = 0; wsIndex < nws; ++wsIndex)
     {
-        const std::size_t num_elem_per_ws_i = vElDofs[wsIndex].dimension(0);
-        if (num_elem_per_ws != num_elem_per_ws_i && wsIndex + 1 < nws)
-            same_num_elem_per_ws = false;
-        num_elem += vElDofs[wsIndex].dimension(0);
+      const std::size_t num_elem_per_ws_i = vElDofs[wsIndex].dimension(0);
+      if (num_elem_per_ws != num_elem_per_ws_i && wsIndex + 1 < nws)
+        same_num_elem_per_ws = false;
+      num_elem += vElDofs[wsIndex].dimension(0);
     }
 
     TEUCHOS_TEST_FOR_EXCEPTION(
@@ -83,28 +78,28 @@ createSparseHessianLinearOp(
 
     Tpetra_GO cols[1];
 
-    for (std::size_t ielem=0; ielem<num_elem; ++ielem) {
-        IDArray wsElDofs = vElDofs[floor(ielem / num_elem_per_ws)];
-        const Tpetra_LO ielem_ws = ielem % num_elem_per_ws;
-        for (std::size_t i = 0; i < NN; ++i)
+    for (std::size_t ielem = 0; ielem < num_elem; ++ielem)
+    {
+      IDArray wsElDofs = vElDofs[floor(ielem / num_elem_per_ws)];
+      const Tpetra_LO ielem_ws = ielem % num_elem_per_ws;
+      for (std::size_t i = 0; i < NN; ++i)
+      {
+        const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem_ws, (int)i, 0);
+        if (lcl_overlapped_node1 < 0)
+          continue;
+
+        const GO row = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
+
+        for (std::size_t j = 0; j < NN; ++j)
         {
-            const Tpetra_LO lcl_overlapped_node1 = wsElDofs((int)ielem_ws, (int)i, 0);
-            if (lcl_overlapped_node1 < 0)
-                continue;
+          const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem_ws, (int)j, 0);
+          if (lcl_overlapped_node2 < 0)
+            continue;
 
-            const GO row = p_overlapped_map->getGlobalElement(lcl_overlapped_node1);
-
-            for (std::size_t j = 0; j < NN; ++j)
-            {
-                const Tpetra_LO lcl_overlapped_node2 = wsElDofs((int)ielem_ws, (int)j, 0);
-                if (lcl_overlapped_node2 < 0)
-                    continue;
-
-                cols[0] = p_overlapped_map->getGlobalElement(lcl_overlapped_node2);
-
-                Hgraph->insertGlobalIndices(row, 1, cols);
-            }
+          cols[0] = p_overlapped_map->getGlobalElement(lcl_overlapped_node2);
+          Hgraph->insertGlobalIndices(row, 1, cols);
         }
+      }
     }
 
     Hgraph->fillComplete();
@@ -112,12 +107,11 @@ createSparseHessianLinearOp(
 
     H = createThyraLinearOp(Ht);
     assign(H, 0.0);
+    return Teuchos::rcp(new MatrixBased_LOWS(H));
+  }
 
-    return H;
-}
-
-void getHessianBlockIDs(int &i1, int &i2, std::string blockName)
-{
+  void getHessianBlockIDs(int &i1, int &i2, std::string blockName)
+  {
     std::string tmp = blockName;
     tmp.erase(std::remove(tmp.begin(), tmp.end(), '('), tmp.end());
     tmp.erase(std::remove(tmp.begin(), tmp.end(), ')'), tmp.end());
@@ -129,44 +123,44 @@ void getHessianBlockIDs(int &i1, int &i2, std::string blockName)
 
     for (int i = 0; i < 2; ++i)
     {
-        if (block_ids[i][0] == 'x')
-            ids[i] = 0;
-        else if (block_ids[i][0] == 'p')
-            ids[i] = stoi(block_ids[i].substr(1)) + 1;
-        else
-            TEUCHOS_TEST_FOR_EXCEPTION(
-                true,
-                Teuchos::Exceptions::InvalidParameter,
-                std::endl
-                    << "Error!  Albany::getHessianBlockIDs():  "
-                    << "The name " << blockName
-                    << " is incorrect; it is impossible to deduce if "
-                    << block_ids[i]
-                    << " refers to a parameter or the solution."
-                    << std::endl);
+      if (block_ids[i][0] == 'x')
+        ids[i] = 0;
+      else if (block_ids[i][0] == 'p')
+        ids[i] = stoi(block_ids[i].substr(1)) + 1;
+      else
+        TEUCHOS_TEST_FOR_EXCEPTION(
+            true,
+            Teuchos::Exceptions::InvalidParameter,
+            std::endl
+                << "Error!  Albany::getHessianBlockIDs():  "
+                << "The name " << blockName
+                << " is incorrect; it is impossible to deduce if "
+                << block_ids[i]
+                << " refers to a parameter or the solution."
+                << std::endl);
     }
 
     i1 = ids[0];
     i2 = ids[1];
-}
+  }
 
-void getParameterVectorID(
-    int &i,
-    bool &is_distributed,
-    std::string parameterName)
-{
+  void getParameterVectorID(
+      int &i,
+      bool &is_distributed,
+      std::string parameterName)
+  {
     std::vector<std::string> elems;
     util::splitStringOnDelim(parameterName, ' ', elems);
     if (elems.size() == 2 && elems[0].compare("parameter_vector") == 0)
     {
-        is_distributed = false;
-        i = stoi(elems[1]);
+      is_distributed = false;
+      i = stoi(elems[1]);
     }
     else
     {
-        is_distributed = true;
-        i = -1;
+      is_distributed = true;
+      i = -1;
     }
-}
+  }
 
 } // namespace Albany

--- a/src/utility/Albany_Hessian.hpp
+++ b/src/utility/Albany_Hessian.hpp
@@ -1,81 +1,85 @@
 #ifndef ALBANY_HESSIAN_HPP
 #define ALBANY_HESSIAN_HPP
 
+#include "Albany_LinearOpWithSolveDecorators.hpp"
+#include "Thyra_MultiVectorBase_decl.hpp"
+#include "Albany_StateInfoStruct.hpp"
+
 namespace Albany
 {
-    /**
-     * \brief createDenseHessianLinearOp function
-     *
-     * This function computes the Thyra::LinearOp associated to
-     * the Hessian w.r.t a parameter vector.
-     *
-     * \param p_vs [in] Thyra::VectorSpace which specifies the entries of the current parameter vector.
-     */
-    Teuchos::RCP<Thyra_LinearOp> createDenseHessianLinearOp(
-        Teuchos::RCP<const Thyra_VectorSpace> p_vs);
 
-    /**
-     * \brief createSparseHessianLinearOp function
-     *
-     * This function computes the Thyra::LinearOp associated to
-     * the Hessian w.r.t a distributed parameter.
-     *
-     * \param p_owned_vs [in] Thyra::VectorSpace which specifies the owned entries of the current distributed parameter.
-     *
-     * \param p_overlapped_vs [in] Thyra::VectorSpace which specifies the overlapped entries of the current distributed parameter.
-     *
-     * \param wsElDofs [in] Vector of IDArray associated to the mesh used.
-     */
-    Teuchos::RCP<Thyra_LinearOp> createSparseHessianLinearOp(
-        Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
-        Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
-        const std::vector<IDArray> wsElDofs);
+  /**
+   * \brief createDenseHessianLinearOp function
+   *
+   * This function computes the Thyra::LinearOp associated to
+   * the Hessian w.r.t a parameter vector.
+   *
+   * \param p_vs [in] Thyra::VectorSpace which specifies the entries of the current parameter vector.
+   */
+  Teuchos::RCP<MatrixBased_LOWS> createDenseHessianLinearOp(
+      Teuchos::RCP<const Thyra_VectorSpace> p_vs);
 
-    /**
-     * \brief getHessianBlockIDs function
-     *
-     * This function gets the block IDs of a block of the Hessian matrix from a blockName.
-     * For example, this function associates the following IDs to the following names:
-     *  - i1=0, i2=0, and blockName="(x,x)",
-     *  - i1=0, i2=1, and blockName="(x,p0)",
-     *  - i1=0, i2=2, and blockName="(x,p1)",
-     *  - i1=1, i2=0, and blockName="(p0,x)",
-     *  - i1=3, i2=5, and blockName="(p2,p4)",
-     *  - (...)
-     * 
-     * \param i1 [out] First block index.
-     *
-     * \param i2 [out] Second block index.
-     *
-     * \param blockName [in] Name of the block for which the IDs have to be computed.
-     */
-    void getHessianBlockIDs(
-        int & i1,
-        int & i2,
-        std::string blockName
-    );
+  /**
+   * \brief createSparseHessianLinearOp function
+   *
+   * This function computes the Thyra::LinearOp associated to
+   * the Hessian w.r.t a distributed parameter.
+   *
+   * \param p_owned_vs [in] Thyra::VectorSpace which specifies the owned entries of the current distributed parameter.
+   *
+   * \param p_overlapped_vs [in] Thyra::VectorSpace which specifies the overlapped entries of the current distributed parameter.
+   *
+   * \param wsElDofs [in] Vector of IDArray associated to the mesh used.
+   */
+  Teuchos::RCP<MatrixBased_LOWS> createSparseHessianLinearOp(
+      Teuchos::RCP<const Thyra_VectorSpace> p_owned_vs,
+      Teuchos::RCP<const Thyra_VectorSpace> p_overlapped_vs,
+      const std::vector<IDArray> wsElDofs);
 
-    /**
-     * \brief getParameterVectorID function 
-     *
-     * This function tests if the name parameterName is associated to a parameter vector
-     * (in this case, a scalar parameter which is not included in a parameter vector in the .yaml file
-     * is considered as a parameter vector of size 1) or to a distributed parameter.
-     *
-     * If the parameterName is associated to a parameter vector, the function computes the index of
-     * associated parameter vector.
-     *
-     * \param i [out] Index associated to the parameter vector (if the current parameter is a parameter vector).
-     *
-     * \param is_distributed [out] Bool which specifies if the current parameter is a parameter vector.
-     *
-     * \param parameterName [in] Name of the current parameter.
-     */
-    void getParameterVectorID(
-        int & i,
-        bool & is_distributed,
-        std::string parameterName
-    );
+  /**
+   * \brief getHessianBlockIDs function
+   *
+   * This function gets the block IDs of a block of the Hessian matrix from a blockName.
+   * For example, this function associates the following IDs to the following names:
+   *  - i1=0, i2=0, and blockName="(x,x)",
+   *  - i1=0, i2=1, and blockName="(x,p0)",
+   *  - i1=0, i2=2, and blockName="(x,p1)",
+   *  - i1=1, i2=0, and blockName="(p0,x)",
+   *  - i1=3, i2=5, and blockName="(p2,p4)",
+   *  - (...)
+   *
+   * \param i1 [out] First block index.
+   *
+   * \param i2 [out] Second block index.
+   *
+   * \param blockName [in] Name of the block for which the IDs have to be computed.
+   */
+  void getHessianBlockIDs(
+      int &i1,
+      int &i2,
+      std::string blockName);
+
+  /**
+   * \brief getParameterVectorID function
+   *
+   * This function tests if the name parameterName is associated to a parameter vector
+   * (in this case, a scalar parameter which is not included in a parameter vector in the .yaml file
+   * is considered as a parameter vector of size 1) or to a distributed parameter.
+   *
+   * If the parameterName is associated to a parameter vector, the function computes the index of
+   * associated parameter vector.
+   *
+   * \param i [out] Index associated to the parameter vector (if the current parameter is a parameter vector).
+   *
+   * \param is_distributed [out] Bool which specifies if the current parameter is a parameter vector.
+   *
+   * \param parameterName [in] Name of the current parameter.
+   */
+  void getParameterVectorID(
+      int &i,
+      bool &is_distributed,
+      std::string parameterName);
+
 } // namespace Albany
 
 #endif // ALBANY_HESSIAN_HPP

--- a/src/utility/Albany_LinearOpWithSolveDecorators.cpp
+++ b/src/utility/Albany_LinearOpWithSolveDecorators.cpp
@@ -1,0 +1,89 @@
+#include "Albany_LinearOpWithSolveDecorators.hpp"
+#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+#include "Thyra_Ifpack2PreconditionerFactory.hpp"
+#include "Stratimikos_MueLuHelpers.hpp"
+#include "Albany_TpetraTypes.hpp"
+
+namespace Albany
+{
+
+  MatrixBased_LOWS::
+      MatrixBased_LOWS(
+          const Teuchos::RCP<Thyra_LinearOp> &matrix) : mat_(matrix) {}
+
+  MatrixBased_LOWS::
+      ~MatrixBased_LOWS() {}
+
+  Teuchos::RCP<const Thyra_VectorSpace>
+  MatrixBased_LOWS::
+      domain() const
+  {
+    return mat_->domain();
+  }
+
+  Teuchos::RCP<const Thyra_VectorSpace>
+  MatrixBased_LOWS::
+      range() const
+  {
+    return mat_->range();
+  }
+
+  Teuchos::RCP<Thyra_LinearOp>
+  MatrixBased_LOWS::
+      getMatrix()
+  {
+    return mat_;
+  }
+
+  void
+  MatrixBased_LOWS::
+      initializeSolver(Teuchos::RCP<Teuchos::ParameterList> solverParamList)
+  {
+    std::string solverType = solverParamList->get<std::string>("Linear Solver Type");
+    Stratimikos::DefaultLinearSolverBuilder strat;
+#ifdef ALBANY_MUELU
+    Stratimikos::enableMueLu<double, LO, Tpetra_GO, KokkosNode>(strat);
+#endif
+#ifdef ALBANY_IFPACK2
+    strat.setPreconditioningStrategyFactory(
+        Teuchos::abstractFactoryStd<Thyra::PreconditionerFactoryBase<ST>,
+                                    Thyra::Ifpack2PreconditionerFactory<Tpetra_CrsMatrix>>(),
+        "Ifpack2", true);
+#endif
+    strat.setParameterList(solverParamList);
+    auto lows_factory = strat.createLinearSolveStrategy(solverType);
+    solver_ = lows_factory->createOp();
+    Thyra::initializeOp<double>(*lows_factory, mat_, solver_.ptr(), Thyra::SUPPORT_SOLVE_FORWARD_ONLY);
+  }
+
+  bool
+  MatrixBased_LOWS::
+      opSupportedImpl(Thyra::EOpTransp M_trans) const
+  {
+    return mat_->opSupported(M_trans);
+  }
+
+  void
+  MatrixBased_LOWS::
+      applyImpl(const Thyra::EOpTransp M_trans,
+                const Thyra_MultiVector &X,
+                const Teuchos::Ptr<Thyra_MultiVector> &Y,
+                const ST alpha,
+                const ST beta) const
+  {
+    mat_->apply(M_trans, X, Y, alpha, beta);
+  }
+
+  Thyra::SolveStatus<double>
+  MatrixBased_LOWS::
+      solveImpl(
+          const Thyra::EOpTransp transp,
+          const Thyra_MultiVector &B,
+          const Teuchos::Ptr<Thyra_MultiVector> &X,
+          const Teuchos::Ptr<const Thyra::SolveCriteria<ST>> solveCriteria) const
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION(Teuchos::is_null(solver_), std::runtime_error, "Error! MatrixBased_LOWS::solveImpl, Solver not initialized, call initializeSolver first.\n");
+    return solver_->solve(transp, B, X, solveCriteria);
+  }
+
+} // namespace Albany

--- a/src/utility/Albany_LinearOpWithSolveDecorators.hpp
+++ b/src/utility/Albany_LinearOpWithSolveDecorators.hpp
@@ -1,0 +1,80 @@
+#ifndef ALBANY_LINEAROPWITHSOLVEDECORATORS_HPP
+#define ALBANY_LINEAROPWITHSOLVEDECORATORS_HPP
+
+
+#include "Albany_ThyraTypes.hpp"
+#include "Thyra_Ifpack2PreconditionerFactory.hpp"
+#include "Stratimikos_DefaultLinearSolverBuilder.hpp"
+#include "Stratimikos_MueLuHelpers.hpp"
+
+namespace Albany
+{
+
+  //Decorator of Thyra::LinearOpWithSolveBase that provides a method to initialize the solver.
+  class Init_LOWS : public Thyra_LOWS
+  {
+  public:
+    virtual void initializeSolver(Teuchos::RCP<Teuchos::ParameterList> solverParamList) = 0;
+  };
+
+
+  //! MatrixBased_LOWS provides a concrete implementation of LinearOpWithSolve based on an existing matrix
+  /*!
+    * This class imports a given matrix (linear operator) and allows to initialize the solver
+    * using a provided Stratimikos parameter list.
+    */
+  class MatrixBased_LOWS : public Init_LOWS
+  {
+  public:
+    // Constructor
+    MatrixBased_LOWS(
+        const Teuchos::RCP<Thyra_LinearOp> &matrix);
+
+    //! Destructor
+    virtual ~MatrixBased_LOWS();
+
+    //! Overrides Thyra::LinearOpWithSolveBase purely virtual method
+    Teuchos::RCP<const Thyra_VectorSpace> domain() const;
+
+    //! Overrides Thyra::LinearOpWithSolveBase purely virtual method
+    Teuchos::RCP<const Thyra_VectorSpace> range() const;
+
+    //! Returns the matrix (linear operator) passed to the constructor
+    Teuchos::RCP<Thyra_LinearOp> getMatrix();
+
+    //! Initilializes the solver from a parameter list with Stratimikos parameters  
+    void initializeSolver(Teuchos::RCP<Teuchos::ParameterList> solverParamList);
+
+    //@}
+
+  protected:
+    //! Overrides Thyra::LinearOpWithSolveBase purely virtual method
+    bool opSupportedImpl(Thyra::EOpTransp M_trans) const;
+
+    //! Overrides Thyra::LinearOpWithSolveBase purely virtual method
+    void applyImpl(const Thyra::EOpTransp M_trans,
+                   const Thyra_MultiVector &X,
+                   const Teuchos::Ptr<Thyra_MultiVector> &Y,
+                   const ST alpha,
+                   const ST beta) const;
+
+    //! Overrides Thyra::LinearOpWithSolveBase purely virtual method
+    Thyra::SolveStatus<double> solveImpl(
+        const Thyra::EOpTransp transp,
+        const Thyra_MultiVector &B,
+        const Teuchos::Ptr<Thyra_MultiVector> &X,
+        const Teuchos::Ptr<const Thyra::SolveCriteria<ST>> solveCriteria) const;
+
+
+    //! stored the matrix passed to the constructor
+    const Teuchos::RCP<Thyra_LinearOp> mat_;
+
+    //! The Thyra LinearOpWithSolve object
+    Teuchos::RCP<Thyra_LOWS> solver_;
+    //@}
+
+  }; // class MatrixBased_LOWS
+
+} // namespace Albany
+
+#endif // ALBANY_LINEAROPWITHSOLVEDECORATORS_HPP

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -76,6 +76,30 @@ ANONYMOUS:
       Boundary Edges Set Name: lateralside
     Body Force:
       Type: FO INTERP SURF GRAD
+    Hessian:
+      Response 1:
+        Parameter 0:
+          Reconstruct H_pp using Hessian-vector products: false
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-9
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: RILUK
   Discretization:
     Method: Extruded
     Number Of Time Derivatives: 0
@@ -161,6 +185,7 @@ ANONYMOUS:
     Sensitivity Method: Adjoint
     Analysis:
       Output Level: 1
+      Output Final Parameters: false
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
@@ -173,7 +198,14 @@ ANONYMOUS:
         Full Space: false
         Use NOX Solver: false
 
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          Matrix Types:
+            Hessian Of Response:
+              Response Index: 1
+
         ROL Options:
+
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
           SimOpt:
             Solve:
@@ -190,7 +222,7 @@ ANONYMOUS:
           Status Test: 
             Gradient Tolerance: 1.0e-4
             Step Tolerance: 1.0e-10
-            Iteration Limit: 3
+            Iteration Limit: 1
 
           General:
             Output Level: 1
@@ -320,7 +352,7 @@ ANONYMOUS:
     Sensitivity For Parameter 0:
       Test Value: 4.530749883697e+00
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [88.249]
+    Piro Analysis Test Values: [57.7495]
   Regression For Response 1:
     Absolute Tolerance: 1.0e-06
     Relative Tolerance: 1.0e-06

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -88,6 +88,33 @@ ANONYMOUS:
       Boundary Edges Set Name: lateralside
     Body Force:
       Type: FO INTERP SURF GRAD
+    Hessian:
+      Response 1:
+        Parameter 0:
+          Reconstruct H_pp using Hessian-vector products: true
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
   Discretization:
     Method: Extruded
     Number Of Time Derivatives: 0
@@ -171,8 +198,8 @@ ANONYMOUS:
             File Name: ../AsciiMeshes/GisUnstructFiles/velocity_Magnitude_RMS.ascii
   Piro:
     Sensitivity Method: Adjoint
-    Output Level: 1
     Analysis:
+      Output Level: 1
       Output Final Parameters: false
       Analysis Package: ROL
       ROL:
@@ -191,31 +218,7 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 1
-              Remove Mean Of The Right-hand Side: false
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
+
         ROL Options:
 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 

--- a/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/small/LandIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -86,6 +86,58 @@ ANONYMOUS:
       Flow Rate Type: Temperature Based
     Body Force:
       Type: FO INTERP SURF GRAD
+    Hessian:
+      Response 1:
+        Parameter 0:
+          Reconstruct H_pp using Hessian-vector products: true
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
+        Parameter 1:
+          Reconstruct H_pp using Hessian-vector products: true
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
   Discretization:
     Method: Extruded
     Number Of Time Derivatives: 0
@@ -203,54 +255,7 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 1
-              Remove Mean Of The Right-hand Side: false
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
-                Block 1:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
+
         ROL Options:
         
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 

--- a/tests/small/LandIce/FO_Hydrology/input_dome_steady_bwd.yaml
+++ b/tests/small/LandIce/FO_Hydrology/input_dome_steady_bwd.yaml
@@ -59,6 +59,55 @@ ANONYMOUS:
         Use AD for Hessian-vector products (default): false
       Response 0:
         Use AD for Hessian-vector products (default): true
+        Parameter 0:
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-8
+                    Num Blocks: 197
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: none
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  # Amesos2 solver name: pardiso_mkl
+        Parameter 1:
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-8
+                    Num Blocks: 198
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: none
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  # Amesos2 solver name: pardiso_mkl
+                  
     Initial Condition:
       Function: Constant
       Function Data: [2.0, 2.0, 10.0]
@@ -271,53 +320,6 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 0
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-8
-                          Num Blocks: 197
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: none
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        # Amesos2 solver name: pardiso_mkl
-                Block 1:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-8
-                          Num Blocks: 198
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: none
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        # Amesos2 solver name: pardiso_mkl
 
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 

--- a/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
+++ b/tests/small/LandIce/FO_Thermo/humboldt_analysis.yaml
@@ -58,6 +58,30 @@ ANONYMOUS:
       Response 0:
         Use AD for Hessian-vector products (default): true
         Reconstruct H_pp: true
+        Parameter 0:
+          Linear Solver Type: Belos
+          Linear Solver Types:
+            Belos:
+              Solver Type: Block GMRES
+              Solver Types:
+                Block GMRES:
+                  Maximum Iterations: 200
+                  Convergence Tolerance: 1e-7
+                  Num Blocks: 200
+                  Output Frequency: 20
+                  Output Style: 1
+                  Verbosity: 33
+              VerboseObject:
+                Verbosity Level: medium
+          Preconditioner Type: Ifpack2
+          Preconditioner Types:
+            Ifpack2:
+              Overlap: 0
+              Prec Type: Amesos2
+              Ifpack2 Settings: 
+                Amesos2: {}
+                Amesos2 solver name: klu
+
       Write Hessian MatrixMarket: true
     LandIce Viscosity: 
       Extract Strain Rate Sq: true
@@ -267,31 +291,7 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 0
-              Remove Mean Of The Right-hand Side: false
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
+
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
           SimOpt:

--- a/tests/small/LandIce/FO_Thermo/humboldt_analysis_contiguous.yaml
+++ b/tests/small/LandIce/FO_Thermo/humboldt_analysis_contiguous.yaml
@@ -58,6 +58,30 @@ ANONYMOUS:
       Response 0:
         Use AD for Hessian-vector products (default): true
         Reconstruct H_pp: true
+        Parameter 0:
+          Linear Solver Type: Belos
+          Linear Solver Types:
+            Belos:
+              Solver Type: Block GMRES
+              Solver Types:
+                Block GMRES:
+                  Maximum Iterations: 200
+                  Convergence Tolerance: 1e-7
+                  Num Blocks: 200
+                  Output Frequency: 20
+                  Output Style: 1
+                  Verbosity: 33
+              VerboseObject:
+                Verbosity Level: medium
+          Preconditioner Type: Ifpack2
+          Preconditioner Types:
+            Ifpack2:
+              Overlap: 0
+              Prec Type: Amesos2
+              Ifpack2 Settings: 
+                Amesos2: {}
+                Amesos2 solver name: klu
+
       Write Hessian MatrixMarket: true
     LandIce Viscosity: 
       Extract Strain Rate Sq: true
@@ -267,31 +291,7 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 0
-              Remove Mean Of The Right-hand Side: false
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
+
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
           SimOpt:

--- a/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/small/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -37,7 +37,57 @@ ANONYMOUS:
       Response 0:
         Use AD for Hessian-vector products (default): true
         Reconstruct H_pp: true
-        Replace H_pp with Identity for Parameter 1: true
+        Parameter 0:         
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
+
+        Parameter 1:
+          Replace H_pp with Identity: true
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: Amesos2
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
+                  
       Write Hessian MatrixMarket: false 
     Response Functions:
       Number Of Responses: 1
@@ -108,54 +158,6 @@ ANONYMOUS:
           Matrix Types:
             Hessian Of Response:
               Response Index: 0
-              Remove Mean Of The Right-hand Side: false
-              Block Diagonal Solver:
-                Block 0:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
-                Block 1:
-                  Linear Solver Type: Belos
-                  Linear Solver Types:
-                    Belos:
-                      Solver Type: Block GMRES
-                      Solver Types:
-                        Block GMRES:
-                          Maximum Iterations: 200
-                          Convergence Tolerance: 1e-7
-                          Num Blocks: 200
-                          Output Frequency: 20
-                          Output Style: 1
-                          Verbosity: 33
-                      VerboseObject:
-                        Verbosity Level: medium
-                  Preconditioner Type: Ifpack2
-                  Preconditioner Types:
-                    Ifpack2:
-                      Overlap: 0
-                      Prec Type: Amesos2
-                      Ifpack2 Settings: 
-                        Amesos2: {}
-                        Amesos2 solver name: klu
 
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 


### PR DESCRIPTION
Until now the Hessian pp matrix has always been a Crs Matrix that can be solved for using standard solvers. However, in some cases it is not easy or performant to explicitly build the matrix. This PR allows a custom linear operator and solves for each response. If such operator is not provided, the Hessian response matrix is built using the current coloring-seeding approach that relies on Hessian vectors products and on the assumption of a finite-element like pattern (for distributed parameters)

This PR also implements the solver for the quadratic response.

A few tests are modified to comply with the changes.

This PR should be merged after https://github.com/trilinos/Trilinos/pull/11353.