### PR TITLE
Generate export_albany only if MPAS interface is ON

### DIFF
--- a/cmake/CreateExportAlbany
+++ b/cmake/CreateExportAlbany
@@ -54,57 +54,6 @@ def get_link_line_make(bin_dir):
     return items
 
 ###############################################################################
-def parse_link_line(items,install_lib_dir,bin_dir,make_dir):
-###############################################################################
-    libs = []
-    libs_dirs = [install_lib_dir]
-    for item in items:
-        if "," in item:
-            # This are link options, so process them one by one
-            tokens = item.split(',')
-            for i,t in enumerate(tokens):
-                if ':' in t:
-                  paths = t.split(':')
-                  # Loop over all paths, replace them with install dir
-                  for j,p in enumerate(paths):
-                    path = pathlib.Path(p).resolve()
-                    paths[j] = str(install_lib_dir)
-
-                  # Replace the rpath list with the unique list
-                  tokens[i] = ':'.join(list(set(paths)))
-                else:
-                  # Just a link flag, keep it
-                  tokens[i] = t
-
-            # Re-join proecessed tokens with commas
-            libs.append(",".join(tokens))
-        elif item.startswith("-l"):
-            # It's either a -lXYZ lib or a link flag. Keep it as is.
-            libs.append(item)
-        elif item.startswith("-") and not item.startswith("-L"):
-            # This is some funky link option (e.g., -mkl or -cxxlib with Intel).
-            # Simply add the item to the "libs" list
-            libs.append(item)
-        else:
-            # We want to get an abs path, with symlinks resolved *except* for symlinks
-            # in the file name, to avoid an error we're seeing where libdl.so points
-            # to the file libdl-2.28.so (an odd name: usually we see libdl.so.2.28)
-            lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
-            if not lib_file_full.exists():
-                print (f"could not locate lib: {lib_file_full}")
-                print (f"cwd: {os.getcwd()}")
-                raise ValueError
-            lib_file      = lib_file_full.name
-            lib_path      = lib_file_full.parent
-            # Remove all extensions (such as .so.5), and remove first 3 chars (lib)
-            lib_name = str(lib_file).split('.')[0][3:]
-            libs.append (f"-l{lib_name}")
-            if not lib_path in libs_dirs and not str(lib_path).startswith(str(bin_dir)):
-                libs_dirs.append(lib_path)
-
-    return libs_dirs, libs
-
-###############################################################################
 def run (bin_dir,install_lib_dir, cmake_generator):
 ###############################################################################
 
@@ -147,6 +96,7 @@ def run (bin_dir,install_lib_dir, cmake_generator):
             # Simply add the item to the "libs" list
             libs.append(item)
         elif item.startswith("-L"):
+            print (f"-L dir: {item}")
             # We want to get an abs path, with symlinks resolved (if any)
             lib_dir_full = pathlib.Path(item[2:]).resolve()
             if not lib_dir_full.exists() or not lib_dir_full.is_dir():
@@ -181,6 +131,7 @@ def run (bin_dir,install_lib_dir, cmake_generator):
     for lib in libs:
         link_line += f"{lib} "
 
+    print (f"writing to {outfile}")
     with outfile.open('w') as fd:
         fd.write(f'ALBANY_LINK_LIBS="{link_line.strip()}"')
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -625,34 +625,36 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/AlbanyConfig.cmake
 
 install(EXPORT albany-export DESTINATION ${CMAKE_INSTALL_LIBDIR}/Albany/cmake  FILE "albany-targets.cmake")
 
-# Create dummy executable that links against all albany libs and its tpls
-# Then, read its link.txt file, to fetch all the actual library files we're linking against.
-# Note: link.txt will contain something like
-#   /path/to/mpicxx $flag1 ... $flagN /path/to/main.cpp.o -o dummy $lib1 ... $libN
-# We want to remove every string up to dummy, and keep only the libs afterward.
+if (ENABLE_MPAS_INTERFACE)
+  # Create dummy executable that links against all albany libs and its tpls
+  # Then, read its link.txt file, to fetch all the actual library files we're linking against.
+  # Note: link.txt will contain something like
+  #   /path/to/mpicxx $flag1 ... $flagN /path/to/main.cpp.o -o dummy $lib1 ... $libN
+  # We want to remove every string up to dummy, and keep only the libs afterward.
 
-# Parse dummy subproject folder
-add_subdirectory (${CMAKE_SOURCE_DIR}/cmake/dummy
-                  ${CMAKE_BINARY_DIR}/dummy)
+  # Parse dummy subproject folder
+  add_subdirectory (${CMAKE_SOURCE_DIR}/cmake/dummy
+                    ${CMAKE_BINARY_DIR}/dummy)
 
-if (CMAKE_GENERATOR STREQUAL "Ninja")
-  set (WORK_DIR ${CMAKE_BINARY_DIR})
-elseif(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
-  set (WORK_DIR ${CMAKE_BINARY_DIR}/dummy)
+  if (CMAKE_GENERATOR STREQUAL "Ninja")
+    set (WORK_DIR ${CMAKE_BINARY_DIR})
+  elseif(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+    set (WORK_DIR ${CMAKE_BINARY_DIR}/dummy)
+  endif()
+
+  add_custom_command (OUTPUT ${CMAKE_BINARY_DIR}/export_albany.in
+                      COMMAND ${CMAKE_SOURCE_DIR}/cmake/CreateExportAlbany
+                      ARGS --bin-dir ${CMAKE_BINARY_DIR}
+                           --install-lib-dir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
+                           --cmake-generator ${CMAKE_GENERATOR}
+                      DEPENDS ${CMAKE_BINARY_DIR}/src/Albany_GitVersion.h
+                      WORKING_DIRECTORY ${WORK_DIR})
+
+  add_custom_target (create_export_albany ALL
+                     DEPENDS ${CMAKE_BINARY_DIR}/export_albany.in)
+  add_dependencies(create_export_albany ${ALBANY_LIBRARIES})
+
+  # Install the file
+  install (FILES ${CMAKE_BINARY_DIR}/export_albany.in
+           DESTINATION ${CMAKE_INSTALL_PREFIX})
 endif()
-
-add_custom_command (OUTPUT ${CMAKE_BINARY_DIR}/export_albany.in
-                    COMMAND ${CMAKE_SOURCE_DIR}/cmake/CreateExportAlbany
-                    ARGS --bin-dir ${CMAKE_BINARY_DIR}
-                         --install-lib-dir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}
-                         --cmake-generator ${CMAKE_GENERATOR}
-                    DEPENDS ${CMAKE_BINARY_DIR}/src/Albany_GitVersion.h
-                    WORKING_DIRECTORY ${WORK_DIR})
-
-add_custom_target (create_export_albany ALL
-                   DEPENDS ${CMAKE_BINARY_DIR}/export_albany.in)
-add_dependencies(create_export_albany ${ALBANY_LIBRARIES})
-
-# Install the file
-install (FILES ${CMAKE_BINARY_DIR}/export_albany.in
-         DESTINATION ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
No point in generating this file unless we need to link to MPAS, since that's its only customer.