### PR TITLE
Comply with Piro changes (https://github.com/trilinos/Trilinos/pull/11649) for Analylisis problems

### DIFF
--- a/doc/LandIce/updates-info/input_files/input_ais_beta_stiff_opt_mperego.yaml
+++ b/doc/LandIce/updates-info/input_files/input_ais_beta_stiff_opt_mperego.yaml
@@ -188,7 +188,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 2
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]

--- a/pyAlbany/examples/extremeEvent/thermal_steady.yaml
+++ b/pyAlbany/examples/extremeEvent/thermal_steady.yaml
@@ -72,7 +72,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0e+00
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/extremeEvent/thermal_steady_2.yaml
+++ b/pyAlbany/examples/extremeEvent/thermal_steady_2.yaml
@@ -57,7 +57,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/landIce/FO_GIS/input_fo_gis_analysis_beta_smbT.yaml
+++ b/pyAlbany/examples/landIce/FO_GIS/input_fo_gis_analysis_beta_smbT.yaml
@@ -184,7 +184,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]

--- a/pyAlbany/examples/paper/input_distributed.yaml
+++ b/pyAlbany/examples/paper/input_distributed.yaml
@@ -60,7 +60,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/paper/input_scalar.yaml
+++ b/pyAlbany/examples/paper/input_scalar.yaml
@@ -65,7 +65,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0e+00
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/paper/input_scalar_to_update.yaml
+++ b/pyAlbany/examples/paper/input_scalar_to_update.yaml
@@ -65,7 +65,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0e+00
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/performanceAnalysis/input_conductivity_dist_paramT.yaml
+++ b/pyAlbany/examples/performanceAnalysis/input_conductivity_dist_paramT.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/tutorial/input_conductivity_dist_paramT.yaml
+++ b/pyAlbany/examples/tutorial/input_conductivity_dist_paramT.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/examples/uncertaintyQuantification/input_dirichletT.yaml
+++ b/pyAlbany/examples/uncertaintyQuantification/input_dirichletT.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Bound Constrained: true
 

--- a/pyAlbany/tests/extremeEvent/thermal_steady.yaml
+++ b/pyAlbany/tests/extremeEvent/thermal_steady.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]
         Bound Constrained: true

--- a/pyAlbany/tests/extremeEvent/thermal_steady_hessian.yaml
+++ b/pyAlbany/tests/extremeEvent/thermal_steady_hessian.yaml
@@ -60,7 +60,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/tests/randCompress/input_conductivity_dist_paramT.yaml
+++ b/pyAlbany/tests/randCompress/input_conductivity_dist_paramT.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0e+00
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/tests/steadyHeat/input_conductivity_dist_paramT.yaml
+++ b/pyAlbany/tests/steadyHeat/input_conductivity_dist_paramT.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 1
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/pyAlbany/tests/steadyHeat/input_dirichlet_mixed_paramsT.yaml
+++ b/pyAlbany/tests/steadyHeat/input_dirichlet_mixed_paramsT.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/src/Albany_ModelEvaluator.cpp
+++ b/src/Albany_ModelEvaluator.cpp
@@ -948,8 +948,12 @@ Thyra_OutArgs ModelEvaluator::createOutArgsImpl() const
     if(analysisParams.isSublist("ROL")) {
       bool reconstructHppROL = false;
       if(analysisParams.sublist("ROL").isSublist("Matrix Based Dot Product"))
-        reconstructHppROL =
+        reconstructHppROL = reconstructHppROL ||
             (analysisParams.sublist("ROL").sublist("Matrix Based Dot Product").get<std::string>("Matrix Type") == "Hessian Of Response");
+
+      if(analysisParams.sublist("ROL").isSublist("Custom Secant"))
+        reconstructHppROL = reconstructHppROL ||
+            (analysisParams.sublist("ROL").sublist("Custom Secant").get<std::string>("Initialization Type") == "Hessian Of Response");
 
       TEUCHOS_TEST_FOR_EXCEPTION(
           (supportHpp == false) && (reconstructHppROL == true),

--- a/src/Albany_RegressionTests.cpp
+++ b/src/Albany_RegressionTests.cpp
@@ -37,7 +37,7 @@ std::pair<int,int> RegressionTests::checkResponse(
   int          failures    = 0;
   int          comparisons = 0;
 
-  if (testParams != NULL) {
+  if ((testParams != NULL) && testParams->isParameter("Test Value")) {
     const double relTol      = testParams->isParameter("Relative Tolerance") ?
         testParams->get<double>("Relative Tolerance") : 1.0e-8;
     const double absTol      = testParams->isParameter("Absolute Tolerance") ?
@@ -232,11 +232,7 @@ RegressionTests::getTestParameters(int response_index) const
 {
   Teuchos::ParameterList* result = &(appParams->sublist(
       util::strint("Regression For Response", response_index)));
-  if(result->isParameter("Test Value"))
-    result->validateParameters(
-        *getValidRegressionResultsParameters(), 0);
-  else
-    result = NULL;
+  result->validateParameters(*getValidRegressionResultsParameters(), 0);
 
   return result;
 }

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -315,36 +315,12 @@ SolverFactory::getValidAppParameters() const
   validPL->sublist("Problem", false, "Problem sublist");
   validPL->sublist("Debug Output", false, "Debug Output sublist");
   validPL->sublist("Scaling", false, "Jacobian/Residual Scaling sublist");
-  validPL->sublist("DataTransferKit", false, "DataTransferKit sublist");
-  validPL->sublist("DataTransferKit", false, "DataTransferKit sublist")
-      .sublist(
-          "Consistent Interpolation",
-          false,
-          "DTK Consistent Interpolation sublist");
-  validPL->sublist("DataTransferKit", false, "DataTransferKit sublist")
-      .sublist("Search", false, "DTK Search sublist");
-  validPL->sublist("DataTransferKit", false, "DataTransferKit sublist")
-      .sublist("L2 Projection", false, "DTK L2 Projection sublist");
-  validPL->sublist("DataTransferKit", false, "DataTransferKit sublist")
-      .sublist("Point Cloud", false, "DTK Point Cloud sublist");
   validPL->sublist("Discretization", false, "Discretization sublist");
-  validPL->sublist("Quadrature", false, "Quadrature sublist");
   const int maxRegression = 10;
   for (int i = 0; i < maxRegression; i++) {
     validPL->sublist(util::strint("Regression For Response", i), false, "Regression Results sublist");
   }
-  validPL->sublist("VTK", false, "DEPRECATED  VTK sublist");
   validPL->sublist("Piro", false, "Piro sublist");
-  validPL->sublist("Coupled System", false, "Coupled system sublist");
-  validPL->sublist("Alternating System", false, "Alternating system sublist");
-  validPL->sublist("Block ID to Physics ID Mapping", false, "Block to physics sublist");
-  validPL->sublist("Physics Blocks", false, "Physics blocks sublist");
-  validPL->sublist("Field Order", false, "Field order sublist");
-
-  // validPL->set<std::string>("Jacobian Operator", "Have Jacobian", "Flag to
-  // allow Matrix-Free specification in Piro");
-  // validPL->set<double>("Matrix-Free Perturbation", 3.0e-7, "delta in
-  // matrix-free formula");
 
   return validPL;
 }

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_dist_paramT.yaml
@@ -35,12 +35,12 @@ ANONYMOUS:
     Cubature Degree: 9
   Regression For Response 0:
     Test Value: 5.8333333333e-01
-    Relative Tolerance: 1.0e-03
-    Absolute Tolerance: 1.0e-04
+    Relative Tolerance: 1.0e-06
+    Absolute Tolerance: 1.0e-06
     Sensitivity For Parameter 0:
       Test Value: 1.04748375675e-01
     Piro Analysis Test Two Norm: true
-    Piro Analysis Test Values: [3.18968]
+    Piro Analysis Test Values: [3.196097204375e+00]
       
   Piro: 
     Sensitivity Method: Adjoint
@@ -50,7 +50,12 @@ ANONYMOUS:
       Output Level: 3
       Analysis Package: ROL
       ROL: 
-        Check Gradient: true
+        Check Derivatives: true
+        Derivative Checks:
+          Number Of Derivative Checks: 1
+          Perform Reduced Derivative Checks: true
+          Perfrom Expensive Derivative Checks: false
+
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]
@@ -61,6 +66,11 @@ ANONYMOUS:
         
         Matrix Based Dot Product: 
           Matrix Type: Identity
+
+        Custom Secant: 
+          Type: Limited-Memory BFGS
+          Maximum Storage: 50
+          Initialization Type: Identity
 
         ROL Options: 
         # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
@@ -90,7 +100,9 @@ ANONYMOUS:
             Secant: 
               Type: Limited-Memory BFGS
               Maximum Storage: 50
-              Use Default Scaling: true
+              Use as Preconditioner: true
+              Use as Hessian: false
+              Use Default Scaling: false
               Initial Hessian Scale: 1.0
               Barzilai-Borwein Type: 1
 
@@ -101,32 +113,30 @@ ANONYMOUS:
               Iteration Limit: 20
 
           Step:
-            Type: "Line Search"
+            Type: "Trust Region"
 
-            Line Search: 
-              Function Evaluation Limit: 20
-              Sufficient Decrease Tolerance: 1.0e-6
-              Initial Step Size: 1.0
-              User Defined Initial Step Size: false
-              Use Previous Step Length as Initial Guess: false
-              Use Adaptive Step Size Selection: true
-
-              Descent Method: 
-                Type: Quasi-Newton Method
-
-              Line-Search Method: 
-                Type: Cubic Interpolation
-                Backtracking Rate: 0.5
-                Bracketing Tolerance: 1.0e-08
-                Path-Based Target Level: 
-                  Target Relaxation Parameter: 1.0
-                  Upper Bound on Path Length: 1.0
-
-              Quasi-Newton:
-                Method: L-Secant-B
-                L-Secant-B:
-                  Sufficient Decrease Parameter: 1.0e-02
-                  Relative Tolerance Exponent: 1.0
+            Trust Region: 
+              Subproblem Model: Lin-More
+              Subproblem Solver: Truncated CG
+              Initial Radius: -1.0
+              Maximum Radius: 5.0e+03
+              Step Acceptance Threshold: 5.0e-02
+              Radius Shrinking Threshold: 5.0e-02
+              Radius Growing Threshold: 9.0e-01
+              Radius Shrinking Rate (Negative rho): 6.25e-02
+              Radius Shrinking Rate (Positive rho): 2.5e-01
+              Radius Growing Rate: 2.5
+              Safeguard Size: 1.0e+03
+              Inexact: 
+                Value: 
+                  Tolerance Scaling: 1.0e-01
+                  Exponent: 9.0e-01
+                  Forcing Sequence Initial Value: 1.0
+                  Forcing Sequence Update Frequency: 10
+                  Forcing Sequence Reduction Factor: 1.0e-01
+                Gradient: 
+                  Tolerance Scaling: 1.0e-01
+                  Relative Tolerance: 2.0e+00
 
     NOX: 
       Direction: 

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_params.yaml
@@ -65,7 +65,11 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
+        Derivative Checks:
+          Number Of Derivative Checks: 1
+          Perform Reduced Derivative Checks: true
+          Perfrom Expensive Derivative Checks: false
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_dirichlet_mixed_paramsT.yaml
@@ -65,7 +65,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: From Model Evaluator
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]

--- a/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
+++ b/tests/corePDEs/SteadyHeatConstrainedOpt2D/input_scalar_and_dist_param_hessianT.yaml
@@ -144,7 +144,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL: 
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 1.0e+00
         Min And Max Of Random Parameter Guess: [-1.0, 2.0]
@@ -156,6 +156,15 @@ ANONYMOUS:
         Matrix Based Dot Product: 
           Matrix Type: Hessian Of Response
           Matrix Types:
+            Hessian Of Response:
+              Lump Matrix: true
+              Response Index: 0
+        
+        Custom Secant: 
+          Type: Limited-Memory BFGS
+          Maximum Storage: 50
+          Initialization Type: Hessian Of Response
+          Initialization Types:
             Hessian Of Response:
               Response Index: 0
 
@@ -185,7 +194,7 @@ ANONYMOUS:
 
             Secant: 
               Type: Limited-Memory BFGS
-              Use as Preconditioner: false
+              Use as Preconditioner: true
               Use as Hessian: false
               Maximum Storage: 50
               Use Default Scaling: true

--- a/tests/landIce/FO_GIS/CMakeLists.txt
+++ b/tests/landIce/FO_GIS/CMakeLists.txt
@@ -154,8 +154,8 @@ if (ALBANY_FROSCH)
   add_test(${testNameRoot}_Humboldt_effectPress_Tpetra_FROSch ${Albany.exe} input_fo_humboldt_frosch_effect_press.yaml)
 
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_humboldt_frosch_pressurized_bed.yaml
-  ${CMAKE_CURRENT_BINARY_DIR}/input_fo_humboldt_frosch_pressurized_bed.yaml)
-add_test(${testNameRoot}_Humboldt_pressurizedBed_Tpetra_FROSch ${Albany.exe} input_fo_humboldt_frosch_pressurized_bed.yaml)
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_fo_humboldt_frosch_pressurized_bed.yaml)
+  add_test(${testNameRoot}_Humboldt_pressurizedBed_Tpetra_FROSch ${Albany.exe} input_fo_humboldt_frosch_pressurized_bed.yaml)
 
   if (NOT ALBANY_PARALELL_EXODUS)
     set_tests_properties(${testNameRoot}_Humboldt_FluxDiv_Tpetra_FROSch
@@ -315,6 +315,14 @@ if (ALBANY_IFPACK2)
       add_test(${testName} ${AlbanyAnalysis.exe} input_fo_gis_analysis_beta_hessian_matfreeT.yaml)
       set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Analysis;ROL")
     endif()
+
+    if(ALBANY_TEKO AND ALBANY_MUELU)
+      set (testName ${testNameRoot}_Analysis_Humboldt)
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_humboldt_analysis.yaml
+                     ${CMAKE_CURRENT_BINARY_DIR}/input_fo_humboldt_analysis.yaml)
+      add_test(${testNameRoot}_Analysis_Humboldt ${AlbanyAnalysis.exe} input_fo_humboldt_analysis.yaml)
+    endif()
+
   endif()
 endif()
 

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_betaT.yaml
@@ -162,7 +162,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 2.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessianT.yaml
@@ -202,7 +202,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 2.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]
@@ -215,6 +215,7 @@ ANONYMOUS:
           Matrix Type: Hessian Of Response
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 1
 
         ROL Options:

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian_matfreeT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian_matfreeT.yaml
@@ -187,7 +187,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 2.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]
@@ -200,6 +200,7 @@ ANONYMOUS:
           Matrix Type: Hessian Of Response
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 1
 
         ROL Options:

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_memT.yaml
@@ -158,7 +158,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 2.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
@@ -170,7 +170,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]
@@ -181,6 +181,7 @@ ANONYMOUS:
 
         Matrix Based Dot Product: 
           Matrix Type: Hessian Of Response
+          Lump Matrix: false
           Matrix Types:
             Hessian Of Response:
               Response Index: 1

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffeningT.yaml
@@ -239,7 +239,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 0.0
         Min And Max Of Random Parameter Guess: [1.0, 2.0]
@@ -252,6 +252,7 @@ ANONYMOUS:
           Matrix Type: Hessian Of Response
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 1
 
         ROL Options:

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening_memT.yaml
@@ -171,7 +171,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 2
-        Check Gradient: true
+        Check Derivatives: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: 0.0e+00
         Min And Max Of Random Parameter Guess: [1.0e+00, 2.0e+00]

--- a/tests/landIce/FO_GIS/input_fo_humboldt_analysis.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_analysis.yaml
@@ -1,0 +1,667 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Debug Output:
+    Write Solution to MatrixMarket: 0
+    Report Timers: false
+  Problem:
+    Phalanx Graph Visualization Detail: 0
+    Solution Method: Steady
+    Name: LandIce Stokes First Order 3D
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: true
+    Compute Sensitivities: true
+    Basal Side Name: basalside
+    Surface Side Name: upperside
+    LandIce Field Norm:
+      sliding_velocity_basalside:
+        Regularization Type: Given Value
+        Regularization Value: 1.0e-05
+    Dirichlet BCs:
+      DBC on NS extruded_boundary_node_set_3 for DOF U0 prescribe Field: velocity
+      DBC on NS extruded_boundary_node_set_3 for DOF U1 prescribe Field: velocity
+    LandIce BCs:
+      Number: 2
+      BC 0:
+        Cubature Degree: 3
+        Type: Basal Friction
+        Side Set Name: basalside
+        Basal Friction Coefficient:
+          Type: Power Law
+          Mu Type: Exponent of Field
+          Mu Field Name: basal_friction_log
+          Power Exponent: 1.0
+          Effective Pressure Type: Constant
+          Effective Pressure: 1.0
+          Zero Beta On Floating Ice: true
+      BC 1:
+        Type: Lateral
+        Cubature Degree: 3
+        Side Set Name: extruded_boundary_side_set_1
+        Melange Force: 6.0e+07 #[N/m]
+        Melange Submerged Thickness Threshold: 0.1 #[km]
+        #Immersed Ratio: 0.893
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Lower Bound: -12.0e+00
+        Mesh Part: bottom
+        Type: Distributed
+        Name: basal_friction_log
+        Upper Bound: 12.0e+00
+    LandIce Viscosity:
+      Extract Strain Rate Sq: true
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.3
+      Continuous Homotopy With Constant Initial Viscosity: true
+      Coefficient For Continuous Homotopy: 8.0
+      Glen's Law A: 2.400304414e-24            # [Pa^-n s^-1
+      Glen's Law n: 3.0
+      Flow Rate Type: Temperature Based
+    LandIce Physical Parameters:
+      Conductivity of ice: 2.1
+      Diffusivity temperate ice: 1.1e-08
+      Heat capacity of ice: 2.009e+03
+      Water Density: 1.028e+03
+      Ice Density: 9.10e+02
+      Gravity Acceleration: 9.81e+00
+      Reference Temperature: 2.65e+02
+      Clausius-Clapeyron Coefficient: 7.9e-08
+      Ice Latent Heat Of Fusion: 3.34e+05
+      Permeability factor: 1.0e-12 #1e-12
+      Viscosity of water: 1.8e-03
+      Omega exponent alpha: 2.0e+00
+      Diffusivity homotopy exponent: -1.1e+00
+    Body Force:
+      Type: FO INTERP SURF GRAD
+    Response Functions:
+      Number Of Responses: 3
+      Response 0:
+        Type: Sum Of Responses
+        Number Of Responses: 3
+
+        Response 0:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Target Value: 0.0
+        Response 1:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_gradient_basalside
+          Side Set Name: basalside
+          Field Rank: Gradient
+          Target Value: 0.0
+        Response 2:
+          Cubature Degree: 4
+          Scaling Coefficient: 5.8824e-07
+          Asinh Scaling: 1.0e+01
+          Name: Surface Velocity Mismatch
+          Regularization Coefficient: 1.0e+00
+      Response 1:
+        Type: Sum Of Responses
+        Number Of Responses: 1
+        Response 0:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Target Value: 0.0
+        Response 1:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_gradient_basalside
+          Side Set Name: basalside
+          Field Rank: Gradient
+          Target Value: 0.0
+      Response 2:
+        Type: Sum Of Responses
+        Number Of Responses: 2
+        Response 0:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_basalside
+          Side Set Name: basalside
+          Field Rank: Scalar
+          Target Value: 0.0
+        Response 1:
+          Scaling: 5.8824e-06
+          Name: Squared L2 Difference Side Source PST Target MST
+          Source Field Name: basal_friction_log_gradient_basalside
+          Side Set Name: basalside
+          Field Rank: Gradient
+          Target Value: 0.0
+      Response 3:
+        Scaling Coefficient: 5.8824e-06
+        Name: Quadratic Linear Operator Based
+        Linear Operator File Name: ../AsciiMeshes/Humboldt/D_humboldt.mm
+        Diagonal Scaling File Name: ../AsciiMeshes/Humboldt/D_humboldt.mm
+        Field Name: basal_friction_log
+    Hessian:
+      Response 2:
+        Parameter 0:
+          Reconstruct H_pp using Hessian-vector products: true
+          H_pp Solver:
+            Linear Solver Type: Belos
+            Linear Solver Types:
+              Belos:
+                Solver Type: Block GMRES
+                Solver Types:
+                  Block GMRES:
+                    Maximum Iterations: 200
+                    Convergence Tolerance: 1e-7
+                    Num Blocks: 200
+                    Output Frequency: 20
+                    Output Style: 1
+                    Verbosity: 33
+                VerboseObject:
+                  Verbosity Level: medium
+            Preconditioner Type: Ifpack2
+            Preconditioner Types:
+              Ifpack2:
+                Overlap: 0
+                Prec Type: RILUK
+                Ifpack2 Settings: 
+                  Amesos2: {}
+                  Amesos2 solver name: klu
+  Discretization:
+    Workset Size: -1
+    Method: Extruded
+    Surface Height Field Name: surface_height
+    Number Of Time Derivatives: 0
+    Cubature Degree: 4
+    Exodus Output File Name: output/humboldt.exo
+    Use Serial Mesh: false
+    Columnwise Ordering: false
+    NumLayers: 2
+    Thickness Field Name: ice_thickness
+    Extrude Basal Node Fields: [ice_thickness, surface_height, basal_friction_log, bed_topography, apparent_mass_balance, apparent_mass_balance_RMS]
+    Basal Node Fields Ranks: [1, 1, 1, 1, 1, 1]
+    Interpolate Basal Elem Layered Fields: [temperature]
+    Basal Elem Layered Fields Ranks: [1]
+    Interpolate Basal Node Layered Fields: [velocity]
+    Basal Node Layered Fields Ranks: [2]
+    Use Glimmer Spacing: true
+    Required Fields Info:
+      Number Of Fields: 10
+      Field 0:
+        Field Name: ice_thickness
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 1:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 2:
+        Field Name: basal_friction_log
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 3:
+        Field Name: temperature
+        Field Type: Elem Scalar
+        Field Origin: Mesh
+      Field 4:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 5:
+        Field Name: apparent_mass_balance
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 6:
+        Field Name: apparent_mass_balance_RMS
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 7:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 8:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 9:
+        Field Name: velocity
+        Field Type: Node Vector
+        Field Origin: Mesh
+    Side Set Discretizations:
+      Side Sets: [basalside, upperside]
+      basalside:
+        Workset Size: -1
+        Method: Ioss
+        Number Of Time Derivatives: 0
+        Restart Index: 1
+        Use Serial Mesh: ${USE_SERIAL_MESH}
+        Exodus Input File Name: ../AsciiMeshes/Humboldt/humboldt_contiguous_2d.exo
+        Exodus Output File Name: output/humboldt_basal.exo
+        Cubature Degree: 4
+        Required Fields Info:
+          Number Of Fields: 10
+          Field 0:
+            Field Name: ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 1:
+            Field Name: observed_ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 2:
+            Field Name: observed_ice_thickness_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness_uncertainty.ascii
+          Field 3:
+            Field Name: surface_height
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_height.ascii
+          Field 4:
+            Field Name: bed_topography
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/bed_topography.ascii
+          Field 5:
+            Field Name: basal_friction_log
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/basal_friction_log.ascii
+          Field 6:
+            Field Name: temperature
+            Field Type: Elem Layered Scalar
+            Number Of Layers: 7
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/cell_temperature.ascii
+          Field 7:
+            Field Name: apparent_mass_balance
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance.ascii
+          Field 8:
+            Field Name: apparent_mass_balance_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance_uncertainty.ascii
+          Field 9:
+            Field Name: velocity
+            Field Origin: File
+            Field Type: Node Layered Vector
+            Number Of Layers: 2
+            Vector Dim: 2
+            File Name: ../AsciiMeshes/Humboldt/extruded_surface_velocity.ascii
+      upperside:
+        Method: SideSetSTK
+        Number Of Time Derivatives: 0
+        Exodus Output File Name: output/humboldt_upper.exo
+        Cubature Degree: 4
+        Required Fields Info:
+          Number Of Fields: 2
+          Field 0:
+            Field Name: observed_surface_velocity
+            Field Type: Node Vector
+            Vector Dim: 2
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity.ascii
+          Field 1:
+            Field Name: observed_surface_velocity_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity_uncertainty.ascii
+  Piro:
+    Sensitivity Method: Adjoint
+    Write Only Converged Solution: false
+    Enable Explicit Matrix Transpose: true
+    Analysis:
+      Output Final Parameters: false
+      Output Level: 3
+      Analysis Package: ROL
+      ROL:
+        Number Of Parameters: 1
+        Check Derivatives: false
+        Derivative Checks:
+          Perform Reduced Derivative Checks: true       
+          Perform Expensive Derivative Checks: false
+        Parameter Initial Guess Type: Uniform Vector
+        Uniform Parameter Guess: 2.0
+        Min And Max Of Random Parameter Guess: [1.0, 2.0]
+        Bound Constrained: true
+
+        Full Space: false
+        Use NOX Solver: true
+        
+        Matrix Based Dot Product: 
+          Matrix Type: Hessian Of Response
+          #Matrix Type: Identity
+          Matrix Types:
+            Hessian Of Response:
+              Lump Matrix: true
+              Response Index: 1
+        
+        Custom Secant: 
+          Type: Limited-Memory BFGS
+          Maximum Storage: 50
+          Initialization Type: Hessian Of Response
+          Initialization Types:
+            Hessian Of Response:
+              Response Index: 2
+
+        ROL Options:
+        # ===========  SIMOPT SOLVER PARAMETER SUBLIST  =========== 
+          SimOpt:
+            Solve:
+              Absolute Residual Tolerance:   1.0e-6
+              Relative Residual Tolerance:   1.0e-1
+              Iteration Limit:               20
+              Sufficient Decrease Tolerance: 1.e-4
+              Step Tolerance:                1.e-8
+              Backtracking Factor:           0.5
+              Output Iteration History:      true
+              Zero Initial Guess:            false
+              Solver Type:                   0    
+          
+          Status Test: 
+            Gradient Tolerance: 1.0e-4
+            Step Tolerance: 1.0e-10
+            Iteration Limit: 2
+
+          General:
+            Output Level: 3
+            Variable Objective Function: false
+            Scale for Epsilon Active Sets: 1.0
+
+            Secant:
+              Type: Limited-Memory BFGS
+              Use as Preconditioner: true
+              Use as Hessian: false
+              Maximum Storage: 50
+              Use Default Scaling: false
+              Initial Hessian Scale: 1.0
+              Barzilai-Borwein Type: 1
+
+            Krylov:
+              Type: Conjugate Gradients
+              Absolute Tolerance: 1.0e-04
+              Relative Tolerance: 1.0e-02
+              Iteration Limit: 50
+
+          Step:
+            Type: "Trust Region"
+
+            Line Search:
+              Function Evaluation Limit: 20
+              Sufficient Decrease Tolerance: 1.0e-6
+              Initial Step Size: 1.0
+              User Defined Initial Step Size: false
+              Accept Linesearch Minimizer: false
+              Accept Last Alpha: false
+              Descent Method:
+                Type: Quasi-Newton Method
+
+              Line-Search Method:
+                Type: Cubic Interpolation
+                Backtracking Rate: 0.5
+                Bracketing Tolerance: 1.0e-08
+                Path-Based Target Level:
+                  Target Relaxation Parameter: 1.0
+                  Upper Bound on Path Length: 1.0
+
+              Quasi-Newton:
+                Method: L-Secant-B
+                L-Secant-B:
+                  Sufficient Decrease Parameter: 1.0e-02
+                  Relative Tolerance Exponent: 1.0
+
+            Trust Region: 
+              Subproblem Model: Lin-More
+              Subproblem Solver: Truncated CG
+              Initial Radius: -1.0
+              Maximum Radius: 1.0e+08
+              Step Acceptance Threshold: 5.0e-02
+              Radius Shrinking Threshold: 5.0e-02
+              Radius Growing Threshold: 9.0e-01
+              Radius Shrinking Rate (Negative rho): 6.25e-02
+              Radius Shrinking Rate (Positive rho): 2.5e-01
+              Radius Growing Rate: 2.5
+              Safeguard Size: 10.0
+              Inexact:
+                Value:
+                  Tolerance Scaling: 1.0e-01
+                  Exponent: 9.0e-01
+                  Forcing Sequence Initial Value: 1.0
+                  Forcing Sequence Update Frequency: 10
+                  Forcing Sequence Reduction Factor: 1.0e-01
+                Gradient: 
+                  Tolerance Scaling: 1.0e-01
+                  Relative Tolerance: 2.0e+00
+
+    NOX:
+      Thyra Group Options:
+        Function Scaling: None
+        Update Row Sum Scaling: Before Each Nonlinear Solve
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: AND
+          Number of Tests: 1
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Scaled
+            Tolerance: 1.0e-08
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 25
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: {}
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+                      Convergence Tolerance: 1.0e-8
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: MueLu
+              Preconditioner Types:
+                Ifpack2:
+                  Overlap: 0
+                  Prec Type: Amesos2
+                MueLu: 
+                  Matrix: 
+                    PDE equations: 2
+                  Factories: 
+                    myLineDetectionFact: 
+                      factory: LineDetectionFactory
+                      'linedetection: orientation': coordinates
+                    mySemiCoarsenPFact1: 
+                      factory: SemiCoarsenPFactory
+                      'semicoarsen: coarsen rate': 14
+                    UncoupledAggregationFact2: 
+                      factory: UncoupledAggregationFactory
+                      'aggregation: ordering': graph
+                      'aggregation: max selected neighbors': 0
+                      'aggregation: min agg size': 3
+                      'aggregation: phase3 avoid singletons': true
+                    MyCoarseMap2: 
+                      factory: CoarseMapFactory
+                      Aggregates: UncoupledAggregationFact2
+                    myTentativePFact2: 
+                      'tentative: calculate qr': true
+                      factory: TentativePFactory
+                      Aggregates: UncoupledAggregationFact2
+                      CoarseMap: MyCoarseMap2
+                    mySaPFact2: 
+                      'sa: eigenvalue estimate num iterations': 10
+                      'sa: damping factor': 1.3333333e+00
+                      factory: SaPFactory
+                      P: myTentativePFact2
+                    myTransferCoordinatesFact: 
+                      factory: CoordinatesTransferFactory
+                      CoarseMap: MyCoarseMap2
+                      Aggregates: UncoupledAggregationFact2
+                    myTogglePFact: 
+                      factory: TogglePFactory
+                      'semicoarsen: number of levels': 2
+                      TransferFactories: 
+                        P1: mySemiCoarsenPFact1
+                        P2: mySaPFact2
+                        Ptent1: mySemiCoarsenPFact1
+                        Ptent2: myTentativePFact2
+                        Nullspace1: mySemiCoarsenPFact1
+                        Nullspace2: myTentativePFact2
+                    myRestrictorFact: 
+                      factory: TransPFactory
+                      P: myTogglePFact
+                    myToggleTransferCoordinatesFact: 
+                      factory: ToggleCoordinatesTransferFactory
+                      Chosen P: myTogglePFact
+                      TransferFactories: 
+                        Coordinates1: mySemiCoarsenPFact1
+                        Coordinates2: myTransferCoordinatesFact
+                    myRAPFact: 
+                      'rap: fix zero diagonals': true 
+                      factory: RAPFactory
+                      P: myTogglePFact
+                      R: myRestrictorFact
+                      TransferFactories: 
+                        For Coordinates: myToggleTransferCoordinatesFact
+                    myRepartitionHeuristicFact: 
+                      factory: RepartitionHeuristicFactory
+                      A: myRAPFact
+                      'repartition: min rows per proc': 1000
+                      'repartition: max imbalance': 1.327e+00
+                      'repartition: start level': 4
+                    myZoltanInterface: 
+                      factory: ZoltanInterface
+                      A: myRAPFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      number of partitions: myRepartitionHeuristicFact
+                    myRepartitionFact: 
+                      factory: RepartitionFactory
+                      A: myRAPFact
+                      Partition: myZoltanInterface
+                      'repartition: remap parts': true
+                      number of partitions: myRepartitionHeuristicFact
+                    myRebalanceProlongatorFact: 
+                      factory: RebalanceTransferFactory
+                      type: Interpolation
+                      P: myTogglePFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      Nullspace: myTogglePFact
+                    myRebalanceRestrictionFact: 
+                      factory: RebalanceTransferFactory
+                      type: Restriction
+                      R: myRestrictorFact
+                    myRebalanceAFact: 
+                      factory: RebalanceAcFactory
+                      A: myRAPFact
+                      TransferFactories: { }
+                    mySmoother1: 
+                      factory: TrilinosSmoother
+                      #type: LINESMOOTHING_BANDEDRELAXATION
+                      type: LINESMOOTHING_TRIDIRELAXATION
+                      'smoother: pre or post': both
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0e+00
+                        'block relaxation: decouple dofs': true
+                        'partitioner: PDE equations': 2
+                    mySmoother3: 
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': both
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0e+00
+                    mySmoother4: 
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': pre
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 4
+                        'relaxation: damping factor': 1.0e+00
+                  Hierarchy: 
+                    max levels: 7
+                    'coarse: max size': 2000
+                    verbosity: Low
+                    use kokkos refactor: false
+                    Finest: 
+                      Smoother: mySmoother1
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact
+                    All: 
+                      startLevel: 1
+                      Smoother: mySmoother4
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact
+          Rescue Bad Newton Solve: true
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Backtrack
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+      Solver Options:
+        Status Test Check Type: Minimal
+  Regression For Response 0:
+    Absolute Tolerance: 1.0e-06
+    Relative Tolerance: 1.0e-06
+    Piro Analysis Test Two Norm: true
+    Piro Analysis Test Values: [75.4983443527]
+...

--- a/tests/landIce/FO_Hydrology/input_dome_steady_bwd.yaml
+++ b/tests/landIce/FO_Hydrology/input_dome_steady_bwd.yaml
@@ -306,18 +306,19 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1 
-        Check Gradient: false
+        Check Derivatives: false
         Parameter Initial Guess Type: From Model Evaluator
         Bound Constrained: true
 
         Full Space: false
         Use NOX Solver: true        
         
-        Matrix Based Dot Product: 
+        Matrix Based Dot Product:
           Matrix Type: Hessian Of Response
           # Matrix Type: Identity
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 0
 
         ROL Options: 

--- a/tests/landIce/FO_Thermo/humboldt_analysis.yaml
+++ b/tests/landIce/FO_Thermo/humboldt_analysis.yaml
@@ -274,7 +274,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Print Output: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: -5.7e+00
@@ -288,6 +288,7 @@ ANONYMOUS:
           Matrix Type: Hessian Of Response
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 0
 
         ROL Options: 

--- a/tests/landIce/FO_Thermo/humboldt_analysis_contiguous.yaml
+++ b/tests/landIce/FO_Thermo/humboldt_analysis_contiguous.yaml
@@ -274,7 +274,7 @@ ANONYMOUS:
       Analysis Package: ROL
       ROL:
         Number Of Parameters: 1
-        Check Gradient: false
+        Check Derivatives: false
         Print Output: true
         Parameter Initial Guess Type: Uniform Vector
         Uniform Parameter Guess: -5.7e+00
@@ -288,6 +288,7 @@ ANONYMOUS:
           Matrix Type: Hessian Of Response
           Matrix Types:
             Hessian Of Response:
+              Lump Matrix: false
               Response Index: 0
 
         ROL Options: 


### PR DESCRIPTION
This PR implements modifications to comply with changes in piro (https://github.com/trilinos/Trilinos/pull/11649).
    
In particular in this PR
    1. we change the notation for checking derivatives,
    2. we now allow to select a user-defined secant based on Hessian of responses
    3. we add a landice test using user-defined secant
    4. we do some cleaning of unused parameters in the main Albany parameterList
