### PR TITLE
Add ScatterResidualBase instantiation

### DIFF
--- a/src/evaluators/scatter/PHAL_ScatterResidual.cpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.cpp
@@ -9,5 +9,6 @@
 #include "PHAL_ScatterResidual.hpp"
 #include "PHAL_ScatterResidual_Def.hpp"
 
+PHAL_INSTANTIATE_TEMPLATE_CLASS(PHAL::ScatterResidualBase)
 PHAL_INSTANTIATE_TEMPLATE_CLASS(PHAL::ScatterResidual)
 PHAL_INSTANTIATE_TEMPLATE_CLASS(PHAL::ScatterResidualWithExtrudedParams)


### PR DESCRIPTION
The attaway build is still broken (see https://sems-cdash-son.sandia.gov/cdash/viewBuildError.php?buildid=47838 & https://github.com/sandialabs/Albany/issues/933 & #861):
```
LandIce_ScatterResidual2D.cpp:(.text._ZN4PHAL32ScatterResidualWithExtrudedFieldINS_12AlbanyTraits8JacobianES1_E14evaluateFieldsERNS_7WorksetE[_ZN4PHAL32ScatterResidualWithExtrudedFieldINS_12AlbanyTraits8JacobianES1_E14evaluateFieldsERNS_7WorksetE]+0x39): undefined reference to `PHAL::ScatterResidualBase<PHAL::AlbanyTraits::Jacobian, PHAL::AlbanyTraits>::gather_fields_offsets(Teuchos::RCP<Albany::DOFManager const> const&)'
```
The build wasn't smart enough to find `gather_fields_offsets()` in the base class. This fixes it.