### PR TITLE
Fix logic for creating adjoint model

### DIFF
--- a/pyAlbany/src/Albany_Interface.cpp
+++ b/pyAlbany/src/Albany_Interface.cpp
@@ -120,8 +120,7 @@ PyProblem::PyProblem(std::string filename, Teuchos::RCP<PyParallelEnv> _pyParall
                                            slvrfctry->getParameters()->sublist("Piro").get<bool>("Enable Explicit Matrix Transpose") : 
                                            false;
 
-    const bool explicitAdjointModel = albanyApp->isAdjointSensitivities() && explicitMatrixTranspose;
-    albanyAdjointModel = explicitAdjointModel ? slvrfctry->createModel(albanyApp, true) : Teuchos::null;
+    albanyAdjointModel = explicitMatrixTranspose ? slvrfctry->createModel(albanyApp, true) : Teuchos::null;
     solver = slvrfctry->createSolver(comm, albanyModel, albanyAdjointModel);
 
     n_params = albanyModel->Np();
@@ -181,8 +180,7 @@ PyProblem::PyProblem(Teuchos::RCP<Teuchos::ParameterList> params, Teuchos::RCP<P
                                            slvrfctry->getParameters()->sublist("Piro").get<bool>("Enable Explicit Matrix Transpose") : 
                                            false;
 
-    const bool explicitAdjointModel = albanyApp->isAdjointSensitivities() && explicitMatrixTranspose;
-    albanyAdjointModel = explicitAdjointModel ? slvrfctry->createModel(albanyApp, true) : Teuchos::null;
+    albanyAdjointModel = explicitMatrixTranspose ? slvrfctry->createModel(albanyApp, true) : Teuchos::null;
     solver = slvrfctry->createSolver(comm, albanyModel, albanyAdjointModel);
 
     n_params = albanyModel->Np();

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -80,15 +80,6 @@ int main(int argc, char *argv[]) {
     // is created (since in the App ctor the pb factories are queried)
     Albany::register_pb_factories();
 
-    //sensitivities are always needed when performing analysis
-    if(slvrfctry.getParameters()->sublist("Problem").isParameter("Compute Sensitivities")) {
-      TEUCHOS_TEST_FOR_EXCEPTION(!slvrfctry.getParameters()->sublist("Problem").get<bool>("Compute Sensitivities"),
-                            Teuchos::Exceptions::InvalidArgument,
-                            "Error! Sensitivities are needed for Analysis problems.\n");
-    } else  {
-      slvrfctry.getParameters()->sublist("Problem").set<bool>("Compute Sensitivities", true);
-    }
-
     // Create app (null initial guess)
     const auto albanyApp = slvrfctry.createApplication(comm);
     //Forward model model evaluator
@@ -100,8 +91,7 @@ int main(int argc, char *argv[]) {
                                            slvrfctry.getParameters()->sublist("Piro").get<bool>("Enable Explicit Matrix Transpose") : 
                                            false;
 
-    const bool explicitAdjointModel = albanyApp->isAdjointSensitivities() && explicitMatrixTranspose;
-    const auto albanyAdjointModel = explicitAdjointModel ? slvrfctry.createModel(albanyApp, true) : Teuchos::null; 
+    const auto albanyAdjointModel = explicitMatrixTranspose ? slvrfctry.createModel(albanyApp, true) : Teuchos::null; 
     const auto solver      = slvrfctry.createSolver(comm, albanyModel, albanyAdjointModel);
 
     stackedTimer->stop("Albany: Setup Time");

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -142,6 +142,7 @@ int main(int argc, char *argv[])
                                         slvrfctry.getParameters()->sublist("Piro").get<bool>("Enable Explicit Matrix Transpose") : 
                                         false;
 
+    // Explicit adjoint model is not needed if we are not computing adjoint sensitivities
     const bool explicitAdjointModel = albanyApp->isAdjointSensitivities() && explicitMatrixTranspose;
     const auto albanyAdjointModel = explicitAdjointModel ? slvrfctry.createModel(albanyApp, true) : Teuchos::null; 
     const auto solver      = slvrfctry.createSolver(comm, albanyModel, albanyAdjointModel);


### PR DESCRIPTION
At the moment, we do not create an adjoint model when `Compute Sensitivities` is `false`. While this makes sense for forward runs, it does not for Analysis runs, where the needed derivatives are computed regardless of the `Compute Sensitivities` parameter.