### PR TITLE
Fix to Dirichlet conditions for DistParamDeriv evaluation.

### DIFF
--- a/pyAlbany/tests/steadyHeat/inv_steadyHeat.py
+++ b/pyAlbany/tests/steadyHeat/inv_steadyHeat.py
@@ -29,10 +29,10 @@ class TestSteadyHeat(unittest.TestCase):
         problem = Utils.createAlbanyProblem(parameter, cls.parallelEnv)
 
         g_target_before = 0.35681844
-        g_target_after = 0.17388298
-        g_target_2 = 0.19570272
-        p_0_target = 0.39886689
-        p_1_norm_target = 5.37319376038225
+        g_target_after = 0.17388281
+        g_target_2 = 0.1957233
+        p_0_target = 0.39855677
+        p_1_norm_target = 5.366834867170422
         tol = 5e-8
 
         problem.performSolve()

--- a/src/Albany_RegressionTests.cpp
+++ b/src/Albany_RegressionTests.cpp
@@ -210,7 +210,7 @@ std::pair<int,int> RegressionTests::checkAnalysisTestResults(
 
       if (testParams->get<bool>("Piro Analysis Test Two Norm",false)) {
         const auto norm = tvec->norm_2();
-        *out << "Parameter Vector Two Norm: " << norm << std::endl;
+        *out << "Parameter Vector Two Norm: " << std::setprecision(12) << norm << std::endl;
         failures += scaledCompare(norm, testValues[0], relTol, absTol, "Piro Analysis Test Two Norm");
         comparisons++;
       }

--- a/src/evaluators/bc/PHAL_Dirichlet.hpp
+++ b/src/evaluators/bc/PHAL_Dirichlet.hpp
@@ -115,6 +115,17 @@ class Dirichlet<PHAL::AlbanyTraits::DistParamDeriv,Traits>
    : public DirichletBase<PHAL::AlbanyTraits::DistParamDeriv, Traits> {
 public:
   Dirichlet(Teuchos::ParameterList& p);
+
+  /**
+    * @brief preEvaluate phase for PHAL::AlbanyTraits::DistParamDeriv EvaluationType.
+    *
+    * During the computation of the Distributed parameter derivative, for the transpose case, 
+    * we use a preEvaluate phase to zero out the Lagrange multipliers associated to degrees of freedom constrained
+    * by a Dirichlet boundary condition. It is necessary to do so in a pre-evaluate phase to ensure a correct implemetation when 
+    * two or more Dirichlet bcs are applied to the same degree of freedom (the last one applied is the one that gets prescribed).
+  */
+  void preEvaluate(typename Traits::EvalData d);
+  
   void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_DirichletField.hpp
+++ b/src/evaluators/bc/PHAL_DirichletField.hpp
@@ -89,6 +89,18 @@ class DirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>
   public:
     DirichletField(Teuchos::ParameterList& p);
     typedef typename PHAL::AlbanyTraits::DistParamDeriv::ScalarT ScalarT;
+
+    /**
+    * @brief preEvaluate phase for PHAL::AlbanyTraits::DistParamDeriv EvaluationType.
+    *
+    * During the computation of the Distributed parameter derivative, for the transpose case, 
+    * we use a preEvaluate phase to zero out the Lagrange multipliers associated to degrees of freedom constrained
+    * by a Dirichlet boundary condition, unless we are differentiating with repsect to this field, in which case we do not zero it out until the evaluation phase.
+    * It is necessary to do so in a pre-evaluate phase to ensure a correct implemetation when 
+    * two or more Dirichlet bcs are applied to the same degree of freedom (the last one applied is the one that gets prescribed).
+    */
+    void preEvaluate(typename Traits::EvalData d);
+    
     void evaluateFields(typename Traits::EvalData d);
 };
 
@@ -112,6 +124,7 @@ class DirichletField<PHAL::AlbanyTraits::HessianVec, Traits>
     * by a Dirichlet boundary condition.
     */
     void preEvaluate(typename Traits::EvalData d);
+    
     void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_DirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_DirichletField_Def.hpp
@@ -289,7 +289,7 @@ evaluateFields(typename Traits::EvalData dirichletWorkset) {
         int lunk = nsNodes[inode][this->offset];
         GO node_gid = nsNodesGIDs[inode];
         int lfield = fieldDofManager.getLocalDOF(field_node_indexer->getLocalElement(node_gid),fieldOffset);
-	      for (int col=0; col<num_cols; ++col) {
+        for (int col=0; col<num_cols; ++col) {
           fpV_nonconst2dView[col][lfield] -= Vp_nonconst2dView[col][lunk];
           Vp_nonconst2dView[col][lunk] = 0.0;
         }

--- a/src/evaluators/bc/PHAL_SDirichlet.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet.hpp
@@ -108,6 +108,17 @@ class SDirichlet<PHAL::AlbanyTraits::DistParamDeriv, Traits>
 
   SDirichlet(Teuchos::ParameterList& p);
 
+  /**
+  * @brief preEvaluate phase for PHAL::AlbanyTraits::DistParamDeriv EvaluationType.
+  *
+  * During the computation of the Distributed parameter derivative, for the transpose case, 
+  * we use a preEvaluate phase to zero out the Lagrange multipliers associated to degrees of freedom constrained
+  * by a Dirichlet boundary condition. It is necessary to do so in a pre-evaluate phase to ensure a correct implemetation when 
+  * two or more Dirichlet bcs are applied to the same degree of freedom (the last one applied is the one that gets prescribed).
+  */
+  void
+  preEvaluate(typename Traits::EvalData d);
+
   void
   evaluateFields(typename Traits::EvalData d);
 };

--- a/src/evaluators/bc/PHAL_SDirichletField.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField.hpp
@@ -112,6 +112,16 @@ class SDirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>
 
     SDirichletField(Teuchos::ParameterList& p);
 
+    /**
+    * @brief preEvaluate phase for PHAL::AlbanyTraits::DistParamDeriv EvaluationType.
+    *
+    * During the computation of the Distributed parameter derivative, for the transpose case, 
+    * we use a preEvaluate phase to zero out the Lagrange multipliers associated to degrees of freedom constrained
+    * by a Dirichlet boundary condition. It is necessary to do so in a pre-evaluate phase to ensure a correct implemetation when 
+    * two or more Dirichlet bcs are applied to the same degree of freedom (the last one applied is the one that gets prescribed).
+    */
+    void preEvaluate(typename Traits::EvalData d);
+    
     void evaluateFields(typename Traits::EvalData d);
 };
 
@@ -136,6 +146,7 @@ class SDirichletField<PHAL::AlbanyTraits::HessianVec, Traits>
     * by a Dirichlet boundary condition.
     */
     void preEvaluate(typename Traits::EvalData d);
+    
     void evaluateFields(typename Traits::EvalData d);
 };
 

--- a/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
@@ -359,11 +359,11 @@ void SDirichletField<PHAL::AlbanyTraits::DistParamDeriv, Traits>::
 preEvaluate(typename Traits::EvalData dirichletWorkset) {
 
   bool isFieldParameter =  dirichletWorkset.dist_param_deriv_name == this->field_name;
-    TEUCHOS_TEST_FOR_EXCEPTION(
+  TEUCHOS_TEST_FOR_EXCEPTION(
       isFieldParameter,
       std::logic_error,
       "Error, SDirichletField cannot handle dirichlet parameter " <<  this->field_name << ", use DirichletField instead." << std::endl);
-  
+
   bool trans = dirichletWorkset.transpose_dist_param_deriv;
 
   if (trans) {

--- a/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
@@ -280,45 +280,52 @@ SDirichlet<PHAL::AlbanyTraits::DistParamDeriv, Traits>::SDirichlet(
   return;
 }
 
-//
-//
-//
+// **********************************************************************
+template <typename Traits>
+void
+SDirichlet<PHAL::AlbanyTraits::DistParamDeriv, Traits>::preEvaluate(
+    typename Traits::EvalData dirichletWorkset)
+{
+  bool trans = dirichletWorkset.transpose_dist_param_deriv;
+  if (trans) {
+    auto Vp_bc = dirichletWorkset.Vp_bc;
+    Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> Vp_nonconst2dView = Albany::getNonconstLocalData(Vp_bc);
+
+    int num_cols = Vp_bc->domain()->dim();
+
+    const std::vector<std::vector<int> >& nsNodes =
+      dirichletWorkset.nodeSets->find(this->nodeSetID)->second;
+
+    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
+      int lunk = nsNodes[inode][this->offset];
+
+      for (int col=0; col<num_cols; ++col) {
+        Vp_nonconst2dView[col][lunk] = 0.0;
+       }
+    }
+  }
+}
+
+// **********************************************************************
 template <typename Traits>
 void
 SDirichlet<PHAL::AlbanyTraits::DistParamDeriv, Traits>::evaluateFields(
-    typename Traits::EvalData dirichlet_workset)
+    typename Traits::EvalData dirichletWorkset)
 {
-  Teuchos::RCP<Thyra_MultiVector> fpV = dirichlet_workset.fpV;
+  bool trans    = dirichletWorkset.transpose_dist_param_deriv;
 
-  bool trans    = dirichlet_workset.transpose_dist_param_deriv;
-  int  num_cols = fpV->domain()->dim();
-
-  const std::vector<std::vector<int>>& nsNodes =
-      dirichlet_workset.nodeSets->find(this->nodeSetID)->second;
-
-  if (trans) {
-    // For (df/dp)^T*V we zero out corresponding entries in V
-    Teuchos::RCP<Thyra_MultiVector>          Vp = dirichlet_workset.Vp_bc;
-    Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> Vp_nonconst2dView =
-        Albany::getNonconstLocalData(Vp);
-
-    for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
-      int lunk = nsNodes[inode][this->offset];
-
-      for (int col = 0; col < num_cols; ++col) {
-        //(*Vp)[col][lunk] = 0.0;
-        Vp_nonconst2dView[col][lunk] = 0.0;
-      }
-    }
-  } else {
+  if (!trans) {
     // for (df/dp)*V we zero out corresponding entries in df/dp
     Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> fpV_nonconst2dView =
-        Albany::getNonconstLocalData(fpV);
+        Albany::getNonconstLocalData(dirichletWorkset.fpV);
+
+    int  num_cols = dirichletWorkset.fpV->domain()->dim();
+    const std::vector<std::vector<int>>& nsNodes =
+      dirichletWorkset.nodeSets->find(this->nodeSetID)->second;
+    
     for (unsigned int inode = 0; inode < nsNodes.size(); inode++) {
       int lunk = nsNodes[inode][this->offset];
-
       for (int col = 0; col < num_cols; ++col) {
-        //(*fpV)[col][lunk] = 0.0;
         fpV_nonconst2dView[col][lunk] = 0.0;
       }
     }

--- a/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
@@ -301,7 +301,7 @@ SDirichlet<PHAL::AlbanyTraits::DistParamDeriv, Traits>::preEvaluate(
 
       for (int col=0; col<num_cols; ++col) {
         Vp_nonconst2dView[col][lunk] = 0.0;
-       }
+      }
     }
   }
 }

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -49,15 +49,15 @@ ANONYMOUS:
     Exodus Output File Name: steady2d_dirichlet_mixed_params.exo
     Cubature Degree: 9
   Regression For Response 0:
+    Relative Tolerance: 1.0e-07
+    Absolute Tolerance: 1.0e-07
     Test Value: 3.53554196849e-01
-    Relative Tolerance: 1.0e-03
-    Absolute Tolerance: 1.0e-04
     Sensitivity For Parameter 0:
-      Test Value: -1.981199378312e-01
+      Test Value: -1.981199464494e-01
     Sensitivity For Parameter 1:
-      Test Value: 6.39756401689e-02
+      Test Value: 6.397466684824e-02
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [20.3598]
+    Piro Analysis Test Values: [20.3595359175]
   Piro: 
     Sensitivity Method: Adjoint
     Analysis: 

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -49,15 +49,15 @@ ANONYMOUS:
     Exodus Output File Name: steady2d_dirichlet_mixed_paramsT.exo
     Cubature Degree: 9
   Regression For Response 0:
+    Relative Tolerance: 1.0e-07
+    Absolute Tolerance: 1.0e-07
     Test Value: 3.53554196849e-01
-    Relative Tolerance: 1.0e-03
-    Absolute Tolerance: 1.0e-04
     Sensitivity For Parameter 0:
-      Test Value: -1.981199378312e-01
+      Test Value: -1.981199464494e-01
     Sensitivity For Parameter 1:
-      Test Value: 6.39756401689e-02
+      Test Value: 6.397466684824e-02
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [20.3598]
+    Piro Analysis Test Values: [20.3595359175]
   Piro: 
     Sensitivity Method: Adjoint
     Analysis: 

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_paramT.yaml
@@ -60,8 +60,8 @@ ANONYMOUS:
     Exodus Output File Name: steady2d_scalar_and_dist_param.exo
     Cubature Degree: 9
   Regression For Response 0:
+    Relative Tolerance: 1.0e-07
     Test Value:  3.714619372618e-01
-    Relative Tolerance: 1.0e-03
     Sensitivity For Parameter 0:
       Test Values: [9.561048021617e-03, -3.169063814956e-01]
     Sensitivity For Parameter 1:

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -127,14 +127,14 @@ ANONYMOUS:
     Exodus Output File Name: steady2d_scalar_and_dist_param.exo
     Cubature Degree: 9
   Regression For Response 0:
+    Relative Tolerance: 1.0e-07
     Test Value:  3.714619372618e-01
-    Relative Tolerance: 1.0e-03
     Sensitivity For Parameter 0:
       Test Values: [9.561048021617e-03, -3.169063814956e-01]
     Sensitivity For Parameter 1:
       Test Value: 8.044261077318e-03
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [41.0171]
+    Piro Analysis Test Values: [41.0170729034]
       
   Piro: 
     Sensitivity Method: Adjoint


### PR DESCRIPTION
In order to allow different Dirichlet conditions to be applied to the same dof (the last one applied is the one that gets prescribed), we need to pre-process the Lagrangian multiplier in the pre-evaluation phase. 

Fixed regression values in a couple of tests accordingly and tighten regression tolerances of a few tests.