### PR TITLE
Remove warnings

### DIFF
--- a/src/disc/stk/Albany_STKNodeFieldContainer_Def.hpp
+++ b/src/disc/stk/Albany_STKNodeFieldContainer_Def.hpp
@@ -84,7 +84,7 @@ getMDA(const stk::mesh::Bucket& buck){
       dv.reset_from_host_ptr(data,buck.size(),dim0);
     case 3:
       dim0 = stk::mesh::field_extent0_per_entity(*node_field,buck);
-      dim0 = stk::mesh::field_extent1_per_entity(*node_field,buck);
+      dim1 = stk::mesh::field_extent1_per_entity(*node_field,buck);
       dv.reset_from_host_ptr(data,buck.size(),dim0,dim1);
     default:
       TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,

--- a/src/landIce/evaluators/LandIce_ViscosityFO_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ViscosityFO_Def.hpp
@@ -317,7 +317,7 @@ KOKKOS_INLINE_FUNCTION
 void ViscosityFO<EvalT, Traits, VelT, TemprT>::operator () (const ViscosityFO_GLENSLAW_TEMPERATUREBASEDQP_Tag&, const int& cell) const
 {
   //We start setting mu=flowFactor, then we multiply it by other terms in glenslaw function
-  for(int qp=0; qp< numQPs; ++qp)
+  for(int qp=0; qp< (int) numQPs; ++qp)
     mu(cell,qp) = 1.0/2.0*pow(flowRate(temperature(cell,qp)), -1.0/n);
   glenslaw(cell);
 }

--- a/src/landIce/interfaceWithMPAS/Interface.cpp
+++ b/src/landIce/interfaceWithMPAS/Interface.cpp
@@ -254,7 +254,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
       // Populate the temperature mesh field, defined at quad points 
       QPScalarFieldType* temperature_field = meshStruct->metaData->get_field <QPScalarFieldType> (stk::topology::ELEMENT_RANK, "temperature");
 
-      for(int ib=0; ib <indexToTriangleID.size(); ++ib ) {
+      for(int ib=0; ib < (int) indexToTriangleID.size(); ++ib ) {
         stk::mesh::Entity elem = meshStruct->bulkData->get_entity(stk::topology::ELEMENT_RANK, indexToTriangleID[ib]);
         double* temperature = stk::mesh::field_data(*temperature_field, elem);
         for(int qp=0; qp<numQPs; qp++) {
@@ -265,7 +265,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
     } else {  //P0 temperature
       // In this case we compute a column average of the MPAS temperature and save it as a P0 field in the 1-layer Albany mesh.
       ScalarFieldType* temperature_field = meshStruct->metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "temperature");
-      for(int ib=0; ib <indexToTriangleID.size(); ++ib ) {
+      for(int ib=0; ib < (int) indexToTriangleID.size(); ++ib ) {
         stk::mesh::Entity elem = meshStruct->bulkData->get_entity(stk::topology::ELEMENT_RANK, indexToTriangleID[ib]);
         double* temperature = stk::mesh::field_data(*temperature_field, elem);
         for(int il=0; il<nLayers; il++) {
@@ -280,7 +280,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
     }
   } else { // Here we copy the temperature on Prisms from MPAS into a P0 field in the Albany mesh.
     ScalarFieldType* temperature_field = meshStruct->metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "temperature");
-    for(int ib=0; ib <indexToTriangleID.size(); ++ib ) {
+    for(int ib=0; ib < (int) indexToTriangleID.size(); ++ib ) {
       for(int il=0; il<nLayers; il++) {
         int lId = il * lElemColumnShift + elemLayerShift * ib;
         int gId = il * elemColumnShift + elemLayerShift * (indexToTriangleID[ib]-1) + 1;
@@ -349,7 +349,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
   auto indexer = Albany::createGlobalLocalIndexer(overlapVS);
 
   if(depthIntegratedModel) {
-    for(int ib = 0; ib < indexToVertexID.size(); ++ib) {
+    for(int ib = 0; ib < (int) indexToVertexID.size(); ++ib) {
       int depthVertexLayerShift = (ordering == 0) ? 1 : 2;
       int gIdBed =  depthVertexLayerShift * (indexToVertexID[ib]-1) + 1;
       int gIdTop = gIdBed + vertexColumnShift;
@@ -387,7 +387,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
   }
 
   if (Teuchos::nonnull(ss_ms) && !betaData.empty() && (betaField!=nullptr)) {
-    for(int ib = 0; ib < indexToVertexID.size(); ++ib) {
+    for(int ib = 0; ib < (int) indexToVertexID.size(); ++ib) {
       stk::mesh::Entity node = ss_ms->bulkData->get_entity(stk::topology::NODE_RANK, indexToVertexID[ib]);
       const double* betaVal = stk::mesh::field_data(*betaField,node);
       betaData[ib] = betaVal[0];


### PR DESCRIPTION
@bartgol can you check if the line:
```
dim1 = stk::mesh::field_extent1_per_entity(*node_field,buck);
```
is correct now?

Before, `dim1` was used uninitialized. 