### PR TITLE
Fixes to comply with changes in STK

### DIFF
--- a/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
@@ -32,44 +32,19 @@ namespace Albany {
 class AbstractSTKFieldContainer
 {
 public:
-  // Tensor per Node/Cell  - (Node, Dim, Dim) or (Cell,Dim,Dim)
-  typedef stk::mesh::Field<double, stk::mesh::Cartesian, stk::mesh::Cartesian>
-      TensorFieldType;
-  // Vector per Node/Cell  - (Node, Dim) or (Cell,Dim)
-  typedef stk::mesh::Field<double, stk::mesh::Cartesian> VectorFieldType;
-  // Scalar per Node/Cell  - (Node) or (Cell)
-  typedef stk::mesh::Field<double> ScalarFieldType;
-  // One int scalar per Node/Cell  - (Node) or (Cell)
-  typedef stk::mesh::Field<int> IntScalarFieldType;
-  // int vector per Node/Cell  - (Node,Dim/VecDim) or (Cell,Dim/VecDim)
-  typedef stk::mesh::Field<int, stk::mesh::Cartesian> IntVectorFieldType;
+  // STK field (scalar/vector/tensor , Node/Cell)
+  using STKFieldType = stk::mesh::Field<double>;
+  // STK int field
+  using STKIntState  = stk::mesh::Field<int>;
 
-  typedef stk::mesh::Cartesian QPTag;  // need to invent shards::ArrayDimTag
-  // Tensor per QP   - (Cell, QP, Dim, Dim)
-  typedef stk::mesh::
-      Field<double, QPTag, stk::mesh::Cartesian, stk::mesh::Cartesian>
-          QPTensorFieldType;
-  // Vector per QP   - (Cell, QP, Dim)
-  typedef stk::mesh::Field<double, QPTag, stk::mesh::Cartesian>
-      QPVectorFieldType;
-  // One scalar per QP   - (Cell, QP)
-  typedef stk::mesh::Field<double, QPTag> QPScalarFieldType;
+  using ValueState = std::vector<const std::string*>;
+  using STKState   = std::vector<STKFieldType*>;
 
-  typedef std::vector<const std::string*> ScalarValueState;
-  typedef std::vector<QPScalarFieldType*> QPScalarState;
-  typedef std::vector<QPVectorFieldType*> QPVectorState;
-  typedef std::vector<QPTensorFieldType*> QPTensorState;
-
-  typedef std::vector<ScalarFieldType*> ScalarState;
-  typedef std::vector<VectorFieldType*> VectorState;
-  typedef std::vector<TensorFieldType*> TensorState;
-
-  typedef std::map<std::string, double>              MeshScalarState;
-  typedef std::map<std::string, std::vector<double>> MeshVectorState;
-
-  typedef std::map<std::string, int>              MeshScalarIntegerState;
-  typedef std::map<std::string, GO>               MeshScalarInteger64State;
-  typedef std::map<std::string, std::vector<int>> MeshVectorIntegerState;
+  using MeshScalarState          = std::map<std::string, double>;
+  using MeshVectorState          = std::map<std::string, std::vector<double>>;
+  using MeshScalarIntegerState   = std::map<std::string, int>;
+  using MeshScalarInteger64State = std::map<std::string, GO>;
+  using MeshVectorIntegerState   = std::map<std::string, std::vector<int>>;
 
   using dof_mgr_ptr_t = Teuchos::RCP<const DOFManager>;
   using mv_ptr_t      = Teuchos::RCP<const Thyra_MultiVector>;
@@ -84,35 +59,35 @@ public:
   addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis) = 0;
 
   // Coordinates field ALWAYS in 3D
-  const VectorFieldType*
+  const STKFieldType*
   getCoordinatesField3d() const
   {
     return coordinates_field3d;
   }
-  VectorFieldType*
+  STKFieldType*
   getCoordinatesField3d()
   {
     return coordinates_field3d;
   }
 
-  const VectorFieldType*
+  const STKFieldType*
   getCoordinatesField() const
   {
     return coordinates_field;
   }
-  VectorFieldType*
+  STKFieldType*
   getCoordinatesField()
   {
     return coordinates_field;
   }
 
-  IntScalarFieldType*
+  STKIntState*
   getProcRankField()
   {
     return proc_rank_field;
   }
 
-  ScalarValueState&
+  ValueState&
   getScalarValueStates()
   {
     return scalarValue_states;
@@ -142,32 +117,32 @@ public:
   {
     return mesh_vector_integer_states;
   }
-  ScalarState&
+  STKState&
   getCellScalarStates()
   {
     return cell_scalar_states;
   }
-  VectorState&
+  STKState&
   getCellVectorStates()
   {
     return cell_vector_states;
   }
-  TensorState&
+  STKState&
   getCellTensorStates()
   {
     return cell_tensor_states;
   }
-  QPScalarState&
+  STKState&
   getQPScalarStates()
   {
     return qpscalar_states;
   }
-  QPVectorState&
+  STKState&
   getQPVectorStates()
   {
     return qpvector_states;
   }
-  QPTensorState&
+  STKState&
   getQPTensorStates()
   {
     return qptensor_states;
@@ -240,22 +215,22 @@ protected:
   // the same field).
   //       Otherwise, coordinates_field3d stores coordinates in 3d (useful for
   //       non-flat 2d meshes)
-  VectorFieldType*    coordinates_field3d;
-  VectorFieldType*    coordinates_field;
-  IntScalarFieldType* proc_rank_field;
+  STKFieldType*    coordinates_field3d;
+  STKFieldType*    coordinates_field;
+  STKIntState* proc_rank_field;
 
-  ScalarValueState          scalarValue_states;
+  ValueState                scalarValue_states;
   MeshScalarState           mesh_scalar_states;
   MeshVectorState           mesh_vector_states;
   MeshScalarIntegerState    mesh_scalar_integer_states;
   MeshScalarInteger64State  mesh_scalar_integer_64_states;
   MeshVectorIntegerState    mesh_vector_integer_states;
-  ScalarState               cell_scalar_states;
-  VectorState               cell_vector_states;
-  TensorState               cell_tensor_states;
-  QPScalarState             qpscalar_states;
-  QPVectorState             qpvector_states;
-  QPTensorState             qptensor_states;
+  STKState                  cell_scalar_states;
+  STKState                  cell_vector_states;
+  STKState                  cell_tensor_states;
+  STKState                  qpscalar_states;
+  STKState                  qpvector_states;
+  STKState                  qptensor_states;
 
   StateInfoStruct nodal_sis;
   StateInfoStruct nodal_parameter_sis;

--- a/src/disc/stk/Albany_AbstractSTKMeshStruct.hpp
+++ b/src/disc/stk/Albany_AbstractSTKMeshStruct.hpp
@@ -81,23 +81,23 @@ struct AbstractSTKMeshStruct : public AbstractMeshStruct
   {
     return fieldContainer;
   }
-  const AbstractSTKFieldContainer::VectorFieldType*
+  const AbstractSTKFieldContainer::STKFieldType*
   getCoordinatesField() const
   {
     return fieldContainer->getCoordinatesField();
   }
-  AbstractSTKFieldContainer::VectorFieldType*
+  AbstractSTKFieldContainer::STKFieldType*
   getCoordinatesField()
   {
     return fieldContainer->getCoordinatesField();
   }
 
-  const AbstractSTKFieldContainer::VectorFieldType*
+  const AbstractSTKFieldContainer::STKFieldType*
   getCoordinatesField3d() const
   {
     return fieldContainer->getCoordinatesField3d();
   }
-  AbstractSTKFieldContainer::VectorFieldType*
+  AbstractSTKFieldContainer::STKFieldType*
   getCoordinatesField3d()
   {
     return fieldContainer->getCoordinatesField3d();

--- a/src/disc/stk/Albany_AsciiSTKMesh2D.cpp
+++ b/src/disc/stk/Albany_AsciiSTKMesh2D.cpp
@@ -327,9 +327,9 @@ void Albany::AsciiSTKMesh2D::setBulkData(
     stk::mesh::PartVector singlePartVec(1);
     unsigned int ebNo = 0; //element block #???
 
-    AbstractSTKFieldContainer::IntScalarFieldType* proc_rank_field =
+    AbstractSTKFieldContainer::STKIntState* proc_rank_field =
         fieldContainer->getProcRankField();
-    AbstractSTKFieldContainer::VectorFieldType* coordinates_field =
+    AbstractSTKFieldContainer::STKFieldType* coordinates_field =
         fieldContainer->getCoordinatesField();
 
     singlePartVec[0] = nsPartVec["node_set"];

--- a/src/disc/stk/Albany_AsciiSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_AsciiSTKMeshStruct.cpp
@@ -446,13 +446,13 @@ AsciiSTKMeshStruct::setBulkData(
 #endif
   unsigned int ebNo = 0; //element block #???
 
-  typedef AbstractSTKFieldContainer::ScalarFieldType ScalarFieldType;
+  typedef AbstractSTKFieldContainer::STKFieldType STKFieldType;
 
-  AbstractSTKFieldContainer::VectorFieldType* coordinates_field = fieldContainer->getCoordinatesField();
-  ScalarFieldType* surfaceHeight_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_height");
-  ScalarFieldType* flowFactor_field = metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "flow_factor");
-  ScalarFieldType* temperature_field = metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "temperature");
-  ScalarFieldType* basal_friction_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "basal_friction");
+  AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
+  STKFieldType* surfaceHeight_field = metaData->get_field<double>(stk::topology::NODE_RANK, "surface_height");
+  STKFieldType* flowFactor_field = metaData->get_field<double>(stk::topology::ELEMENT_RANK, "flow_factor");
+  STKFieldType* temperature_field = metaData->get_field<double>(stk::topology::ELEMENT_RANK, "temperature");
+  STKFieldType* basal_friction_field = metaData->get_field<double>(stk::topology::NODE_RANK, "basal_friction");
 
   if(!surfaceHeight_field)
      have_sh = false;

--- a/src/disc/stk/Albany_GenericSTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_GenericSTKFieldContainer.cpp
@@ -81,15 +81,6 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
 
   using namespace Albany;
 
-  // QuadPoint fields
-  // dim[0] = nCells, dim[1] = nQP, dim[2] = nVec dim[3] = nVec dim[4] = nVec
-  typedef typename AbstractSTKFieldContainer::QPScalarFieldType QPSFT;
-  typedef typename AbstractSTKFieldContainer::QPVectorFieldType QPVFT;
-  typedef typename AbstractSTKFieldContainer::QPTensorFieldType QPTFT;
-  typedef typename AbstractSTKFieldContainer::ScalarFieldType SFT;
-  typedef typename AbstractSTKFieldContainer::VectorFieldType VFT;
-  typedef typename AbstractSTKFieldContainer::TensorFieldType TFT;
-
   // Code to parse the vector of StateStructs and create STK fields
   for(std::size_t i = 0; i < sis->size(); i++) {
     StateStruct& st = *((*sis)[i]);
@@ -100,7 +91,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
       if (dim.size()==1)
       {
         // Scalar on cell
-        cell_scalar_states.push_back(& metaData->declare_field< SFT >(stk::topology::ELEMENT_RANK, st.name));
+        cell_scalar_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
         stk::mesh::put_field_on_mesh(*cell_scalar_states.back(), metaData->universal_part(), 1, nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_scalar_states.back(), role_type(st.output));
@@ -109,7 +100,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
       else if (dim.size()==2)
       {
         // Vector on cell
-        cell_vector_states.push_back(& metaData->declare_field< VFT >(stk::topology::ELEMENT_RANK, st.name));
+        cell_vector_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
         stk::mesh::put_field_on_mesh(*cell_vector_states.back(), metaData->universal_part(), dim[1], nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_vector_states.back(), role_type(st.output));
@@ -118,7 +109,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
       else if (dim.size()==3)
       {
         // 2nd order tensor on cell
-        cell_tensor_states.push_back(& metaData->declare_field< TFT >(stk::topology::ELEMENT_RANK, st.name));
+        cell_tensor_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
         stk::mesh::put_field_on_mesh(*cell_tensor_states.back(), metaData->universal_part(), dim[2], dim[1], nullptr);
 #ifdef ALBANY_SEACAS
         stk::io::set_field_role(*cell_tensor_states.back(), role_type(st.output));
@@ -135,7 +126,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
     } else if(st.entity == StateStruct::QuadPoint || st.entity == StateStruct::ElemNode){
 
         if(dim.size() == 2){ // Scalar at QPs
-          qpscalar_states.push_back(& metaData->declare_field< QPSFT >(stk::topology::ELEMENT_RANK, st.name));
+          qpscalar_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
           stk::mesh::put_field_on_mesh(*qpscalar_states.back(), metaData->universal_part(), dim[1], nullptr);
         //Debug
         //      cout << "Allocating qps field name " << qpscalar_states.back()->name() <<
@@ -145,7 +136,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
 #endif
         }
         else if(dim.size() == 3){ // Vector at QPs
-          qpvector_states.push_back(& metaData->declare_field< QPVFT >(stk::topology::ELEMENT_RANK, st.name));
+          qpvector_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
           // Multi-dim order is Fortran Ordering, so reversed here
           stk::mesh::put_field_on_mesh(*qpvector_states.back(), metaData->universal_part(), dim[2], dim[1], nullptr);
           //Debug
@@ -156,7 +147,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
 #endif
         }
         else if(dim.size() == 4){ // Tensor at QPs
-          qptensor_states.push_back(& metaData->declare_field< QPTFT >(stk::topology::ELEMENT_RANK, st.name));
+          qptensor_states.push_back(& metaData->declare_field< double >(stk::topology::ELEMENT_RANK, st.name));
           // Multi-dim order is Fortran Ordering, so reversed here
 #ifdef IKT_DEBUG
           //Debug

--- a/src/disc/stk/Albany_GmshSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GmshSTKMeshStruct.cpp
@@ -292,8 +292,8 @@ void Albany::GmshSTKMeshStruct::setBulkData(
     stk::mesh::PartVector singlePartVec(1);
     unsigned int ebNo = 0; //element block #???
 
-    AbstractSTKFieldContainer::IntScalarFieldType* proc_rank_field = fieldContainer->getProcRankField();
-    AbstractSTKFieldContainer::VectorFieldType* coordinates_field =  fieldContainer->getCoordinatesField();
+    AbstractSTKFieldContainer::STKIntState* proc_rank_field = fieldContainer->getProcRankField();
+    AbstractSTKFieldContainer::STKFieldType* coordinates_field =  fieldContainer->getCoordinatesField();
 
     singlePartVec[0] = nsPartVec["Node"];
 

--- a/src/disc/stk/Albany_IossSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_IossSTKMeshStruct.cpp
@@ -31,7 +31,7 @@ namespace {
 void get_element_block_sizes(stk::io::StkMeshIoBroker &mesh_data,
                              std::vector<int>& el_blocks)
 {
-  Ioss::Region &io = *mesh_data.get_input_io_region();
+  Ioss::Region &io = *mesh_data.get_input_ioss_region();
   const Ioss::ElementBlockContainer& elem_blocks = io.get_element_blocks();
   for(Ioss::ElementBlockContainer::const_iterator it = elem_blocks.begin(); it != elem_blocks.end(); ++it) {
     Ioss::ElementBlock *entity = *it;
@@ -112,7 +112,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
   for (StringArray::const_iterator it = additionalNodeSets.begin(), it_end = additionalNodeSets.end(); it != it_end; ++it) {
     stk::mesh::Part &newNodeSet = metaData->declare_part(*it, stk::topology::NODE_RANK);
     if (!stk::io::is_part_io_part(newNodeSet)) {
-      stk::mesh::Field<double> * const distrFactorfield = metaData->get_field<stk::mesh::Field<double> >(stk::topology::NODE_RANK, "distribution_factors");
+      stk::mesh::Field<double> * const distrFactorfield = metaData->get_field<double>(stk::topology::NODE_RANK, "distribution_factors");
       if (distrFactorfield != NULL){
         stk::mesh::put_field_on_mesh(*distrFactorfield, newNodeSet, nullptr);
       }
@@ -157,7 +157,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
 
   // the method 'initializesidesetmeshspecs' requires that ss parts store a valid stk topology.
   // therefore, we try to retrieve the topology of this part using stk stuff.
-  auto r = mesh_data->get_input_io_region();
+  auto r = mesh_data->get_input_ioss_region();
   auto& sss = r->get_sidesets();
   for (auto ss : sss) {
     auto& ssb = ss->get_side_blocks();
@@ -216,7 +216,7 @@ Albany::IossSTKMeshStruct::IossSTKMeshStruct(
   }
 
   {
-    const Ioss::Region& inputRegion = *(mesh_data->get_input_io_region());
+    const Ioss::Region& inputRegion = *(mesh_data->get_input_ioss_region());
     m_solutionFieldHistoryDepth = inputRegion.get_property("state_count").get_int();
   }
 
@@ -312,7 +312,7 @@ Albany::IossSTKMeshStruct::setFieldData (
   // Restart index to read solution from exodus file.
   int index = params->get("Restart Index",-1); // Default to no restart
   double res_time = params->get<double>("Restart Time",-1.0); // Default to no restart
-  Ioss::Region& region = *(mesh_data->get_input_io_region());
+  Ioss::Region& region = *(mesh_data->get_input_ioss_region());
   /*
    * The following code block reads a single mesh on PE 0, then distributes the mesh across
    * the other processors. stk_rebalance is used, which requires Zoltan
@@ -507,7 +507,7 @@ Albany::IossSTKMeshStruct::setBulkData (
   // Restart index to read solution from exodus file.
   int index = params->get("Restart Index",-1); // Default to no restart
   double res_time = params->get<double>("Restart Time",-1.0); // Default to no restart
-  Ioss::Region& region = *(mesh_data->get_input_io_region());
+  Ioss::Region& region = *(mesh_data->get_input_ioss_region());
   /*
    * The following code block reads a single mesh on PE 0, then distributes the mesh across
    * the other processors. stk_rebalance is used, which requires Zoltan
@@ -772,7 +772,7 @@ Albany::IossSTKMeshStruct::getSolutionFieldHistoryStamp(int step) const
   TEUCHOS_ASSERT(step >= 0 && step < m_solutionFieldHistoryDepth);
 
   const int index = step + 1; // 1-based step indexing
-  const Ioss::Region &  inputRegion = *(mesh_data->get_input_io_region());
+  const Ioss::Region &  inputRegion = *(mesh_data->get_input_ioss_region());
   return inputRegion.get_state_time(index);
 }
 
@@ -781,7 +781,7 @@ Albany::IossSTKMeshStruct::loadOrSetCoordinates3d(int index)
 {
   const std::string coords3d_name = "coordinates3d";
 
-  auto region = mesh_data->get_input_io_region();
+  auto region = mesh_data->get_input_ioss_region();
   const Ioss::NodeBlockContainer& node_blocks = region->get_node_blocks();
   Ioss::NodeBlock *nb = node_blocks[0];
 

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
@@ -39,26 +39,26 @@ class OrdinarySTKFieldContainer : public GenericSTKFieldContainer
     return (residual_field != NULL);
   }
 
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
+  Teuchos::Array<AbstractSTKFieldContainer::STKFieldType*>
   getSolutionFieldArray()
   {
     return solution_field;
   }
 
-  AbstractSTKFieldContainer::VectorFieldType*
+  AbstractSTKFieldContainer::STKFieldType*
   getSolutionField()
   {
     return solution_field[0];
   };
 
 #if defined(ALBANY_DTK)
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
+  Teuchos::Array<AbstractSTKFieldContainer::STKFieldType*>
   getSolutionFieldDTKArray()
   {
     return solution_field_dtk;
   };
 
-  AbstractSTKFieldContainer::VectorFieldType*
+  AbstractSTKFieldContainer::STKFieldType*
   getSolutionFieldDTK()
   {
     return solution_field_dtk[0];
@@ -126,12 +126,12 @@ class OrdinarySTKFieldContainer : public GenericSTKFieldContainer
 
   void initializeProcRankField();
 
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*> solution_field;
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
+  Teuchos::Array<AbstractSTKFieldContainer::STKFieldType*> solution_field;
+  Teuchos::Array<AbstractSTKFieldContainer::STKFieldType*>
                                               solution_field_dtk;
-  Teuchos::Array<AbstractSTKFieldContainer::VectorFieldType*>
+  Teuchos::Array<AbstractSTKFieldContainer::STKFieldType*>
                                               solution_field_dxdp;
-  AbstractSTKFieldContainer::VectorFieldType* residual_field;
+  AbstractSTKFieldContainer::STKFieldType* residual_field;
 };
 
 }  // namespace Albany

--- a/src/disc/stk/Albany_STKFieldContainerHelper.cpp
+++ b/src/disc/stk/Albany_STKFieldContainerHelper.cpp
@@ -10,7 +10,6 @@
 
 namespace Albany {
 
-template struct STKFieldContainerHelper<Albany::AbstractSTKFieldContainer::ScalarFieldType>;
-template struct STKFieldContainerHelper<Albany::AbstractSTKFieldContainer::VectorFieldType>;
+template struct STKFieldContainerHelper<Albany::AbstractSTKFieldContainer::STKFieldType>;
 
 } // namespace Albany

--- a/src/disc/stk/Albany_STKFieldContainerHelper_Def.hpp
+++ b/src/disc/stk/Albany_STKFieldContainerHelper_Def.hpp
@@ -32,7 +32,7 @@ fillVector (      Thyra_Vector&    field_thyra,
 {
   constexpr int rank = FieldRank<FieldType>::n;
   static_assert(rank==0 || rank==1,
-                "Error! Can only handle ScalarFieldType and VectorFieldType for now.\n");
+                "Error! Can only handle Scalar and Vector fields for now.\n");
 
   using ScalarT = typename FieldScalar<FieldType>::type;
   using ViewT = Kokkos::View<const ScalarT**,Kokkos::LayoutRight,Kokkos::HostSpace>;
@@ -116,7 +116,7 @@ saveVector(const Thyra_Vector& field_thyra,
 {
   constexpr int rank = FieldRank<FieldType>::n;
   static_assert(rank==0 || rank==1,
-                "Error! Can only handle ScalarFieldType and VectorFieldType for now.\n");
+                "Error! Can only handle scalar and vector fields for now.\n");
 
   using ScalarT = typename FieldScalar<FieldType>::type;
   using ViewT = Kokkos::View<ScalarT**,Kokkos::LayoutRight,Kokkos::HostSpace>;
@@ -182,7 +182,7 @@ copySTKField(const FieldType& source,
 {
   constexpr int rank = FieldRank<FieldType>::n;
   static_assert(rank==0 || rank==1,
-                "Error! Can only handle ScalarFieldType and VectorFieldType for now.\n");
+                "Error! Can only handle scalar and vector fields for now.\n");
 
   using ScalarT = typename FieldScalar<FieldType>::type;
   using SrcViewT = Kokkos::View<const ScalarT**,Kokkos::LayoutRight,Kokkos::HostSpace>;

--- a/src/disc/stk/Albany_STKNodeFieldContainer.hpp
+++ b/src/disc/stk/Albany_STKNodeFieldContainer.hpp
@@ -85,9 +85,9 @@ struct NodeData_Traits<T, 1> {
                                  const std::vector<PHX::DataLayout::size_type>& /* dim */,
                                  stk::mesh::MetaData* metaData)
   {
-    field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
+    field_type *fld = & metaData->declare_field<T>(stk::topology::NODE_RANK, name);
     // Multi-dim order is Fortran Ordering, so reversed here
-    stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), nullptr);
+    stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), 1, nullptr);
 
     return fld; // Address is held by stk
   }
@@ -98,12 +98,12 @@ template <typename T>
 struct NodeData_Traits<T, 2> {
 
   enum { size = 2 }; // Two array dimension tags (Node, Dim), store type T values
-  typedef stk::mesh::Field<T, stk::mesh::Cartesian> field_type ;
+  typedef stk::mesh::Field<T> field_type ;
   static field_type* createField(const std::string& name,
                                  const std::vector<PHX::DataLayout::size_type>& dim,
                                  stk::mesh::MetaData* metaData)
   {
-    field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
+    field_type *fld = & metaData->declare_field<T>(stk::topology::NODE_RANK, name);
     // Multi-dim order is Fortran Ordering, so reversed here
     stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), dim[1], nullptr);
 
@@ -116,12 +116,12 @@ template <typename T>
 struct NodeData_Traits<T, 3> {
 
   enum { size = 3 }; // Three array dimension tags (Node, Dim, Dim), store type T values
-  typedef stk::mesh::Field<T, stk::mesh::Cartesian, stk::mesh::Cartesian> field_type ;
+  typedef stk::mesh::Field<T> field_type ;
   static field_type* createField(const std::string& name,
                                  const std::vector<PHX::DataLayout::size_type>& dim,
                                  stk::mesh::MetaData* metaData)
   {
-    field_type *fld = & metaData->declare_field<field_type>(stk::topology::NODE_RANK, name);
+    field_type *fld = & metaData->declare_field<T>(stk::topology::NODE_RANK, name);
     // Multi-dim order is Fortran Ordering, so reversed here
     stk::mesh::put_field_on_mesh(*fld , metaData->universal_part(), dim[2], dim[1], nullptr);
 

--- a/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_SideSetSTKMeshStruct.cpp
@@ -149,11 +149,11 @@ void SideSetSTKMeshStruct::setBulkData (
   const stk::mesh::MetaData& inputMetaData = *parentMeshStruct->metaData;
   const stk::mesh::BulkData& inputBulkData = *parentMeshStruct->bulkData;
 
-  typedef AbstractSTKFieldContainer::VectorFieldType VectorFieldType;
-  const VectorFieldType& parent_coordinates_field   = *parentMeshStruct->getCoordinatesField();
-  const VectorFieldType& parent_coordinates_field3d = *parentMeshStruct->getCoordinatesField3d();
-  VectorFieldType&       coordinates_field          = *fieldContainer->getCoordinatesField();
-  VectorFieldType&       coordinates_field3d        = *fieldContainer->getCoordinatesField3d();
+  typedef AbstractSTKFieldContainer::STKFieldType STKFieldType;
+  const STKFieldType& parent_coordinates_field   = *parentMeshStruct->getCoordinatesField();
+  const STKFieldType& parent_coordinates_field3d = *parentMeshStruct->getCoordinatesField3d();
+  STKFieldType&       coordinates_field          = *fieldContainer->getCoordinatesField();
+  STKFieldType&       coordinates_field3d        = *fieldContainer->getCoordinatesField3d();
 
   // Now we can extract the entities
   std::vector<stk::mesh::Entity> sides, nodes;

--- a/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
+++ b/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
@@ -580,8 +580,8 @@ TmplSTKMeshStruct<1>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& commT)
   std::vector<GO> elemNumber(1);
   unsigned int ebNo;
 
-  AbstractSTKFieldContainer::IntScalarFieldType* proc_rank_field = fieldContainer->getProcRankField();
-  AbstractSTKFieldContainer::VectorFieldType* coordinates_field = fieldContainer->getCoordinatesField();
+  AbstractSTKFieldContainer::STKIntState* proc_rank_field = fieldContainer->getProcRankField();
+  AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
       this->PBCStruct.periodic[0] = true;
@@ -682,7 +682,7 @@ TmplSTKMeshStruct<2>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& /* commT
   const GO mod_x   = periodic_x ? nelem[0] : std::numeric_limits<GO>::max();
   const GO mod_y   = periodic_y ? nelem[1] : std::numeric_limits<GO>::max();
 
-  AbstractSTKFieldContainer::VectorFieldType* coordinates_field = fieldContainer->getCoordinatesField();
+  AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
       this->PBCStruct.periodic[0] = true;
@@ -923,8 +923,8 @@ TmplSTKMeshStruct<3>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& commT)
   const GO mod_y    = periodic_y ? nelem[1] : std::numeric_limits<GO>::max();
   const GO mod_z    = periodic_z ? nelem[2] : std::numeric_limits<GO>::max();
 
-  AbstractSTKFieldContainer::IntScalarFieldType* proc_rank_field = fieldContainer->getProcRankField();
-  AbstractSTKFieldContainer::VectorFieldType* coordinates_field = fieldContainer->getCoordinatesField();
+  AbstractSTKFieldContainer::STKIntState* proc_rank_field = fieldContainer->getProcRankField();
+  AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
       this->PBCStruct.periodic[0] = true;

--- a/src/disc/stk/percept/stk_rebalance/GeomDecomp.hpp
+++ b/src/disc/stk/percept/stk_rebalance/GeomDecomp.hpp
@@ -71,7 +71,7 @@ namespace rebalance {
 
 class GeomDecomp: public Partition {
 public:
-  typedef mesh::Field<double,mesh::Cartesian> VectorField ;
+  typedef mesh::Field<double> VectorField ;
 public:
 
   GeomDecomp( ParallelMachine comm): Partition(comm) {}

--- a/src/disc/stk/percept/stk_rebalance/Partition.hpp
+++ b/src/disc/stk/percept/stk_rebalance/Partition.hpp
@@ -57,8 +57,8 @@
 namespace stk {
 namespace rebalance {
 
-typedef mesh::Field<double, mesh::Cartesian>  VectorField ;
-typedef mesh::Field<double>                   ScalarField ;
+typedef mesh::Field<double>  VectorField ;
+typedef mesh::Field<double>  ScalarField ;
 
 
 /** @class Partition for keeping track of a mesh entity partition.

--- a/src/disc/stk/percept/stk_rebalance/Rebalance.cpp
+++ b/src/disc/stk/percept/stk_rebalance/Rebalance.cpp
@@ -168,7 +168,6 @@ bool full_rebalance(mesh::BulkData  & bulk_data ,
 }
 } // namespace
 
-
 bool stk::rebalance::rebalance(mesh::BulkData   & bulk_data  ,
                                const mesh::Selector  & selector ,
                                const VectorField     * rebal_coord_ref ,

--- a/src/disc/stk/percept/stk_rebalance/Rebalance.hpp
+++ b/src/disc/stk/percept/stk_rebalance/Rebalance.hpp
@@ -59,6 +59,7 @@ namespace rebalance {
  * pre-defined derived classes in stk::rebalance, like \a ZoltanPartition,
  * or to define your own.
  */
+
 bool rebalance(mesh::BulkData & bulk_data ,
                const mesh::Selector & selector ,
                const VectorField * coord_ref ,

--- a/src/landIce/interfaceWithCISM/Albany_CismSTKMeshStruct.cpp
+++ b/src/landIce/interfaceWithCISM/Albany_CismSTKMeshStruct.cpp
@@ -351,18 +351,17 @@ constructMesh(const Teuchos::RCP<const Teuchos_Comm>& comm,
   unsigned int ebNo = 0; //element block #???
   int sideID = 0;
 
-  typedef AbstractSTKFieldContainer::ScalarFieldType ScalarFieldType;
-  typedef AbstractSTKFieldContainer::VectorFieldType VectorFieldType;
+  typedef AbstractSTKFieldContainer::STKFieldType STKFieldType;
 
-  VectorFieldType* coordinates_field = fieldContainer->getCoordinatesField();
-  ScalarFieldType* surfaceHeight_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "surface_height");
-  ScalarFieldType* thickness_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "ice_thickness");
-  ScalarFieldType* dsurfaceHeight_dx_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "xgrad_surface_height");
-  ScalarFieldType* dsurfaceHeight_dy_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "ygrad_surface_height");
-  ScalarFieldType* flowFactor_field = metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "flow_factor");
-  ScalarFieldType* temperature_field = metaData->get_field<ScalarFieldType>(stk::topology::ELEMENT_RANK, "temperature");
-  ScalarFieldType* basal_friction_field = metaData->get_field<ScalarFieldType>(stk::topology::NODE_RANK, "basal_friction");
-  VectorFieldType* dirichlet_field = metaData->get_field<VectorFieldType>(stk::topology::NODE_RANK, "dirichlet_field");
+  STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
+  STKFieldType* surfaceHeight_field = metaData->get_field<double>(stk::topology::NODE_RANK, "surface_height");
+  STKFieldType* thickness_field = metaData->get_field<double>(stk::topology::NODE_RANK, "ice_thickness");
+  STKFieldType* dsurfaceHeight_dx_field = metaData->get_field<double>(stk::topology::NODE_RANK, "xgrad_surface_height");
+  STKFieldType* dsurfaceHeight_dy_field = metaData->get_field<double>(stk::topology::NODE_RANK, "ygrad_surface_height");
+  STKFieldType* flowFactor_field = metaData->get_field<double>(stk::topology::ELEMENT_RANK, "flow_factor");
+  STKFieldType* temperature_field = metaData->get_field<double>(stk::topology::ELEMENT_RANK, "temperature");
+  STKFieldType* basal_friction_field = metaData->get_field<double>(stk::topology::NODE_RANK, "basal_friction");
+  STKFieldType* dirichlet_field = metaData->get_field<double>(stk::topology::NODE_RANK, "dirichlet_field");
 
   if(!surfaceHeight_field)
      have_sh = false;

--- a/src/landIce/interfaceWithCISM/ali_driver.cpp
+++ b/src/landIce/interfaceWithCISM/ali_driver.cpp
@@ -618,7 +618,7 @@ void ali_driver_run(AliToGlimmer * ftg_ptr, double& cur_time_yr, double time_inc
      auto stk_disc = Teuchos::rcp_dynamic_cast<Albany::STKDiscretization>(abs_disc);
 
      //Check what kind of ordering you have in the solution & create solutionField object.
-     Albany::AbstractSTKFieldContainer::VectorFieldType* solutionField;
+     Albany::AbstractSTKFieldContainer::STKFieldType* solutionField;
      solutionField = Teuchos::rcp_dynamic_cast<Albany::OrdinarySTKFieldContainer>
        (stk_disc->getSolutionFieldContainer())->getSolutionField();
 


### PR DESCRIPTION
STK `Field<>` is no longer templated with the `stk::mesh::Cartesian` type:
```
using VectorField = stk::mesh::Field<double, stk::mesh::Cartesian>; //deprecated
using VectorField = stk::mesh::Field<double>; //new
```
Similarly, `get_field<>` and `declare_field<>` methods are now only templated on the data type.
More details in the attached document provided by Dave Glaze [simple_fields.pptx](https://github.com/sandialabs/Albany/files/11638824/simple_fields.pptx).
