### PR TITLE
LandIce: ViscosityFO: Allow evaluating temperature at quadrature points

### DIFF
--- a/src/landIce/evaluators/LandIce_PressureCorrectedTemperature.hpp
+++ b/src/landIce/evaluators/LandIce_PressureCorrectedTemperature.hpp
@@ -43,18 +43,20 @@ public:
 private:
   // Input:
   typedef typename Albany::StrongestScalarType<typename Albany::StrongestScalarType<TempST,MeshScalarT>::type, SurfHeightST>::type OutputScalarT;
-  PHX::MDField<const SurfHeightST,Cell> sHeight;
-  PHX::MDField<const TempST,Cell> temp;
-  PHX::MDField<const MeshScalarT,Cell,Dim> coord;
-
+  PHX::MDField<const SurfHeightST> sHeight;
+  PHX::MDField<const TempST> temp;
+  PHX::MDField<const MeshScalarT> coord;
   // Output:
-  PHX::MDField<OutputScalarT,Cell> correctedTemp;
+  PHX::MDField<OutputScalarT> correctedTemp;
 
   double beta;     //[K Pa^{-1}]
   double rho_i;    //[kg m^{-3}]
   double g;        //[m s^{-2}]
   double coeff;    //[K km^{-1}]
   double meltingT; //[K], 273.15
+
+  bool useP0Temp;
+  int numQPs;
 
   PHAL::MDFieldMemoizer<Traits> memoizer;
 };

--- a/src/landIce/evaluators/LandIce_ViscosityFO.hpp
+++ b/src/landIce/evaluators/LandIce_ViscosityFO.hpp
@@ -44,9 +44,8 @@ public:
   void evaluateFields(typename Traits::EvalData d);
 
 private:
-  template<typename TemperatureT>
   KOKKOS_INLINE_FUNCTION
-  TemperatureT flowRate(const TemperatureT& T) const;
+  TemprT flowRate(const TemprT& T) const;
 
   const double pi, actenh, actenl, gascon, switchingT;
   const double arrmlh, arrmll, scyr, k4scyr;
@@ -55,6 +54,7 @@ private:
   bool extractStrainRateSq;
   bool useStereographicMap;
   bool useStiffeningFactor;
+  bool useP0Temp;
   Teuchos::ParameterList* stereographicMapList;
 
   // Coefficients for Glen's law
@@ -65,7 +65,7 @@ private:
   PHX::MDField<const VelT,Cell,QuadPoint,VecDim,Dim> Ugrad; //[(k yr)^{-1}], k=1000
   PHX::MDField<const VelT,Cell,QuadPoint,VecDim> U; //[m/yr]
   PHX::MDField<const MeshScalarT,Cell,QuadPoint, Dim> coordVec; // [Km]
-  PHX::MDField<const TemprT,Cell> temperature; // [K]
+  PHX::MDField<const TemprT> temperature; // [K]
   PHX::MDField<const RealType,Cell> flowFactorA;  // [k^{-(n+1)} Pa^{-n} yr^{-1} ], k=1000.  This is the coefficient A.
   PHX::MDField<const ParamScalarT,Cell,QuadPoint> stiffeningFactor;
   PHX::MDField<const ScalarT> homotopyParam;
@@ -95,12 +95,14 @@ public:
   struct ViscosityFO_CONSTANT_Tag{};
   struct ViscosityFO_GLENSLAW_UNIFORM_Tag{};
   struct ViscosityFO_GLENSLAW_TEMPERATUREBASED_Tag{};
+  struct ViscosityFO_GLENSLAW_TEMPERATUREBASEDQP_Tag{};
   struct ViscosityFO_GLENSLAW_FROMFILE_Tag{};
 
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_EXPTRIG_Tag> ViscosityFO_EXPTRIG_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_CONSTANT_Tag> ViscosityFO_CONSTANT_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_UNIFORM_Tag> ViscosityFO_GLENSLAW_UNIFORM_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_TEMPERATUREBASED_Tag> ViscosityFO_GLENSLAW_TEMPERATUREBASED_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_TEMPERATUREBASEDQP_Tag> ViscosityFO_GLENSLAW_TEMPERATUREBASED_QP_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace, ViscosityFO_GLENSLAW_FROMFILE_Tag> ViscosityFO_GLENSLAW_FROMFILE_Policy;
 
   KOKKOS_INLINE_FUNCTION
@@ -116,10 +118,13 @@ public:
   void operator() (const ViscosityFO_GLENSLAW_TEMPERATUREBASED_Tag& tag, const int& i) const;
 
   KOKKOS_INLINE_FUNCTION
+  void operator() (const ViscosityFO_GLENSLAW_TEMPERATUREBASEDQP_Tag& tag, const int& i) const;
+
+  KOKKOS_INLINE_FUNCTION
   void operator() (const ViscosityFO_GLENSLAW_FROMFILE_Tag& tag, const int& i) const;
 
   KOKKOS_INLINE_FUNCTION
-  void glenslaw (const ScalarT &flowFactorVec, const int& cell) const;
+  void glenslaw (const int& cell) const;
 
   double R, x_0, y_0, R2;
 };

--- a/src/landIce/problems/LandIce_Enthalpy.hpp
+++ b/src/landIce/problems/LandIce_Enthalpy.hpp
@@ -325,8 +325,10 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
 
   fm0.template registerEvaluator<EvalT> (evalUtils.getMSTUtils().constructDOFGradInterpolationEvaluator("melting_temperature"));
 
-  // Interpolate temperature from nodes to cell
-  fm0.template registerEvaluator<EvalT> (evalUtils.constructBarycenterEvaluator("temperature", cellBasis, FRT::Scalar));
+
+  // Interpolate corrected temperature from nodes to cell (used when viscosity uses P0 Temperature) and from nodes to quad points
+  fm0.template registerEvaluator<EvalT> (evalUtils.constructBarycenterEvaluator("corrected_temperature", cellBasis, FRT::Scalar));
+  fm0.template registerEvaluator<EvalT> (evalUtils.constructDOFInterpolationEvaluator("corrected_temperature"));
 
   // Interpolate pressure melting temperature gradient from nodes to QPs
   //fm0.template registerEvaluator<EvalT> (evalUtils.getPSTUtils().constructDOFGradInterpolationSideEvaluator("melting temp",basalSideName));
@@ -508,8 +510,9 @@ LandIce::Enthalpy::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
       p->set<std::string>("Coordinate Vector Variable Name", Albany::coord_vec_name);
       p->set<std::string>("Velocity QP Variable Name", "velocity");
       p->set<std::string>("Velocity Gradient QP Variable Name", "velocity Gradient");
-      p->set<std::string>("Temperature Variable Name", "temperature");
+      p->set<std::string>("Temperature Variable Name", "corrected_temperature");
       p->set<std::string>("Flow Factor Variable Name", "flow_factor");
+      p->set<bool>("Use P0 Temperature", params->sublist("LandIce Viscosity").get("Use P0 Temperature",true));
 
       p->set<ParameterList*>("Stereographic Map", &params->sublist("Stereographic Map"));
       p->set<ParameterList*>("Parameter List", &params->sublist("LandIce Viscosity"));

--- a/src/landIce/problems/LandIce_StokesFO.cpp
+++ b/src/landIce/problems/LandIce_StokesFO.cpp
@@ -247,7 +247,7 @@ void StokesFO::setupEvaluatorRequests () {
     ss_utils_needed[ssName][UtilityRequest::QP_COORDS] = true;
     ss_utils_needed[ssName][UtilityRequest::NORMALS  ] = true;
   }
-  if (viscosity_use_corrected_temperature) {
+  if (viscosity_use_corrected_temperature && viscosity_use_p0_temperature) {
     build_interp_ev[surface_height_name][InterpolationRequest::CELL_VAL] = true;
   }
 

--- a/src/landIce/problems/LandIce_StokesFO.hpp
+++ b/src/landIce/problems/LandIce_StokesFO.hpp
@@ -208,6 +208,7 @@ StokesFO::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& fm0,
     p->set<std::string>("Coordinate Vector Variable Name", Albany::coord_vec_name);
     p->set<Teuchos::ParameterList*>("LandIce Physical Parameters", &params->sublist("LandIce Physical Parameters"));
     p->set<std::string>("Temperature Variable Name", temperature_name);
+    p->set<bool>("Use P0 Temperature", viscosity_use_p0_temperature);
 
     //Output
     p->set<std::string>("Corrected Temperature Variable Name", corrected_temperature_name);

--- a/src/landIce/problems/LandIce_StokesFOBase.cpp
+++ b/src/landIce/problems/LandIce_StokesFOBase.cpp
@@ -54,6 +54,9 @@ StokesFOBase (const Teuchos::RCP<Teuchos::ParameterList>& params_,
   } else {
     viscosity_use_corrected_temperature = false;
   }
+
+  viscosity_use_p0_temperature = params->sublist("LandIce Viscosity").get("Use P0 Temperature",true);
+
   compute_dissipation = params->sublist("LandIce Viscosity").get("Extract Strain Rate Sq", false);
 
   if (!physics_list.isParameter("Atmospheric Pressure Melting Temperature")) {
@@ -414,6 +417,8 @@ void StokesFOBase::parseInputFields ()
       loc = FL::Node;
     } else if (fieldType.find("Elem")!=std::string::npos) {
       loc = FL::Cell;
+    } else if (fieldType.find("QuadPoint")!=std::string::npos) {
+      loc = FL::QuadPoint;
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
         "Error! Failed to deduce location for field '" + fieldName + "' from type '" + fieldType + "'.\n");
@@ -487,6 +492,8 @@ void StokesFOBase::parseInputFields ()
         loc = FL::Node;
       } else if (fieldType.find("Elem")!=std::string::npos) {
         loc = FL::Cell;
+      } else if (fieldType.find("QuadPoint")!=std::string::npos) {
+        loc = FL::QuadPoint;
       } else {
         TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error,
           "Error! Failed to deduce location for field '" + fieldName + "' from type '" + fieldType + "'.\n");

--- a/src/landIce/problems/LandIce_StokesFOThermoCoupled.cpp
+++ b/src/landIce/problems/LandIce_StokesFOThermoCoupled.cpp
@@ -254,6 +254,7 @@ void StokesFOThermoCoupled::setupEvaluatorRequests ()
 
   build_interp_ev[temperature_name          ][IReq::CELL_VAL   ] = true;
   build_interp_ev[corrected_temperature_name][IReq::CELL_VAL   ] = true;
+  build_interp_ev[corrected_temperature_name][IReq::QP_VAL     ] = true;
   build_interp_ev[stiffening_factor_name    ][IReq::QP_VAL     ] = true;
   build_interp_ev[surface_height_name       ][IReq::QP_VAL     ] = true;
   build_interp_ev[surface_height_name       ][IReq::GRAD_QP_VAL] = true;

--- a/src/landIce/problems/LandIce_StokesFOThickness.hpp
+++ b/src/landIce/problems/LandIce_StokesFOThickness.hpp
@@ -123,6 +123,7 @@ StokesFOThickness::constructEvaluators (PHX::FieldManager<PHAL::AlbanyTraits>& f
   p->set<std::string>("Coordinate Vector Variable Name", Albany::coord_vec_name);
   p->set<Teuchos::ParameterList*>("LandIce Physical Parameters", &params->sublist("LandIce Physical Parameters"));
   p->set<std::string>("Temperature Variable Name", temperature_name);
+  p->set<bool>("Use P0 Temperature", viscosity_use_p0_temperature);  
 
   //Output
   p->set<std::string>("Corrected Temperature Variable Name", "corrected " + temperature_name);

--- a/tests/landIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/landIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -19,6 +19,7 @@ ANONYMOUS:
     Dirichlet BCs:
       DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
     LandIce Viscosity:
+      Use P0 Temperature: false
       Extract Strain Rate Sq: true
       Type: Glen's Law
       Glen's Law Homotopy Parameter: 0.5e+00
@@ -287,9 +288,9 @@ ANONYMOUS:
         Status Test Check Type: Minimal
   Regression For Response 0:
     Relative Tolerance: 1.0e-06
-    Test Value: -1.246900214613e+01
+    Test Value: -1.251507530710e+01
     Sensitivity For Parameter 0:
-      Test Value: 1.485033563141e-05
+      Test Value: 1.414057848721e-05
     
     
 ...

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -56,6 +56,7 @@ ANONYMOUS:
         Name: basal_friction_log
         Upper Bound: 12.0
     LandIce Viscosity:
+      Use P0 Temperature: false
       Extract Strain Rate Sq: true
       Type: Glen's Law
       Glen's Law Homotopy Parameter: 0.5e+00
@@ -404,14 +405,14 @@ ANONYMOUS:
         Status Test Check Type: Minimal
   Regression For Response 0:
     Relative Tolerance: 1.0e-06
-    Test Value:  8.853557373397e+00
+    Test Value:  8.794803492345e+00
     Sensitivity For Parameter 0:
-      Test Value: 2.286186416967e+00
+      Test Value: 2.229417788390e+00
   Regression For Response 1:
     Relative Tolerance: 1.0e-06
-    Test Value: 6.986714588061e-04
+    Test Value: 6.990490666634e-04
     Sensitivity For Parameter 0:
-      Test Value: 1.544850310382e-04
+      Test Value: 1.543749302241e-04
   Regression For Response 2:
     Relative Tolerance: 1.0e-06
     Test Value: 5.967986097162e+00

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
@@ -33,6 +33,7 @@ ANONYMOUS:
         Type: Scalar
         Name: Glen's Law Homotopy Parameter
     LandIce Viscosity:
+      Use P0 Temperature: false
       Extract Strain Rate Sq: true
       Type: Glen's Law
       Glen's Law Homotopy Parameter: 0.4e+00
@@ -200,7 +201,7 @@ ANONYMOUS:
                       Size of Krylov Subspace: 200
                       Output Frequency: 20
                     Max Iterations: 500
-                    Tolerance: 9.99999999999999954e-08
+                    Tolerance: 1.0e-7
                 Belos:
                   Solver Type: Block GMRES
                   Solver Types:
@@ -226,7 +227,7 @@ ANONYMOUS:
                     default values: SA
                     ML output: 0
                     'repartition: enable': 1
-                    'repartition: max min ratio': 1.32699999999999995e+00
+                    'repartition: max min ratio': 1.3267e+00
                     'repartition: min per proc': 600
                     'repartition: Zoltan dimensions': 2
                     'repartition: start level': 4
@@ -234,12 +235,12 @@ ANONYMOUS:
                     'semicoarsen: coarsen rate': 12
                     'smoother: sweeps': 4
                     'smoother: type': Chebyshev
-                    'smoother: Chebyshev eig boost': 1.19999999999999995e+00
+                    'smoother: Chebyshev eig boost': 1.2e+00
                     'smoother: sweeps (level 0)': 1
                     'smoother: sweeps (level 1)': 4
                     'smoother: type (level 0)': line Jacobi
                     'smoother: type (level 1)': line Jacobi
-                    'smoother: damping factor': 5.50000000000000044e-01
+                    'smoother: damping factor': 5.5e-01
                     'smoother: pre or post': both
                     'coarse: type': Amesos-KLU
                     'coarse: pre or post': pre
@@ -248,7 +249,7 @@ ANONYMOUS:
           Rescue Bad Newton Solve: true
       Line Search:
         Full Step:
-          Full Step: 1.00000000000000000e+00
+          Full Step: 1.0
         Method: Full Step
       Nonlinear Solver: Line Search Based
       Printing:
@@ -267,8 +268,8 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:
+    Relative Tolerance: 1.0e-06
+    Test Value: 9.193763151141e-01
     Sensitivity For Parameter 0:
-      Test Value: -4.047248515945e-01
-    Test Value: 9.189270361967e-01
-    Relative Tolerance: 1.0e-02
+      Test Value: -4.124427136211e-01
 ...


### PR DESCRIPTION
Until now viscosity used P0 temperature fields.
Modified a couple of tests to exercise new capability.

Also, fixed Enthalpy problem so that it uses the pressure corrected temperature for computing the viscosity.