### PR TITLE
Comply with Tpetra changes to KokkosCompat (https://github.com/trilinos/Trilinos/pull/11632)

### DIFF
--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -13,7 +13,7 @@
 #include "Albany_ScalarOrdinalTypes.hpp"
 
 // Get Kokkos node wrapper
-#include "KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
+#include "Tpetra_KokkosCompat_ClassicNodeAPI_Wrapper.hpp"
 
 // Get Kokkos graph and matrix
 #include "Kokkos_StaticCrsGraph.hpp"
@@ -23,7 +23,7 @@
 #include "Phalanx_KokkosDeviceTypes.hpp"
 
 // The Kokkos node is determined from the Phalanx Device
-typedef Kokkos::Compat::KokkosDeviceWrapperNode<PHX::Device>  KokkosNode;
+typedef Tpetra::KokkosCompat::KokkosDeviceWrapperNode<PHX::Device>  KokkosNode;
 
 namespace Albany
 {


### PR DESCRIPTION
Tpetra has deprecated Kokkos-prefixed files and namespaces. This PR updates Albany to be in compliance with this change.