### PR TITLE
Fix clang release build

### DIFF
--- a/src/Albany_DualView.hpp
+++ b/src/Albany_DualView.hpp
@@ -84,8 +84,8 @@ struct DualView {
   }
 
   // Allow implicit conversion to DualView<const DT>;
-  template<typename SrcDT = DT, typename = typename std::enable_if<not std::is_same<SrcDT,const_DT>::value>::type>
-  operator const_type() const {
+  template<typename SrcDT = DT>
+  operator DualView<std::enable_if_t<not std::is_same_v<SrcDT,const_DT>, const_DT>>() const {
     const_type ct;
     ct.d_view = d_view;
     ct.h_view = h_view;

--- a/src/InitialCondition.cpp
+++ b/src/InitialCondition.cpp
@@ -48,7 +48,8 @@ void InitialConditions (const Teuchos::RCP<Thyra_Vector>& soln,
 {
   auto soln_data = Albany::getNonconstLocalData(soln);
   const auto& dof_mgr = disc->getDOFManager();
-  const auto& elem_lids = disc->getWsElementLIDs().host();
+  const auto& elem_lids_dual_view = disc->getWsElementLIDs();
+  const auto& elem_lids = elem_lids_dual_view.host();
   const auto& ws_sizes = disc->getWorksetsSizes();
   const auto& elem_dof_lids = dof_mgr->elem_dof_lids().host();
   const auto& wsEBNames = disc->getWsEBNames();


### PR DESCRIPTION
See #930.

Some optimization in the clang release build is causing the data in elem_lids to go out of scope. This fixes it.

This also gets rid of the warning associated with the dual view:
```
[Albany/src/Albany_DualView.hpp:88](https://blob/master/Albany/src/Albany_DualView.hpp#L88):3: warning: conversion function converting 'Albany::DualView<const int *>' to itself will never be used [-Wclass-conversion]
  operator const_type() const {
```

@bartgol @mcarlson801 Can you remind me again why we're not using a `Kokkos::DualView` for this?