### PR TITLE
Fix fad offsets when dealing with column-coupled equations

### DIFF
--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -59,7 +59,8 @@ template<> int getDerivativeDimensions<PHAL::AlbanyTraits::Jacobian> (
         int side_node_count = ms->ctd.side[3].topology->node_count;
         int node_count = ms->ctd.node_count;
         int numLevels = app->getDiscretization()->getLayeredMeshNumbering()->numLayers+1;
-        dDims = app->getNumEquations()*(node_count + side_node_count*numLevels);
+        int neq = app->getNumEquations();
+        dDims = neq*std::max(node_count, side_node_count*numLevels);
       }
   }
   checkDerivativeDimensions<PHAL::AlbanyTraits::Jacobian>(dDims);

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -59,8 +59,7 @@ template<> int getDerivativeDimensions<PHAL::AlbanyTraits::Jacobian> (
         int side_node_count = ms->ctd.side[3].topology->node_count;
         int node_count = ms->ctd.node_count;
         int numLevels = app->getDiscretization()->getLayeredMeshNumbering()->numLayers+1;
-        int neq = app->getNumEquations();
-        dDims = neq*std::max(node_count, side_node_count*numLevels);
+        dDims = app->getNumEquations()*(node_count + side_node_count*numLevels);
       }
   }
   checkDerivativeDimensions<PHAL::AlbanyTraits::Jacobian>(dDims);

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
@@ -280,7 +280,7 @@ evaluateFields(typename Traits::EvalData workset)
     PHAL::SeparableScatterScalarResponse<EvalT, Traits>::evaluateFields(workset);
 
   if(Teuchos::nonnull(cell_topo))
-    PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToExtrudedSolution(workset,sideSetName, cell_topo);
+    PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToColumnContraction(workset,sideSetName, cell_topo);
 }
 
 // **********************************************************************

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
@@ -73,7 +73,7 @@ public:
 
   void evaluateFields(typename Traits::EvalData /* d */) {}
 
-  void evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData /* d */,
+  void evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData /* d */,
                                                         const std::string& /* sidesetName */,
                                                         Teuchos::RCP<const CellTopologyData> /* cellTopo */) {}
 
@@ -146,7 +146,7 @@ public:
   }
   void preEvaluate(typename Traits::PreEvalData d);
   void evaluateFields(typename Traits::EvalData d);
-  void evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData d, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo);
+  void evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData d, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo);
   void postEvaluate(typename Traits::PostEvalData d);
 protected:
   typedef PHAL::AlbanyTraits::Jacobian EvalT;
@@ -180,7 +180,7 @@ public:
   }
   void preEvaluate(typename Traits::PreEvalData d);
   void evaluateFields(typename Traits::EvalData d);
-  void evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData /* d */,
+  void evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData /* d */,
                                                         const std::string& /* sidesetName */,
                                                         Teuchos::RCP<const CellTopologyData> /* cellTopo */) {}
   void postEvaluate(typename Traits::PostEvalData d);
@@ -289,7 +289,7 @@ public:
   }
   void preEvaluate(typename Traits::PreEvalData d);
   void evaluateFields(typename Traits::EvalData d);
-  void evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData d, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo);
+  void evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData d, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo);
   void postEvaluate(typename Traits::PostEvalData d);
 
 protected:

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -192,7 +192,7 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
             const LO  inode = ov_node_indexer->getLocalElement(ginode);
             for (int eq_col=0; eq_col<neq; eq_col++) {
               const LO dof = solDOFManager.getLocalDOF(inode, eq_col);
-              int deriv = neq *this->numNodes+il_col*neq*numSideNodes + neq*i + eq_col;
+              int deriv = il_col*neq*numSideNodes + neq*i + eq_col;
               dg_data[res][dof] += val.dx(deriv);
             }
           }

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -173,6 +173,9 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
 
     auto ov_node_indexer = workset.disc->getOverlapNodeGlobalLocalIndexer();
 
+    // The first neq*numNodes derivs are for dofs gathered "normally", without
+    // any knowledge of column contraction operations.
+    const int columnsOffset = neq*this->numNodes;
     for (std::size_t iSide = 0; iSide < sideSet.size(); ++iSide) { // loop over the sides on this ws and name
       // Get the data that corresponds to the side
       const int elem_LID = sideSet[iSide].elem_LID;
@@ -192,7 +195,7 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
             const LO  inode = ov_node_indexer->getLocalElement(ginode);
             for (int eq_col=0; eq_col<neq; eq_col++) {
               const LO dof = solDOFManager.getLocalDOF(inode, eq_col);
-              int deriv = il_col*neq*numSideNodes + neq*i + eq_col;
+              int deriv = columnsOffset + il_col*neq*numSideNodes + neq*i + eq_col;
               dg_data[res][dof] += val.dx(deriv);
             }
           }
@@ -752,6 +755,9 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
   const Albany::SideSetList& ssList = *(workset.sideSets);
   Albany::SideSetList::const_iterator it = ssList.find(sideset);
 
+  // The first neq*numNodes derivs are for dofs gathered "normally", without
+  // any knowledge of column contraction operations.
+  const int columnsOffset = neq*this->numNodes;
   if(!hess_vec_prod_g_xx.is_null())
   {
     auto hess_vec_prod_g_xx_data = Albany::getNonconstLocalData(hess_vec_prod_g_xx);
@@ -781,7 +787,7 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
               const LO  inode = ov_node_indexer->getLocalElement(ginode);
               for (int eq_col=0; eq_col<neq; eq_col++) {
                 const LO dof = solDOFManager.getLocalDOF(inode, eq_col);
-                int deriv = neq *this->numNodes+il_col*neq*numSideNodes + neq*i + eq_col;
+                int deriv = columnsOffset + il_col*neq*numSideNodes + neq*i + eq_col;
                 hess_vec_prod_g_xx_data[res][dof] += val.dx(deriv).dx(0);
               }
             }
@@ -819,7 +825,7 @@ evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData work
               const LO  inode = ov_node_indexer->getLocalElement(ginode);
               for (int eq_col=0; eq_col<neq; eq_col++) {
                 const LO dof = solDOFManager.getLocalDOF(inode, eq_col);
-                int deriv = neq *this->numNodes+il_col*neq*numSideNodes + neq*i + eq_col;
+                int deriv = columnsOffset + il_col*neq*numSideNodes + neq*i + eq_col;
                 hess_vec_prod_g_xp_data[res][dof] += val.dx(deriv).dx(0);
               }
             }

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -662,7 +662,6 @@ evaluateFields(typename Traits::EvalData workset)
     auto hess_vec_prod_g_px_data = Albany::getNonconstLocalData(hess_vec_prod_g_px);
 
     int num_deriv = this->numNodes;
-    auto nodeID = workset.wsElNodeEqID;
     int fieldLevel = level_it->second;
 
     const Albany::LayeredMeshNumbering<GO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();
@@ -698,7 +697,6 @@ evaluateFields(typename Traits::EvalData workset)
     auto hess_vec_prod_g_pp_data = Albany::getNonconstLocalData(hess_vec_prod_g_pp);
 
     int num_deriv = this->numNodes;
-    auto nodeID = workset.wsElNodeEqID;
     int fieldLevel = level_it->second;
 
     const Albany::LayeredMeshNumbering<GO>& layeredMeshNumbering = *workset.disc->getLayeredMeshNumbering();

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -143,7 +143,7 @@ evaluateFields(typename Traits::EvalData workset)
 
 template<typename Traits>
 void SeparableScatterScalarResponse<PHAL::AlbanyTraits::Jacobian, Traits>::
-evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData workset, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo)
+evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData workset, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo)
 {
   // Here we scatter the *local* response derivative
   Teuchos::RCP<Thyra_MultiVector> dgdx = workset.overlapped_dgdx;
@@ -731,7 +731,7 @@ evaluateFields(typename Traits::EvalData workset)
 
 template<typename Traits>
 void SeparableScatterScalarResponse<PHAL::AlbanyTraits::HessianVec, Traits>::
-evaluate2DFieldsDerivativesDueToExtrudedSolution(typename Traits::EvalData workset, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo)
+evaluate2DFieldsDerivativesDueToColumnContraction(typename Traits::EvalData workset, std::string& sideset, Teuchos::RCP<const CellTopologyData> cellTopo)
 {
   // Here we scatter the *local* response derivative
   Teuchos::RCP<Thyra_MultiVector> hess_vec_prod_g_xx = workset.hessianWorkset.overlapped_hess_vec_prod_g_xx;

--- a/src/landIce/evaluators/LandIce_Gather2DField.hpp
+++ b/src/landIce/evaluators/LandIce_Gather2DField.hpp
@@ -47,7 +47,6 @@ protected:
   // Output:
   PHX::MDField<ScalarT,Cell,Node>  field2D;
 
-  std::size_t vecDim;
   std::size_t numNodes;
   std::size_t offset; // Offset of first DOF being gathered
 

--- a/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
+++ b/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
@@ -144,7 +144,7 @@ evaluateFields(typename Traits::EvalData workset)
         std::size_t node = side.node[i];
         typename PHAL::Ref<ScalarT>::type val = (this->field2D)(elem_LID,node);
         val = FadType(val.size(), x_constView[nodeID(elem_LID,node,this->offset)]);
-        val.fastAccessDx(numSideNodes*neq*this->fieldLevel+neq*i+this->offset) = workset.j_coeff;
+        val.fastAccessDx(node*neq+this->offset) = workset.j_coeff;
       }
     }
   }
@@ -244,7 +244,7 @@ evaluateFields(typename Traits::EvalData workset)
         // If we differentiate w.r.t. the solution, we have to set the first
         // derivative to workset.j_coeff
         if (is_x_active)
-          val.fastAccessDx(numSideNodes*neq*this->fieldLevel+neq*i+this->offset).val() = workset.j_coeff;
+          val.fastAccessDx(neq*node+this->offset).val() = workset.j_coeff;
         // If we differentiate w.r.t. the solution direction, we have to set
         // the second derivative to the related direction value
         if (is_x_direction_active)

--- a/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
+++ b/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
@@ -38,7 +38,6 @@ Gather2DFieldBase(const Teuchos::ParameterList& p,
 
   dl->node_gradient->dimensions(dims);
   numNodes = dims[1];
-  vecDim = dims[2];
 
   this->setName("Gather2DField"+PHX::print<EvalT>());
 
@@ -127,6 +126,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   const Albany::SideSetList& ssList = *(workset.sideSets);
   Albany::SideSetList::const_iterator it = ssList.find(this->meshPart);
+  const int neq = nodeID.extent(2);
 
   if (it != ssList.end()) {
     const std::vector<Albany::SideStruct>& sideSet = it->second;
@@ -144,7 +144,7 @@ evaluateFields(typename Traits::EvalData workset)
         std::size_t node = side.node[i];
         typename PHAL::Ref<ScalarT>::type val = (this->field2D)(elem_LID,node);
         val = FadType(val.size(), x_constView[nodeID(elem_LID,node,this->offset)]);
-        val.fastAccessDx(numSideNodes*this->vecDim*this->fieldLevel+this->vecDim*i+this->offset) = workset.j_coeff;
+        val.fastAccessDx(this->numNodes*neq+numSideNodes*neq*this->fieldLevel+neq*i+this->offset) = workset.j_coeff;
       }
     }
   }
@@ -226,6 +226,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   if (it != ssList.end()) {
     const std::vector<Albany::SideStruct>& sideSet = it->second;
+    const int neq = nodeID.extent(2);
 
     // Loop over the sides that form the boundary condition
     for (std::size_t iSide = 0; iSide < sideSet.size(); ++iSide) { // loop over the sides on this ws and name
@@ -243,7 +244,7 @@ evaluateFields(typename Traits::EvalData workset)
         // If we differentiate w.r.t. the solution, we have to set the first
         // derivative to workset.j_coeff
         if (is_x_active)
-          val.fastAccessDx(numSideNodes*this->vecDim*this->fieldLevel+this->vecDim*i+this->offset).val() = workset.j_coeff;
+          val.fastAccessDx(this->numNodes*neq+numSideNodes*neq*this->fieldLevel+neq*i+this->offset).val() = workset.j_coeff;
         // If we differentiate w.r.t. the solution direction, we have to set
         // the second derivative to the related direction value
         if (is_x_direction_active)

--- a/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
+++ b/src/landIce/evaluators/LandIce_Gather2DField_Def.hpp
@@ -144,7 +144,7 @@ evaluateFields(typename Traits::EvalData workset)
         std::size_t node = side.node[i];
         typename PHAL::Ref<ScalarT>::type val = (this->field2D)(elem_LID,node);
         val = FadType(val.size(), x_constView[nodeID(elem_LID,node,this->offset)]);
-        val.fastAccessDx(this->numNodes*neq+numSideNodes*neq*this->fieldLevel+neq*i+this->offset) = workset.j_coeff;
+        val.fastAccessDx(numSideNodes*neq*this->fieldLevel+neq*i+this->offset) = workset.j_coeff;
       }
     }
   }
@@ -244,7 +244,7 @@ evaluateFields(typename Traits::EvalData workset)
         // If we differentiate w.r.t. the solution, we have to set the first
         // derivative to workset.j_coeff
         if (is_x_active)
-          val.fastAccessDx(this->numNodes*neq+numSideNodes*neq*this->fieldLevel+neq*i+this->offset).val() = workset.j_coeff;
+          val.fastAccessDx(numSideNodes*neq*this->fieldLevel+neq*i+this->offset).val() = workset.j_coeff;
         // If we differentiate w.r.t. the solution direction, we have to set
         // the second derivative to the related direction value
         if (is_x_direction_active)

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -232,6 +232,10 @@ evaluateFields(typename Traits::EvalData workset)
     const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
     const auto& ov_node_indexer = *workset.disc->getOverlapNodeGlobalLocalIndexer();
 
+    // The first neq*numNodes derivs are for dofs gathered "normally", without
+    // any knowledge of column contraction operations.
+    const int columnsOffset = neq*this->numNodes;
+
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) { // loop over the sides on this ws and name
       // Get the data that corresponds to the side
       const unsigned int elem_LID = sideSet.elem_LID(sideSet_idx);
@@ -258,12 +262,12 @@ evaluateFields(typename Traits::EvalData workset)
           for(unsigned int comp=0; comp<this->vecDim; ++comp) {
             this->contractedSol(sideSet_idx,i,comp) = FadType(this->contractedSol(sideSet_idx,i,comp).size(), contrSol[comp]);
             for(int il=0; il<this->numLayers+1; ++il)
-              this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(numSideNodes*il+i)+comp+this->offset) = this->quadWeights(il)*workset.j_coeff;
+              this->contractedSol(sideSet_idx,i,comp).fastAccessDx(columnsOffset+neq*(numSideNodes*il+i)+comp+this->offset) = this->quadWeights(il)*workset.j_coeff;
           }
         } else {
           this->contractedSol(sideSet_idx,i) = FadType(this->contractedSol(sideSet_idx,i).size(), contrSol[0]);
           for(int il=0; il<this->numLayers+1; ++il)
-            this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(numSideNodes*il+i)+this->offset) = this->quadWeights(il)*workset.j_coeff;
+            this->contractedSol(sideSet_idx,i).fastAccessDx(columnsOffset+neq*(numSideNodes*il+i)+this->offset) = this->quadWeights(il)*workset.j_coeff;
         }
       }
     }
@@ -482,6 +486,10 @@ evaluateFields(typename Traits::EvalData workset)
     const Albany::NodalDOFManager& solDOFManager = workset.disc->getOverlapDOFManager("ordinary_solution");
     const auto& ov_node_indexer = *workset.disc->getOverlapNodeGlobalLocalIndexer();
 
+    // The first neq*numNodes derivs are for dofs gathered "normally", without
+    // any knowledge of column contraction operations.
+    const int columnsOffset = neq*this->numNodes;
+
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) { // loop over the sides on this ws and name
       // Get the data that corresponds to the side
       const unsigned int elem_LID = sideSet.elem_LID(sideSet_idx);
@@ -520,7 +528,7 @@ evaluateFields(typename Traits::EvalData workset)
               this->contractedSol(sideSet_idx,i,comp).val().fastAccessDx(0) = contrDirection[comp];
             if (g_xx_is_active||g_xp_is_active)
               for(int il=0; il<this->numLayers+1; ++il)
-                this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(numSideNodes*il+i)+comp+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
+                this->contractedSol(sideSet_idx,i,comp).fastAccessDx(columnsOffset+neq*(numSideNodes*il+i)+comp+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
           }
         } else {
           this->contractedSol(sideSet_idx,i) = HessianVecFad(this->contractedSol(sideSet_idx,i).size(), contrSol[0]);
@@ -528,7 +536,7 @@ evaluateFields(typename Traits::EvalData workset)
             this->contractedSol(sideSet_idx,i).val().fastAccessDx(0) = contrDirection[0];
           if (g_xx_is_active||g_xp_is_active)
             for(int il=0; il<this->numLayers+1; ++il)
-              this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(numSideNodes*il+i)+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
+              this->contractedSol(sideSet_idx,i).fastAccessDx(columnsOffset+neq*(numSideNodes*il+i)+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
         }
       }
     }

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -258,12 +258,12 @@ evaluateFields(typename Traits::EvalData workset)
           for(unsigned int comp=0; comp<this->vecDim; ++comp) {
             this->contractedSol(sideSet_idx,i,comp) = FadType(this->contractedSol(sideSet_idx,i,comp).size(), contrSol[comp]);
             for(int il=0; il<this->numLayers+1; ++il)
-              this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(this->numNodes+numSideNodes*il+i)+comp+this->offset) = this->quadWeights(il)*workset.j_coeff;
+              this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(numSideNodes*il+i)+comp+this->offset) = this->quadWeights(il)*workset.j_coeff;
           }
         } else {
           this->contractedSol(sideSet_idx,i) = FadType(this->contractedSol(sideSet_idx,i).size(), contrSol[0]);
           for(int il=0; il<this->numLayers+1; ++il)
-            this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(this->numNodes+numSideNodes*il+i)+this->offset) = this->quadWeights(il)*workset.j_coeff;
+            this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(numSideNodes*il+i)+this->offset) = this->quadWeights(il)*workset.j_coeff;
         }
       }
     }
@@ -520,7 +520,7 @@ evaluateFields(typename Traits::EvalData workset)
               this->contractedSol(sideSet_idx,i,comp).val().fastAccessDx(0) = contrDirection[comp];
             if (g_xx_is_active||g_xp_is_active)
               for(int il=0; il<this->numLayers+1; ++il)
-                this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(this->numNodes+numSideNodes*il+i)+comp+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
+                this->contractedSol(sideSet_idx,i,comp).fastAccessDx(neq*(numSideNodes*il+i)+comp+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
           }
         } else {
           this->contractedSol(sideSet_idx,i) = HessianVecFad(this->contractedSol(sideSet_idx,i).size(), contrSol[0]);
@@ -528,7 +528,7 @@ evaluateFields(typename Traits::EvalData workset)
             this->contractedSol(sideSet_idx,i).val().fastAccessDx(0) = contrDirection[0];
           if (g_xx_is_active||g_xp_is_active)
             for(int il=0; il<this->numLayers+1; ++il)
-              this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(this->numNodes+numSideNodes*il+i)+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
+              this->contractedSol(sideSet_idx,i).fastAccessDx(neq*(numSideNodes*il+i)+this->offset).val() = this->quadWeights(il) * workset.j_coeff;
         }
       }
     }

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -190,7 +190,7 @@ void ResponseGLFlux<EvalT, Traits, ThicknessST>::evaluateFields(typename Traits:
 
   // Do any local-scattering necessary
   PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluateFields(workset);
-  PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToExtrudedSolution(workset,basalSideName, cell_topo);
+  PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToColumnContraction(workset,basalSideName, cell_topo);
 }
 
 // **********************************************************************

--- a/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -183,7 +183,7 @@ void LandIce::ResponseSMBMismatch<EvalT, Traits, ThicknessScalarType>::evaluateF
 
   // Do any local-scattering necessary
   PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluateFields(workset);
-  PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToExtrudedSolution(workset,basalSideName, cell_topo);
+  PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::evaluate2DFieldsDerivativesDueToColumnContraction(workset,basalSideName, cell_topo);
 }
 
 // **********************************************************************

--- a/src/landIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
@@ -83,10 +83,6 @@ evaluateFields(typename Traits::EvalData workset)
 
     const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
 
-    // The first numNodes*neq fad derivs are related to normal volume operations.
-    // The following numSideNodes*neq*numLevels are related to 2d fields and extruded/contracted stuff
-    const int offset2DFad = this->numNodes*neq;
-
     // Loop over the sides that form the boundary condition
     for (std::size_t iSide = 0; iSide < sideSet.size(); ++iSide) { // loop over the sides on this ws and name
       // Get the data that corresponds to the side
@@ -132,7 +128,7 @@ evaluateFields(typename Traits::EvalData workset)
             f_data[lrow] += valptr.val();
           }
           if (valptr.hasFastAccess()) {
-            Albany::addToLocalRowValues(Jac,lrow,lcols(), Teuchos::arrayView(&(valptr.fastAccessDx(offset2DFad)),lcols.size()));
+            Albany::addToLocalRowValues(Jac,lrow,lcols(), Teuchos::arrayView(&(valptr.fastAccessDx(0)),lcols.size()));
           } // has fast access
         }
       }

--- a/src/landIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ScatterResidual2D_Def.hpp
@@ -83,6 +83,10 @@ evaluateFields(typename Traits::EvalData workset)
 
     const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID  = workset.disc->getWsElNodeID()[workset.wsIndex];
 
+    // The first numNodes*neq fad derivs are related to normal volume operations.
+    // The following numSideNodes*neq*numLevels are related to 2d fields and extruded/contracted stuff
+    const int offset2DFad = this->numNodes*neq;
+
     // Loop over the sides that form the boundary condition
     for (std::size_t iSide = 0; iSide < sideSet.size(); ++iSide) { // loop over the sides on this ws and name
       // Get the data that corresponds to the side
@@ -128,7 +132,7 @@ evaluateFields(typename Traits::EvalData workset)
             f_data[lrow] += valptr.val();
           }
           if (valptr.hasFastAccess()) {
-            Albany::addToLocalRowValues(Jac,lrow,lcols(), Teuchos::arrayView(&(valptr.fastAccessDx(0)),lcols.size()));
+            Albany::addToLocalRowValues(Jac,lrow,lcols(), Teuchos::arrayView(&(valptr.fastAccessDx(offset2DFad)),lcols.size()));
           } // has fast access
         }
       }

--- a/tests/landIce/FO_GIS/input_fo_gis_coupled.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_coupled.yaml
@@ -219,7 +219,7 @@ ANONYMOUS:
   Regression For Response 0:
     Absolute Tolerance: 1.00000000000000004e-04
     Sensitivity For Parameter 0:
-      Test Value: 1.828925382015e+07
-    Test Value: 1.096538698283e+08
+      Test Value: 1.829144244865e+07
+    Test Value: 1.096541803121e+08
     Relative Tolerance: 1.00000000000000004e-04
 ...

--- a/tests/landIce/FO_GIS/input_fo_gis_coupledT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_coupledT.yaml
@@ -217,7 +217,7 @@ ANONYMOUS:
   Regression For Response 0:
     Absolute Tolerance: 1.00000000000000004e-04
     Sensitivity For Parameter 0:
-      Test Value: 1.828924648452e+07
-    Test Value: 1.096538698283e+08
+      Test Value: 1.829143517389e+07
+    Test Value: 1.096541803121e+08
     Relative Tolerance: 1.00000000000000004e-04
 ...


### PR DESCRIPTION
There were a few inconsistencies in how we dealt with column couplings. In particular, in some places we offset fad entries for column coupling by `neq*numCellNodes`, while in others we didn't. But then, after adding the offset to all gather/scatter places, I realized we don't need it, since we never use simultaneously the "volume" fads (the first `neq*numCellNodes` entries) and the "column" fads (the following `neq*numSideNodes*numLevels` entries), so we can reduce the fad length of column-coupled responses to `neq*max(numCellNodes,numSideNodes*numLevels)`.

I spent some time thinking about whether I was going to mix up things, but I think I'm not. SO LONG as the 2D solution field is gathered via `Gather2DField`, then all Fad use the convention that 2d quantities Fads are located at Fad entry `numSideNodes*field2dLevel + $node2d*neq + eq`.

For a 10 layers mesh with wedges, for the FOThicknes sproblem, this brings the Fad length from `3*6+3*11*3=117` to `3*11*3=99`. Not a huge gain, but still a 20% memory reduction for the response FM.

With this mod, I get sensitivities for the FO_GIS_Coupled test that are close to what I get in the DOFManager branch (diff ~ 3e5). I am hoping the diff can now be made smaller by simply cranking down the solvers tolerances (I will check).

Note: I still have to push changes to the input files. I need to run all tests first, to see what changes.