### PR TITLE
LandIce: adding Depth Integrated Model

### DIFF
--- a/src/evaluators/utility/PHAL_ComputeBasisFunctions.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctions.hpp
@@ -49,7 +49,8 @@ private:
   //! Coordinate vector at vertices
   PHX::MDField<const MeshScalarT,Cell,Vertex,Dim> coordVec;
   Teuchos::RCP<Intrepid2::Cubature<PHX::Device> > cubature;
-  Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis;
+  Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepid2FEBasis;
+  Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepid2MapBasis;
 
   Kokkos::DynRankView<RealType, PHX::Device> val_at_cub_points;
   Kokkos::DynRankView<RealType, PHX::Device> grad_at_cub_points;
@@ -57,11 +58,11 @@ private:
   Kokkos::DynRankView<RealType, PHX::Device> refWeights;
   Kokkos::DynRankView<MeshScalarT, PHX::Device> jacobian;
   Kokkos::DynRankView<MeshScalarT, PHX::Device> jacobian_inv;
+  Kokkos::DynRankView<MeshScalarT, PHX::Device> jacobian_det;
 
   // Output:
   //! Basis Functions at quadrature points
   PHX::MDField<MeshScalarT,Cell,QuadPoint> weighted_measure;
-  PHX::MDField<MeshScalarT,Cell,QuadPoint> jacobian_det; 
   PHX::MDField<RealType,Cell,Node,QuadPoint> BF;
   PHX::MDField<MeshScalarT,Cell,Node,QuadPoint> wBF;
   PHX::MDField<MeshScalarT,Cell,Node,QuadPoint,Dim> GradBF;

--- a/src/landIce/CMakeLists.txt
+++ b/src/landIce/CMakeLists.txt
@@ -190,6 +190,8 @@ set(HEADERS
   evaluators/hydrology/LandIce_HydrologyWaterDischarge_Def.hpp
   evaluators/hydrology/LandIce_HydrologyWaterThickness.hpp
   evaluators/hydrology/LandIce_HydrologyWaterThickness_Def.hpp
+  utility/Intrepid2_HGRAD_LINE_I4_FEM.hpp
+  utility/Intrepid2_HGRAD_LINE_I4_FEMDef.hpp
   problems/LandIce_ColumnCouplingTest.hpp
   problems/LandIce_Enthalpy.hpp
   problems/LandIce_Hydrology.hpp
@@ -233,6 +235,7 @@ set (LANDICE_INCLUDE_DIRS
      ${CMAKE_CURRENT_SOURCE_DIR}
      ${CMAKE_CURRENT_SOURCE_DIR}/evaluators
      ${CMAKE_CURRENT_SOURCE_DIR}/evaluators/hydrology
+     ${CMAKE_CURRENT_SOURCE_DIR}/utility
      ${CMAKE_CURRENT_SOURCE_DIR}/problems
 )
 

--- a/src/landIce/problems/LandIce_StokesFO.hpp
+++ b/src/landIce/problems/LandIce_StokesFO.hpp
@@ -82,6 +82,10 @@ public:
   template <typename EvalT>
   void constructFields(PHX::FieldManager<PHAL::AlbanyTraits>& fm0);
 
+  const Teuchos::RCP<IntrepidCubature> getCellCubature() const {
+    return this->cellCubature;
+  }
+
 protected:
 
   void setFieldsProperties();

--- a/src/landIce/utility/Intrepid2_HGRAD_LINE_I4_FEM.hpp
+++ b/src/landIce/utility/Intrepid2_HGRAD_LINE_I4_FEM.hpp
@@ -1,0 +1,275 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov), or
+//                    Mauro Perego  (mperego@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_HGRAD_LINE_I4_FEM.hpp
+    \brief  Header file for the Intrepid2::Basis_HGRAD_LINE_I4_FEM class.
+    \author Created by M. Perego
+*/
+
+#ifndef __INTREPID2_HGRAD_LINE_I4_FEM_HPP__
+#define __INTREPID2_HGRAD_LINE_I4_FEM_HPP__
+
+#include "Intrepid2_Basis.hpp"
+
+namespace Intrepid2 {
+
+  /** \class  Intrepid2::Basis_HGRAD_LINE_I4_FEM   
+      \brief  Implementation of the H(grad)-compatible Lagrangian polynomial FEM basis on Line cell.
+
+      Implements Lagrangian polynomial basis on the reference Line cell. The basis has
+      cardinality 2 and reproduces constants.
+      Following Intrepid2 notations, the I4 in the name, stands for the fact that the basis funcitons are 
+      polynomials of dregree 4 but they do not span the complete polynomial space P^4 (I = Incomplete).
+      The defualt basis functions are
+      \phi_0(x) = 1-f(1/2-x/2), \phi_1(x) = f(1/2-x/2), with f(z)= 1-z^4,  x \in [-1,1]
+      The basis can be changed setting coefficients c_0, c_1, c_2 via the setCoefficients function, in which case,
+      f(z) = (1-z)(1+c_0 z+c_1 z^2+c_2 z^3)
+      Basis functions are dual to a unisolvent set of degrees-of-freedom (DoF) defined and enumerated as follows:
+
+      \verbatim
+      =================================================================================================
+      |         |           degree-of-freedom-tag table                    |                           |
+      |   DoF   |----------------------------------------------------------|      DoF definition       |
+      | ordinal |  subc dim    | subc ordinal | subc DoF ord |subc num DoF |                           |
+      |=========|==============|==============|==============|=============|===========================|
+      |    0    |       0      |       0      |       0      |      1      |   L_0(u) = u(-1)          |
+      |---------|--------------|--------------|--------------|-------------|---------------------------|
+      |    1    |       0      |       1      |       0      |      1      |   L_1(u) = u(1)           |
+      |=========|==============|==============|==============|=============|===========================|
+      |   MAX   |  maxScDim=0  |  maxScOrd=1  |  maxDfOrd=0  |      -      |                           |
+      |=========|==============|==============|==============|=============|===========================|
+      \endverbatim
+  */
+
+  namespace Impl {
+
+    /**
+      \brief See Intrepid2::Basis_HGRAD_LINE_I4_FEM
+    */
+    class Basis_HGRAD_LINE_I4_FEM {
+    public:
+      typedef struct Line<2> cell_topology_type;
+      /**
+        \brief See Intrepid2::Basis_HGRAD_LINE_I4_FEM
+      */
+      template<EOperator opType>
+      struct Serial {
+        template<typename OutputViewType,
+                 typename inputViewType,
+                 typename coeffType>
+        KOKKOS_INLINE_FUNCTION
+        static void
+        getValues(       OutputViewType output,
+                   const inputViewType input,
+                   const coeffType c0,
+                   const coeffType c1,
+                   const coeffType c2);
+
+      };
+
+      template<typename DeviceType,
+               typename outputValueValueType, class ...outputValueProperties,
+               typename inputPointValueType,  class ...inputPointProperties,
+               typename coeffType>
+      static void
+      getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+                 const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
+                 const coeffType c0,
+                 const coeffType c1,
+                 const coeffType c2,
+                 const EOperator operatorType);
+
+      /**
+        \brief See Intrepid2::Basis_HGRAD_LINE_I4_FEM
+      */
+      template<typename outputValueViewType,
+               typename inputPointViewType,
+               typename coeffType,
+               EOperator opType>
+      struct Functor {
+             outputValueViewType _outputValues;
+        const inputPointViewType  _inputPoints;
+        const coeffType  _c0;
+        const coeffType  _c1;
+        const coeffType  _c2;
+
+        KOKKOS_INLINE_FUNCTION
+        Functor(       outputValueViewType outputValues_,
+                       inputPointViewType  inputPoints_,
+                       coeffType c0_,
+                       coeffType c1_,
+                       coeffType c2_)
+          : _outputValues(outputValues_), _inputPoints(inputPoints_), _c0(c0_), _c1(c1_), _c2(c2_) {}
+
+        KOKKOS_INLINE_FUNCTION
+        void operator()(const ordinal_type pt) const {
+         // std::cout << " eccof: " <<std::endl; 
+          switch (opType) {
+          case OPERATOR_VALUE : {
+            auto       output = Kokkos::subview( _outputValues, Kokkos::ALL(), pt );
+            const auto input  = Kokkos::subview( _inputPoints,                 pt, Kokkos::ALL() );
+            Serial<opType>::getValues( output, input, _c0, _c1, _c2 );
+            break;
+          }
+          case OPERATOR_GRAD :
+          case OPERATOR_MAX : {
+            auto       output = Kokkos::subview( _outputValues, Kokkos::ALL(), pt, Kokkos::ALL() );
+            const auto input  = Kokkos::subview( _inputPoints,                 pt, Kokkos::ALL() );
+            Serial<opType>::getValues( output, input, _c0, _c1, _c2 );
+            break;
+          }
+          default: {
+            INTREPID2_TEST_FOR_ABORT( opType != OPERATOR_VALUE &&
+                                      opType != OPERATOR_GRAD &&
+                                      opType != OPERATOR_MAX,
+                                      ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::Serial::getValues) operator is not supported");
+
+          }
+          }
+        }
+      };
+    };
+  }
+
+  template<typename DeviceType = void,
+           typename outputValueType = double,
+           typename pointValueType = double>
+  class Basis_HGRAD_LINE_I4_FEM
+    : public Basis<DeviceType,outputValueType,pointValueType> {
+  public:
+    using BasisBase = Basis<DeviceType,outputValueType,pointValueType>;
+    using HostBasis = Basis_HGRAD_LINE_I4_FEM<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>;
+    
+    using OrdinalTypeArray1DHost = typename BasisBase::OrdinalTypeArray1DHost;
+    using OrdinalTypeArray2DHost = typename BasisBase::OrdinalTypeArray2DHost;
+    using OrdinalTypeArray3DHost = typename BasisBase::OrdinalTypeArray3DHost;
+    
+    using OutputViewType = typename BasisBase::OutputViewType;
+    using PointViewType  = typename BasisBase::PointViewType ;
+    using ScalarViewType = typename BasisBase::ScalarViewType;
+      
+    /** \brief  Constructor.
+     */
+    Basis_HGRAD_LINE_I4_FEM(const ordinal_type order = 0,
+                            const EPointType   pointType = POINTTYPE_EQUISPACED);
+
+    using BasisBase::getValues;
+
+    outputValueType c0_, c1_, c2_;
+
+    void setCoefficients (const outputValueType c0, const outputValueType c1, const outputValueType c2) {
+      c0_=c0; c1_= c1; c2_= c2;
+    }
+
+    virtual
+    void
+    getValues(       OutputViewType outputValues,
+               const PointViewType  inputPoints,
+               const EOperator operatorType = OPERATOR_VALUE) const override {
+          //      std::cout << " ecco0: "  <<std::endl; 
+#ifdef HAVE_INTREPID2_DEBUG
+      // Verify arguments
+      Intrepid2::getValues_HGRAD_Args(outputValues,
+                                      inputPoints,
+                                      operatorType,
+                                      this->getBaseCellTopology(),
+                                      this->getCardinality() );
+#endif
+      Impl::Basis_HGRAD_LINE_I4_FEM::
+        getValues<DeviceType>( outputValues,
+                                  inputPoints,
+                                  c0_,
+                                  c1_,
+                                  c2_,
+                                  operatorType );
+    }
+
+    virtual
+    void
+    getDofCoords( ScalarViewType dofCoords ) const override {
+#ifdef HAVE_INTREPID2_DEBUG
+      // Verify rank of output array.
+      INTREPID2_TEST_FOR_EXCEPTION( dofCoords.rank() != 2, std::invalid_argument,
+                                    ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::getDofCoords) rank = 2 required for dofCoords array");
+      // Verify 0th dimension of output array.
+      INTREPID2_TEST_FOR_EXCEPTION( static_cast<ordinal_type>(dofCoords.extent(0)) != this->basisCardinality_, std::invalid_argument,
+                                    ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::getDofCoords) mismatch in number of dof and 0th dimension of dofCoords array");
+      // Verify 1st dimension of output array.
+      INTREPID2_TEST_FOR_EXCEPTION( dofCoords.extent(1) != this->basisCellTopology_.getDimension(), std::invalid_argument,
+                                    ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::getDofCoords) incorrect reference cell (1st) dimension in dofCoords array");
+#endif
+      Kokkos::deep_copy(dofCoords, this->dofCoords_);
+    }
+
+    virtual
+    void
+    getDofCoeffs( ScalarViewType dofCoeffs ) const override {
+#ifdef HAVE_INTREPID2_DEBUG
+      // Verify rank of output array.
+      INTREPID2_TEST_FOR_EXCEPTION( dofCoeffs.rank() != 1, std::invalid_argument,
+                                    ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::getdofCoeffs) rank = 1 required for dofCoeffs array");
+      // Verify 0th dimension of output array.
+      INTREPID2_TEST_FOR_EXCEPTION( static_cast<ordinal_type>(dofCoeffs.extent(0)) != this->getCardinality(), std::invalid_argument,
+                                    ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::getdofCoeffs) mismatch in number of dof and 0th dimension of dofCoeffs array");
+#endif
+      Kokkos::deep_copy(dofCoeffs, 1.0);
+    }
+
+    virtual
+    const char*
+    getName() const override {
+      return "Intrepid2_HGRAD_LINE_I4_FEM";
+    }
+
+    BasisPtr<typename Kokkos::HostSpace::device_type,outputValueType,pointValueType>
+    getHostBasis() const override{
+      auto hostBasis = Teuchos::rcp(new HostBasis(this->basisDegree_));
+      return hostBasis;
+    }
+
+  };
+
+}// namespace Intrepid2
+
+#include "Intrepid2_HGRAD_LINE_I4_FEMDef.hpp"
+
+#endif

--- a/src/landIce/utility/Intrepid2_HGRAD_LINE_I4_FEMDef.hpp
+++ b/src/landIce/utility/Intrepid2_HGRAD_LINE_I4_FEMDef.hpp
@@ -1,0 +1,203 @@
+// @HEADER
+// ************************************************************************
+//
+//                           Intrepid2 Package
+//                 Copyright (2007) Sandia Corporation
+//
+// Under terms of Contract DE-AC04-94AL85000, there is a non-exclusive
+// license for use of this work by or on behalf of the U.S. Government.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+// 1. Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the Corporation nor the names of the
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY SANDIA CORPORATION "AS IS" AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL SANDIA CORPORATION OR THE
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Questions? Contact Kyungjoo Kim  (kyukim@sandia.gov), or
+//                    Mauro Perego  (mperego@sandia.gov)
+//
+// ************************************************************************
+// @HEADER
+
+/** \file   Intrepid2_HGRAD_LINE_I4_FEMDef.hpp
+    \brief  Definition file for FEM basis functions for H(grad) functions on a Line.
+    \author Created by M. Perego
+ */
+
+#ifndef __INTREPID2_HGRAD_LINE_I4_FEM_DEF_HPP__
+#define __INTREPID2_HGRAD_LINE_I4_FEM_DEF_HPP__
+
+#include "KokkosExp_View_Fad.hpp"
+
+namespace Intrepid2 {
+
+  // -------------------------------------------------------------------------------------
+
+  namespace Impl {
+
+    template<EOperator opType>
+    template<typename OutputViewType,
+             typename inputViewType,
+             typename coeffType>
+    KOKKOS_INLINE_FUNCTION
+    void
+    Basis_HGRAD_LINE_I4_FEM::Serial<opType>::
+    getValues(       OutputViewType output,
+               const inputViewType input,
+               const coeffType c0,
+               const coeffType c1,
+               const coeffType c2) {
+                
+      switch (opType) {        
+      case OPERATOR_VALUE : {
+        const auto z = (1.0 - input(0))/2.0;  //input(0) \in [-1,1];
+        const typename OutputViewType::value_type f = (1-z)*(1.0+z*(c0+z*(c1+z*c2)));
+        output.access(0) = 1.0-f; 
+        output.access(1) = f;       
+        break;
+      }
+      case OPERATOR_GRAD : {  
+        const auto z = (1.0 - input(0))/2.0;  //input(0) \in [-1,1];
+        const typename OutputViewType::value_type dfdz = c0-1.0+z*(2.0*(c1-c0)+z*(3.0*(c2-c1)-z*4.0*c2));
+        output.access(0, 0) = dfdz/2.0;
+        output.access(1, 0) = -dfdz/2.0;
+        break;
+      }
+      default: {
+        INTREPID2_TEST_FOR_ABORT( opType != OPERATOR_VALUE &&
+                                  opType != OPERATOR_GRAD &&
+                                  opType != OPERATOR_MAX,
+                                  ">>> ERROR: (Intrepid2::Basis_HGRAD_LINE_I4_FEM::Serial::getValues) operator is not supported");
+
+      }
+      }
+    }
+
+    template<typename DT,
+             typename outputValueValueType, class ...outputValueProperties,
+             typename inputPointValueType,  class ...inputPointProperties,
+             typename coeffType>
+    void
+    Basis_HGRAD_LINE_I4_FEM::
+    getValues(       Kokkos::DynRankView<outputValueValueType,outputValueProperties...> outputValues,
+               const Kokkos::DynRankView<inputPointValueType, inputPointProperties...>  inputPoints,
+               const coeffType c0,
+               const coeffType c1,
+               const coeffType c2,
+               const EOperator operatorType ) {
+                //std::cout << " ecco1: "  <<std::endl; 
+      typedef          Kokkos::DynRankView<outputValueValueType,outputValueProperties...>         outputValueViewType;
+      typedef          Kokkos::DynRankView<inputPointValueType, inputPointProperties...>          inputPointViewType;
+      typedef typename ExecSpace<typename inputPointViewType::execution_space,typename DT::execution_space>::ExecSpaceType ExecSpaceType;
+
+      // Number of evaluation points = dim 0 of inputPoints
+      const auto loopSize = inputPoints.extent(0);
+      Kokkos::RangePolicy<ExecSpaceType,Kokkos::Schedule<Kokkos::Static> > policy(0, loopSize);
+
+      switch (operatorType) {
+
+      case OPERATOR_VALUE: {
+        typedef Functor<outputValueViewType,inputPointViewType,coeffType,OPERATOR_VALUE> FunctorType;
+        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, c0, c1, c2) );
+        break;
+      }
+      case OPERATOR_GRAD:
+      case OPERATOR_DIV:
+      case OPERATOR_CURL:
+      case OPERATOR_D1: {
+        typedef Functor<outputValueViewType,inputPointViewType,coeffType,OPERATOR_GRAD> FunctorType;
+        Kokkos::parallel_for( policy, FunctorType(outputValues, inputPoints, c0, c1, c2) );
+        break;
+      }
+      default: {
+        INTREPID2_TEST_FOR_EXCEPTION( !Intrepid2::isValidOperator(operatorType), std::invalid_argument,
+                                      ">>> ERROR (Basis_HGRAD_SIA_LINE_I4_FEM): Invalid operator type");
+      }
+      }
+    }
+
+
+
+  }
+
+  // -------------------------------------------------------------------------------------
+
+  template<typename DT, typename OT, typename PT>
+  Basis_HGRAD_LINE_I4_FEM<DT,OT,PT>::
+  Basis_HGRAD_LINE_I4_FEM(const ordinal_type /*order*/,
+                            const EPointType   pointType) {
+    this->basisCardinality_  = 2;
+    this->basisDegree_       = 4;
+    this->basisCellTopology_ = shards::CellTopology(shards::getCellTopologyData<shards::Line<2> >() );
+    this->basisType_         = BASIS_FEM_LAGRANGIAN;
+    this->basisCoordinates_  = COORDINATES_CARTESIAN;
+    this->functionSpace_     = FUNCTION_SPACE_HGRAD;
+
+    c0_ = c1_ = c2_ = 1.0;
+
+    // initialize tags
+    {
+      // Basis-dependent intializations
+      const ordinal_type tagSize  = 4;        // size of DoF tag, i.e., number of fields in the tag
+      const ordinal_type posScDim = 0;        // position in the tag, counting from 0, of the subcell dim
+      const ordinal_type posScOrd = 1;        // position in the tag, counting from 0, of the subcell ordinal
+      const ordinal_type posDfOrd = 2;        // position in the tag, counting from 0, of DoF ordinal relative to the subcell
+
+      // An array with local DoF tags assigned to basis functions, in the order of their local enumeration
+      ordinal_type tags[8]  = { 0, 0, 0, 1,
+                                0, 1, 0, 1 };
+
+
+
+      // host tags
+      OrdinalTypeArray1DHost tagView(&tags[0], 8);
+
+      // Basis-independent function sets tag and enum data in tagToOrdinal_ and ordinalToTag_ arrays:
+      // tags are constructed on host and sent to devices
+      //OrdinalTypeArray2DHost ordinalToTag;
+      //OrdinalTypeArray3DHost tagToOrdinal;
+      this->setOrdinalTagData(this->tagToOrdinal_,
+                              this->ordinalToTag_,
+                              tagView,
+                              this->basisCardinality_,
+                              tagSize,
+                              posScDim,
+                              posScOrd,
+                              posDfOrd);
+    }
+
+    // dofCoords on host and create its mirror view to device
+    Kokkos::DynRankView<typename ScalarViewType::value_type,typename DT::execution_space::array_layout,Kokkos::HostSpace>
+      dofCoords("dofCoordsHost", this->basisCardinality_,this->basisCellTopology_.getDimension());
+
+    dofCoords(0,0) = -1.0;
+    dofCoords(1,0) =  1.0;
+
+    this->dofCoords_ = Kokkos::create_mirror_view(typename DT::memory_space(), dofCoords);
+    Kokkos::deep_copy(this->dofCoords_, dofCoords);
+  }
+
+}
+
+#endif

--- a/src/problems/Albany_EvaluatorUtils_Def.hpp
+++ b/src/problems/Albany_EvaluatorUtils_Def.hpp
@@ -597,12 +597,14 @@ EvaluatorUtilsImpl<EvalT,Traits,ScalarType>::constructComputeBasisFunctionsEvalu
     p->set< RCP<IntrepidCubature> >("Cubature", cubature);
 
     p->set< RCP<IntrepidBasis> >
-        ("Intrepid2 Basis", intrepidBasis);
+        ("Intrepid2 FE Basis", intrepidBasis);
+    
+    p->set< RCP<IntrepidBasis> >
+        ("Intrepid2 Ref-To-Phys Map Basis", intrepidBasis);
 
     p->set<RCP<shards::CellTopology> >("Cell Type", cellType);
     // Outputs: BF, weightBF, Grad BF, weighted-Grad BF, all in physical space
     p->set<std::string>("Weights Name",              weights_name);
-    p->set<std::string>("Jacobian Det Name",         jacobian_det_name);
     p->set<std::string>("BF Name",                   bf_name);
     p->set<std::string>("Weighted BF Name",          weighted_bf_name);
     p->set<std::string>("Gradient BF Name",          grad_bf_name);

--- a/tests/landIce/FO_GIS/CMakeLists.txt
+++ b/tests/landIce/FO_GIS/CMakeLists.txt
@@ -196,15 +196,28 @@ if (ALBANY_MUELU)
                  ${CMAKE_CURRENT_BINARY_DIR}/input_fo_humboldt_muelu.yaml)
   add_test(${testNameRoot}_Humboldt_Tpetra_MueLu ${Albany.exe} input_fo_humboldt_muelu.yaml)
 
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_humboldt_depthInt_muelu.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_fo_humboldt_depthInt_muelu.yaml)
+  add_test(${testNameRoot}_Humboldt_DepthIntegrated_Tpetra_MueLu ${Albany.exe} input_fo_humboldt_depthInt_muelu.yaml)
+
   if (NOT ALBANY_PARALELL_EXODUS)
     set_tests_properties(${testNameRoot}_Humboldt_Tpetra_MueLu
                        PROPERTIES
-                       LABELS            "LandIce;Epetra;Forward"
+                       LABELS            "LandIce;Tpetra;Forward"
+                       FIXTURES_REQUIRED humboldtMeshSetup)
+
+    set_tests_properties(${testNameRoot}_Humboldt_DepthIntegrated_Tpetra_MueLu
+                       PROPERTIES
+                       LABELS            "LandIce;Tpetra;Forward"
                        FIXTURES_REQUIRED humboldtMeshSetup)
   else ()
     set_tests_properties(${testNameRoot}_Humboldt_Tpetra_MueLu
                        PROPERTIES
-                       LABELS         "LandIce;Epetra;Forward")
+                       LABELS         "LandIce;Tpetra;Forward")
+
+    set_tests_properties(${testNameRoot}_Humboldt_DepthIntegrated_Tpetra_MueLu
+                       PROPERTIES
+                       LABELS         "LandIce;Tpetra;Forward")
   endif()
   
 endif()

--- a/tests/landIce/FO_GIS/input_fo_humboldt_depthInt_muelu.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_depthInt_muelu.yaml
@@ -1,0 +1,459 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Debug Output:
+    Write Solution to MatrixMarket: 0
+  Problem:
+    Phalanx Graph Visualization Detail: 0
+    Depth Integrated Model: true
+    Solution Method: Steady
+    Name: LandIce Stokes First Order 3D
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: true
+    Compute Sensitivities: true
+    Basal Side Name: basalside
+    Surface Side Name: upperside
+    Cubature Degrees (Horiz Vert): [4, 6]
+    Basal Cubature Degree: 4
+    Surface Cubature Degree: 4
+    LandIce Field Norm:
+      sliding_velocity_basalside:
+        Regularization Type: Given Value
+        Regularization Value: 1.0e-05
+    Dirichlet BCs:
+      SDBC on NS extruded_boundary_node_set_3 for DOF U0 prescribe Field: velocity
+      SDBC on NS extruded_boundary_node_set_3 for DOF U1 prescribe Field: velocity
+    LandIce BCs:
+      Number: 2
+      BC 0:
+        Type: Basal Friction
+        Side Set Name: basalside
+        Basal Friction Coefficient:
+          Type: Power Law
+          Mu Type: Exponent of Field
+          Mu Field Name: basal_friction_log
+          Power Exponent: 1.0
+          Effective Pressure Type: Constant
+          Effective Pressure: 1.0
+          Zero Beta On Floating Ice: true
+      BC 1:
+        Type: Lateral
+        Cubature Degree: 3
+        Side Set Name: extruded_boundary_side_set_1
+        Melange Force: 6.0e+07 #[N/m]
+        Melange Submerged Thickness Threshold: 0.1 #[km]
+        #Immersed Ratio: 0.893
+    Parameters:
+      Number Of Parameters: 0
+    LandIce Viscosity:
+      Use P0 Temperature: false
+      Extract Strain Rate Sq: true
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.3
+      Continuous Homotopy With Constant Initial Viscosity: true
+      Coefficient For Continuous Homotopy: 8.0
+      Glen's Law A: 2.400304414e-24            # [Pa^-n s^-1
+      Glen's Law n: 3.0
+      Flow Rate Type: Temperature Based
+    LandIce Physical Parameters:
+      Conductivity of ice: 2.1
+      Diffusivity temperate ice: 1.1e-08
+      Heat capacity of ice: 2.009e+03
+      Water Density: 1.028e+03
+      Ice Density: 9.10e+02
+      Gravity Acceleration: 9.81e+00
+      Reference Temperature: 2.65e+02
+      Clausius-Clapeyron Coefficient: 7.9e-08
+      Ice Latent Heat Of Fusion: 3.34e+05
+      Permeability factor: 1.0e-12 #1e-12
+      Viscosity of water: 1.8e-03
+      Omega exponent alpha: 2.0e+00
+      Diffusivity homotopy exponent: -1.1e+00
+    Body Force:
+      Type: FO INTERP SURF GRAD
+    Response Functions:
+      Number Of Responses: 1
+      Response 0:
+        Type: Sum Of Responses
+        Number Of Responses: 2
+        Response 1:
+          Name: Surface Mass Balance Mismatch
+          SMB Coefficient: 1.0
+          Regularization Coefficient: 1.0e+00
+          Scaling Coefficient: 5.8824e-07
+          H Coefficient: 100.0e+00
+        Response 0:
+          Scaling Coefficient: 5.8824e-07
+          Asinh Scaling: 1.0e+01
+          Name: Surface Velocity Mismatch
+          Regularization Coefficient: 1.0e+00
+  Discretization:
+    Workset Size: -1
+    Method: Extruded
+    Surface Height Field Name: surface_height
+    Number Of Time Derivatives: 0
+    Exodus Output File Name: output/humboldt.exo
+    Use Serial Mesh: false
+    Columnwise Ordering: true
+    NumLayers: 1
+    Thickness Field Name: ice_thickness
+    Extrude Basal Node Fields: [ice_thickness, surface_height, basal_friction_log, bed_topography, apparent_mass_balance, apparent_mass_balance_RMS]
+    Basal Node Fields Ranks: [1, 1, 1, 1, 1, 1]
+    Interpolate Basal Node Layered Fields: [temperature, velocity]
+    Basal Node Layered Fields Ranks: [1, 2]
+    Use Glimmer Spacing: true
+    Required Fields Info:
+      Number Of Fields: 10
+      Field 0:
+        Field Name: ice_thickness
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 1:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 2:
+        Field Name: basal_friction_log
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 3:
+        Field Name: temperature
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 4:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 5:
+        Field Name: apparent_mass_balance
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 6:
+        Field Name: apparent_mass_balance_RMS
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 7:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 8:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 9:
+        Field Name: velocity
+        Field Type: Node Vector
+        Field Origin: Mesh
+    Side Set Discretizations:
+      Side Sets: [basalside, upperside]
+      basalside:
+        Workset Size: -1
+        Method: Ioss
+        Number Of Time Derivatives: 0
+        Restart Index: 1
+        Use Serial Mesh: ${USE_SERIAL_MESH}
+        Exodus Input File Name: ../AsciiMeshes/Humboldt/humboldt_2d.exo
+        Exodus Output File Name: output/humboldt_basal.exo
+        Required Fields Info:
+          Number Of Fields: 11
+          Field 0:
+            Field Name: ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 1:
+            Field Name: observed_ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 2:
+            Field Name: observed_ice_thickness_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness_uncertainty.ascii
+          Field 3:
+            Field Name: surface_height
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_height.ascii
+          Field 4:
+            Field Name: bed_topography
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/bed_topography.ascii
+          Field 5:
+            Field Name: flux_divergence
+            Field Type: Elem Scalar
+            Field Usage: Output
+          Field 6:
+            Field Name: basal_friction_log
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/basal_friction_log.ascii
+          Field 7:
+            Field Name: temperature
+            Field Type: Node Layered Scalar
+            Number Of Layers: 8
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/nodal_temperature.ascii
+          Field 8:
+            Field Name: apparent_mass_balance
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance.ascii
+          Field 9:
+            Field Name: apparent_mass_balance_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance_uncertainty.ascii
+          Field 10:
+            Field Name: velocity
+            Field Origin: File
+            Field Type: Node Layered Vector
+            Number Of Layers: 2
+            Vector Dim: 2
+            File Name: ../AsciiMeshes/Humboldt/extruded_surface_velocity.ascii
+      upperside:
+        Method: SideSetSTK
+        Number Of Time Derivatives: 0
+        Exodus Output File Name: output/humboldt_upper.exo
+        Required Fields Info:
+          Number Of Fields: 2
+          Field 0:
+            Field Name: observed_surface_velocity
+            Field Type: Node Vector
+            Vector Dim: 2
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity.ascii
+          Field 1:
+            Field Name: observed_surface_velocity_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity_uncertainty.ascii
+  Piro:
+    Sensitivity Method: Adjoint
+    Write Only Converged Solution: false
+    NOX:
+      Thyra Group Options:
+        Function Scaling: None
+        Update Row Sum Scaling: Before Each Nonlinear Solve
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: AND
+          Number of Tests: 1
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Scaled
+            Tolerance: 1.0e-08
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 25
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: {}
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: MueLu
+              Preconditioner Types:
+                Ifpack2:
+                  Overlap: 0
+                  Prec Type: Amesos2
+                MueLu: 
+                  Matrix: 
+                    PDE equations: 2
+                  Factories: 
+                    myLineDetectionFact: 
+                      factory: LineDetectionFactory
+                      'linedetection: orientation': coordinates
+                    mySemiCoarsenPFact1: 
+                      factory: SemiCoarsenPFactory
+                      'semicoarsen: coarsen rate': 14
+                    UncoupledAggregationFact2: 
+                      factory: UncoupledAggregationFactory
+                      'aggregation: ordering': graph
+                      'aggregation: max selected neighbors': 0
+                      'aggregation: min agg size': 3
+                      'aggregation: phase3 avoid singletons': true
+                    MyCoarseMap2: 
+                      factory: CoarseMapFactory
+                      Aggregates: UncoupledAggregationFact2
+                    myTentativePFact2: 
+                      'tentative: calculate qr': true
+                      factory: TentativePFactory
+                      Aggregates: UncoupledAggregationFact2
+                      CoarseMap: MyCoarseMap2
+                    mySaPFact2: 
+                      'sa: eigenvalue estimate num iterations': 10
+                      'sa: damping factor': 1.3333333e+00
+                      factory: SaPFactory
+                      P: myTentativePFact2
+                    myTransferCoordinatesFact: 
+                      factory: CoordinatesTransferFactory
+                      CoarseMap: MyCoarseMap2
+                      Aggregates: UncoupledAggregationFact2
+                    myTogglePFact: 
+                      factory: TogglePFactory
+                      'semicoarsen: number of levels': 2
+                      TransferFactories: 
+                        P1: mySemiCoarsenPFact1
+                        P2: mySaPFact2
+                        Ptent1: mySemiCoarsenPFact1
+                        Ptent2: myTentativePFact2
+                        Nullspace1: mySemiCoarsenPFact1
+                        Nullspace2: myTentativePFact2
+                    myRestrictorFact: 
+                      factory: TransPFactory
+                      P: myTogglePFact
+                    myToggleTransferCoordinatesFact: 
+                      factory: ToggleCoordinatesTransferFactory
+                      Chosen P: myTogglePFact
+                      TransferFactories: 
+                        Coordinates1: mySemiCoarsenPFact1
+                        Coordinates2: myTransferCoordinatesFact
+                    myRAPFact: 
+                      'rap: fix zero diagonals': true 
+                      factory: RAPFactory
+                      P: myTogglePFact
+                      R: myRestrictorFact
+                      TransferFactories: 
+                        For Coordinates: myToggleTransferCoordinatesFact
+                    myRepartitionHeuristicFact: 
+                      factory: RepartitionHeuristicFactory
+                      A: myRAPFact
+                      'repartition: min rows per proc': 1000
+                      'repartition: max imbalance': 1.327e+00
+                      'repartition: start level': 4
+                    myZoltanInterface: 
+                      factory: ZoltanInterface
+                      A: myRAPFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      number of partitions: myRepartitionHeuristicFact
+                    myRepartitionFact: 
+                      factory: RepartitionFactory
+                      A: myRAPFact
+                      Partition: myZoltanInterface
+                      'repartition: remap parts': true
+                      number of partitions: myRepartitionHeuristicFact
+                    myRebalanceProlongatorFact: 
+                      factory: RebalanceTransferFactory
+                      type: Interpolation
+                      P: myTogglePFact
+                      Coordinates: myToggleTransferCoordinatesFact
+                      Nullspace: myTogglePFact
+                    myRebalanceRestrictionFact: 
+                      factory: RebalanceTransferFactory
+                      type: Restriction
+                      R: myRestrictorFact
+                    myRebalanceAFact: 
+                      factory: RebalanceAcFactory
+                      A: myRAPFact
+                      TransferFactories: { }
+                    mySmoother1: 
+                      factory: TrilinosSmoother
+                      #type: LINESMOOTHING_BANDEDRELAXATION
+                      type: LINESMOOTHING_TRIDIRELAXATION
+                      'smoother: pre or post': both
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0e+00
+                        'block relaxation: decouple dofs': true
+                        'partitioner: PDE equations': 2
+                    mySmoother3: 
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': both
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 1
+                        'relaxation: damping factor': 1.0e+00
+                    mySmoother4: 
+                      factory: TrilinosSmoother
+                      type: RELAXATION
+                      'smoother: pre or post': pre
+                      ParameterList: 
+                        'relaxation: type': Gauss-Seidel
+                        'relaxation: sweeps': 4
+                        'relaxation: damping factor': 1.0e+00
+                  Hierarchy: 
+                    max levels: 7
+                    'coarse: max size': 2000
+                    verbosity: Low
+                    use kokkos refactor: false
+                    Finest: 
+                      Smoother: mySmoother1
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact
+                    All: 
+                      startLevel: 1
+                      Smoother: mySmoother4
+                      CoarseSolver: mySmoother4
+                      P: myRebalanceProlongatorFact
+                      Nullspace: myRebalanceProlongatorFact
+                      CoarseNumZLayers: myLineDetectionFact
+                      LineDetection_Layers: myLineDetectionFact
+                      LineDetection_VertLineIds: myLineDetectionFact
+                      A: myRebalanceAFact
+                      Coordinates: myRebalanceProlongatorFact
+                      Importer: myRepartitionFact
+          Rescue Bad Newton Solve: true
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Backtrack
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+      Solver Options:
+        Status Test Check Type: Minimal
+  Regression For Response 0:
+    Test Value: 2.660410088747e+01
+    Relative Tolerance: 1.0e-06
+...

--- a/tests/landIce/FO_MMS/input_smb_tri.yaml
+++ b/tests/landIce/FO_MMS/input_smb_tri.yaml
@@ -39,7 +39,6 @@ ANONYMOUS:
         H Coefficient: 3.0
         SMB Coefficient: 3.0
         Scaling Coefficient: 1.0
-        Cubature Degree: 3
         Field Name: Velocity
     Dirichlet BCs: { }
     Neumann BCs: { }

--- a/tests/landIce/FO_Thermo/CMakeLists.txt
+++ b/tests/landIce/FO_Thermo/CMakeLists.txt
@@ -67,6 +67,9 @@ if (ALBANY_FROSCH)
   
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_FO_Thermo_Humboldt_fluxDiv.yaml
                  ${CMAKE_CURRENT_BINARY_DIR}/input_FO_Thermo_Humboldt_fluxDiv.yaml)
+
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml)
   
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_FO_Thermo_Humboldt_lubricated.yaml
                  ${CMAKE_CURRENT_BINARY_DIR}/input_FO_Thermo_Humboldt_lubricated.yaml)
@@ -78,6 +81,10 @@ if (ALBANY_FROSCH)
   
   set (testName ${testNameRoot}_Humboldt_fluxDiv)
   add_test(${testName} ${Albany.exe} input_FO_Thermo_Humboldt_fluxDiv.yaml)
+  set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Forward;FROSch")
+
+  set (testName ${testNameRoot}_Humboldt_depthIntegrated_fluxDiv)
+  add_test(${testName} ${Albany.exe} input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml)
   set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Tpetra;Forward;FROSch")
   
   set (testName ${testNameRoot}_Humboldt_lubricated)

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml
@@ -1,0 +1,423 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Build Type: Tpetra
+  Debug Output:
+    Write Solution to MatrixMarket: 0
+    #Write Jacobian to MatrixMarket: -1
+    #Write Residual to MatrixMarket: -1
+  Problem:
+    Phalanx Graph Visualization Detail: 0
+    Depth Integrated Model: true
+    Solution Method: Steady
+    Name: LandIce Stokes FO Thermo Coupled 3D
+    Compute Sensitivities: true
+    Extruded Column Coupled in 2D Response: true
+    #Adjust Bed Topography to Account for Thickness Changes: true
+    Basal Side Name: basalside
+    Surface Side Name: upperside
+    Cubature Degrees (Horiz Vert): [4, 6]
+    Basal Cubature Degree: 4
+    Surface Cubature Degree: 4
+    Needs Dissipation: true
+    Needs Basal Friction: true
+    LandIce Field Norm:
+      sliding_velocity_basalside:
+        Regularization Type: Given Value
+        Regularization Value: 1.0e-05
+    Dirichlet BCs:
+      DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
+      DBC on NS extruded_boundary_node_set_3 for DOF U0 prescribe Field: velocity
+      DBC on NS extruded_boundary_node_set_3 for DOF U1 prescribe Field: velocity
+    LandIce BCs:
+      Number: 2
+      BC 0:
+        Type: Basal Friction
+        Side Set Name: basalside
+        Basal Friction Coefficient:
+          #Type: Exponent Of Given Field
+          Type: Power Law
+          Mu Type: Exponent of Field
+          Mu Field Name: basal_friction_log
+          Power Exponent: 1.0
+          Effective Pressure Type: Constant
+          Effective Pressure: 1.0
+          Zero Beta On Floating Ice: true
+      BC 1:
+        Type: Lateral
+        Cubature Degree: 3
+        Side Set Name: extruded_boundary_side_set_1
+        #Immersed Ratio: 0.893
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Lower Bound: -12.0
+        Mesh Part: bottom
+        Type: Distributed
+        Name: basal_friction_log
+        Upper Bound: 12.0
+    LandIce Viscosity:
+      Use P0 Temperature: false
+      Extract Strain Rate Sq: true
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.5e+00
+      Continuous Homotopy With Constant Initial Viscosity: true
+      Coefficient For Continuous Homotopy: 8.0
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0
+      Flow Rate Type: Temperature Based
+    LandIce Physical Parameters:
+      Conductivity of ice: 2.1
+      Diffusivity temperate ice: 1.1e-08
+      Heat capacity of ice: 2.009e+03
+      Water Density: 1028.0
+      Ice Density: 910.0
+      Gravity Acceleration: 9.81
+      Reference Temperature: 2.65e+02
+      Clausius-Clapeyron Coefficient: 7.9e-08
+      Ice Latent Heat Of Fusion: 3.34e+05
+      Permeability factor: 1.0e-12
+      Viscosity of water: 1.8e-03
+      Omega exponent alpha: 2.0
+      Diffusivity homotopy exponent: -1.1
+    Body Force:
+      Type: FO INTERP SURF GRAD
+    LandIce Flux Divergence:
+      Use Upwind Stabilization: false
+      Flux Divergence Is Part Of Solution: true
+    LandIce L2 Projected Boundary Laplacian:
+      Field Name: basal_friction_log
+      Mass Coefficient: 1.0e-01
+      Laplacian Coefficient: 1.0e+01
+      Robin Coefficient: 1.0
+      Boundary Edges Set Name: boundary_side_set
+    LandIce Enthalpy:
+      Regularization:
+        Flux Regularization:
+          alpha: 4.0
+          beta: 0.0
+        Basal Melting Regularization:
+          alpha: 4.0
+          beta: 0.0
+      Stabilization:
+        Type: Upwind
+        Parameter Delta: 0.5
+      Bed Lubrication:
+        Type: Dry
+    Response Functions:
+      Number Of Responses: 3
+      Response 0:
+        Type: Sum Of Responses
+        Number Of Responses: 1
+        Response 0:
+          Scaling: 5.8824e-07
+          Name: Squared L2 Difference Side Source ST Target RT
+          Source Field Name: flux_divergence_basalside
+          Response Depends On Solution Column: true
+          Root Mean Square Error Field Name: apparent_mass_balance_RMS_basalside
+          Field Rank: Scalar
+          Target Field Name: apparent_mass_balance_basalside
+          Side Set Name: basalside
+          Is Side Set Planar: true
+      Response 1:
+        Scaling: 5.8824e-07
+        Name: Squared L2 Difference Side Source ST Target RT
+        Source Field Name: flux_divergence_gradient_basalside
+        Response Depends On Solution Column: true
+        Side Set Name: basalside
+        Field Rank: Gradient
+        Is Side Set Planar: true
+        Target Value: 0.0
+      Response 2:
+        Scaling Coefficient: 5.8824e-05
+        Name: Boundary Squared L2 Norm
+        Field Name: L2 Projected Boundary Laplacian_basalside 
+  Discretization:
+    Workset Size: -1
+    Method: Extruded
+    Surface Height Field Name: surface_height
+    Number Of Time Derivatives: 0
+    Exodus Output File Name: ./humboldt_full.exo
+    Use Serial Mesh: false
+    Columnwise Ordering: true
+    NumLayers: 1
+    Thickness Field Name: ice_thickness
+    Extrude Basal Node Fields: [ice_thickness, surface_height, basal_friction_log, bed_topography, apparent_mass_balance, apparent_mass_balance_RMS, surface_air_temperature]
+    Basal Node Fields Ranks: [1, 1, 1, 1, 1, 1, 1]
+    Interpolate Basal Node Layered Fields: [velocity]
+    Basal Node Layered Fields Ranks: [2]
+    Use Glimmer Spacing: true
+    Required Fields Info:
+      Number Of Fields: 13
+      Field 0:
+        Field Name: ice_thickness
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 1:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 2:
+        Field Name: basal_friction_log
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 3:
+        Field Name: surface_air_temperature
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 4:
+        Field Name: surface_enthalpy
+        Field Type: Node Scalar
+        Field Usage: Output
+      Field 5:
+        Field Name: temperature
+        Field Type: Elem Scalar
+        Field Usage: Output
+      Field 6:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 7:
+        Field Name: apparent_mass_balance
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 8:
+        Field Name: apparent_mass_balance_RMS
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 9:
+        Field Name: Diff Enth
+        Field Type: Node Scalar
+        Field Usage: Output
+      Field 10:
+        Field Name: bed_topography
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 11:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+        Field Usage: Output
+      Field 12:
+        Field Name: velocity
+        Field Type: Node Vector
+        Field Origin: Mesh
+    Side Set Discretizations:
+      Side Sets: [basalside, upperside]
+      basalside:
+        Workset Size: -1
+        Method: Ioss
+        Number Of Time Derivatives: 0
+        Restart Index: 1
+        Use Serial Mesh: false
+        Exodus Input File Name: ../AsciiMeshes/Humboldt/humboldt_2d.exo
+        Exodus Output File Name: ./humboldt_basal.exo
+        Required Fields Info:
+          Number Of Fields: 12
+          Field 0:
+            Field Name: ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 1:
+            Field Name: observed_ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness.ascii
+          Field 2:
+            Field Name: observed_ice_thickness_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/thickness_uncertainty.ascii
+          Field 3:
+            Field Name: surface_height
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_height.ascii
+          Field 4:
+            Field Name: bed_topography
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/bed_topography.ascii
+          Field 5:
+            Field Name: flux_divergence
+            Field Type: Node Scalar
+            Field Usage: Output
+          Field 6:
+            Field Name: basal_friction_log
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/basal_friction_log.ascii
+          Field 7:
+            Field Name: surface_air_temperature
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_air_temperature.ascii
+          Field 8:
+            Field Name: heat_flux
+            Field Type: Node Scalar
+            Field Origin: File
+            Field Value: 0.042
+            #File Name: ../AsciiMeshes/Humboldt/basal_heat_flux.ascii
+          Field 9:
+            Field Name: apparent_mass_balance
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance.ascii
+          Field 10:
+            Field Name: apparent_mass_balance_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/apparent_mass_balance_uncertainty.ascii
+          Field 11:
+            Field Name: velocity
+            Field Origin: File
+            Field Type: Node Layered Vector
+            Number Of Layers: 2
+            Vector Dim: 2
+            File Name: ../AsciiMeshes/Humboldt/extruded_surface_velocity.ascii
+      upperside:
+        Workset Size: -1
+        Method: SideSetSTK
+        Number Of Time Derivatives: 0
+        #Exodus Output File Name: output/humboldt_upper.exo
+        Required Fields Info:
+          Number Of Fields: 0
+          Field 0:
+            Field Name: observed_surface_velocity
+            Field Type: Node Vector
+            Vector Dim: 2
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity.ascii
+          Field 1:
+            Field Name: observed_surface_velocity_RMS
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Humboldt/surface_velocity_uncertainty.ascii
+  Piro:
+    Sensitivity Method: Adjoint
+    Write Only Converged Solution: false
+    Enable Explicit Matrix Transpose: true
+    NOX:
+      Thyra Group Options:
+        Function Scaling: None
+        Update Row Sum Scaling: Before Each Nonlinear Solve
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: AND
+          Number of Tests: 1
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Scaled
+            Tolerance: 1.0e-08
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 60
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7  # used for forward solves
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: {}
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Convergence Tolerance: 1.0e-7  # used for adjoint solve
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: FROSch
+              Preconditioner Types:
+                FROSch:
+                  FROSch Preconditioner Type: OneLevelPreconditioner        # FROSch preconditioner type. Options: OneLevelPreconditioner, TwoLevelPreconditioner
+                  OverlappingOperator Type: AlgebraicOverlappingOperator    # First Level: AlgebrAlgebraicOverlappingOperator determines the overlap based on the graph of the matrix
+                  CoarseOperator Type: IPOUHarmonicCoarseOperator           # Second Level: IPOUHarmonicCoarseOperator work for all kinds of GDSW type coarse spaces
+                  Recycling: true                                           # This enables the possibility to re-use parts of the preconditioner in a Newton or time iteration
+                  Dimension: 3                                              # Spatial dimension of the problem
+                  DofsPerNode: 6                                            # Number of degrees of freedom per node
+                  Overlap: 0                                                # Number of layers of elements in the overlap
+                  Null Space Type: Input                                    # Null space is provided by Albany
+                  AlgebraicOverlappingOperator:
+                    'Reuse: Symbolic Factorization': true                   # Reuse of the symbolic factorization
+                    Solver:                                                 # Solver on the first level
+                      SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
+                      Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
+                  IPOUHarmonicCoarseOperator:
+                    'Reuse: Coarse Basis': true                             # Reuse of the coarse basis functions
+                    'Reuse: Coarse Matrix': false                           # Reuse of the coarse matrix
+                    'Reuse: Coarse Matrix Symbolic Factorization': true     # Reuse of the symbolic factorization of the coarse matrix
+                    Blocks:
+                      1:                                                    # For a multiphysics problem, the coarse space may be decomposed into several blocks. Here, we only need one block.
+                        InterfacePartitionOfUnity:                          # The interface partition of unity defines the specific GDSW type coarse space
+                          Type: RGDSW                                       # Possible types: GDSW, RGDSW
+                          GDSW:
+                            Type: Full                                      # Here, we could select subspaces of the GDSW coarse. Generally, we use "Full".
+                          RGDSW:
+                            Type: Full                                      # Here, we could select subspaces of the RGDSW coarse. Generally, we use "Full".
+                            Distance Function: Inverse Euclidean            # Options 1 and 2.2 differ in the distance function used to compute the interface values: "Constant" (Option 1) and "Inverse Euclidean" (Option 2.2)
+                    ExtensionSolver:                                        # Solver for the energy-minimizing extensions
+                      SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
+                      Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
+                    Distribution:                                           # Parallel distribution of the coarse problem
+                      Type: linear                                          # Specifies the parallel distribution strategy. For now, we use "linear"
+                      NumProcs: 1                                           # Number of ranks used for the coarse problem
+                    CoarseSolver:                                           # Solver for the coarse problem
+                      SolverType: Amesos2                                   # Solver package: Amesos2 or Ifpack2
+                      Solver: Klu                                           # Solver name (depends on the solver package): Klu, RILUK, ...
+          Rescue Bad Newton Solve: true
+      Line Search:
+        Full Step:
+          Full Step: 1.0e+00
+        Method: Backtrack
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+      Solver Options:
+        Status Test Check Type: Minimal
+  Regression For Response 0:
+    Relative Tolerance: 1.0e-06
+    Test Value:  1.005134707194e+01
+    Sensitivity For Parameter 0:
+      Test Value: 2.547069319315e+00
+  Regression For Response 1:
+    Relative Tolerance: 1.0e-06
+    Test Value: 6.504639411833e-04
+    Sensitivity For Parameter 0:
+      Test Value: 1.489447982684e-04
+  Regression For Response 2:
+    Relative Tolerance: 1.0e-06
+    Test Value:  5.967986097162e+00
+    Sensitivity For Parameter 0:
+      Test Value: 4.713654424891e-01
+...
+...

--- a/tests/unit/evaluators/DOFInterpolation.cpp
+++ b/tests/unit/evaluators/DOFInterpolation.cpp
@@ -69,7 +69,8 @@ TEUCHOS_UNIT_TEST(DOFInterpolation, Scalar)
 
   bfp.set("Coordinate Vector Name", Albany::coord_vec_name);
   bfp.set("Cubature", cubature);
-  bfp.set("Intrepid2 Basis", intrepidBasis);
+  bfp.set("Intrepid2 FE Basis", intrepidBasis);
+  bfp.set("Intrepid2 Ref-To-Phys Map Basis", intrepidBasis);
 
   // Outputs: BF, weightBF, Grad BF, weighted-Grad BF, all in physical space
   bfp.set("Weights Name",              Albany::weights_name);


### PR DESCRIPTION
This PR adds the` Depth Integrated Model` obtained from the `FO` model by using only one mesh layer and replacing the reference trial and test functions for wedges with a tensor-product basis (triangle X line) having the usual P1 bases for the triangle and the basis functions `{1-(1-z)^4, (1-z)^4}` instead of `{z, 1-z}` in the vertical direction (for `z in [0,1]`). 
While our implementation differs, this model is equivalent to other models in the literature, e.g. the MOLHO model https://tc.copernicus.org/articles/16/179/2022/.  

Added a couple of tests using the new capability. We'll also modify MPAS tests to use this capability.

The model is enabled by adding `Depth Integrated Model: true` to the `Problem` sublist of a `LandIce Stokes First Order 3D` or a `LandIce Stokes FO Thermo Coupled 3D` problem. 
At the moment we use the same basis functions for temperature and velocity, but we might change this in the future.
Also, we plan to allow prescribing different Lagrangian polynomial basis functions in alternative to `{1-(1-z)^4, (1-z)^4}`.