### PR TITLE
Add support for UVM-free Trilinos (Velocity)

### DIFF
--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -15,6 +15,8 @@
 #include "Phalanx_MDField.hpp"
 #include "Phalanx_DataLayout_MDALayout.hpp"
 
+#include "PHAL_AlbanyTraits.hpp"
+
 // Forward declarations
 namespace Albany {
   class Application;
@@ -84,6 +86,24 @@ private:
   typename PHX::DataLayout::size_type dimsm1_[5], idxs_[5];
   int i_, rank_;
   bool done_;
+};
+
+//! Mimics MDFieldIterator's access patterns in a Kokkos::parallel_for friendly way
+//! MDFieldIterator treats MDField like it has RightLayout regardless of memory space,
+//! and may not be efficient on GPU
+template<typename T>
+class MDFieldVectorRight {
+public:
+  using array_type = typename PHX::MDField<T>::array_type;
+  using reference_type = typename PHX::MDField<T>::reference_type;
+  using return_type = typename PHX::MDFieldReturnType<array_type>::return_type;
+  explicit MDFieldVectorRight(PHX::MDField<T>& a);
+  KOKKOS_INLINE_FUNCTION typename Ref<T>::type operator[](const int i) const;
+  
+private:
+  PHX::MDField<T>& a_;
+  typename PHX::DataLayout::size_type dim0, dim1, dim2, dim3, dim4;
+  int rank_;
 };
 
 //! Reduce on an MDField.

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -90,18 +90,19 @@ private:
 
 //! Mimics MDFieldIterator's access patterns in a Kokkos::parallel_for friendly way
 //! MDFieldIterator treats MDField like it has RightLayout regardless of memory space,
-//! and may not be efficient on GPU
+//! and may not be efficient on GPU in some situations
 template<typename T>
 class MDFieldVectorRight {
 public:
-  using array_type = typename PHX::MDField<T>::array_type;
-  using reference_type = typename PHX::MDField<T>::reference_type;
-  using return_type = typename PHX::MDFieldReturnType<array_type>::return_type;
-  explicit MDFieldVectorRight(PHX::MDField<T>& a);
-  KOKKOS_INLINE_FUNCTION typename Ref<T>::type operator[](const int i) const;
+  using ref_t = typename PHAL::Ref<T>::type;
+  MDFieldVectorRight() = default;
+  MDFieldVectorRight(const MDFieldVectorRight<T>&) = default;
+  MDFieldVectorRight<T>& operator=(const MDFieldVectorRight<T>&) = default;
+  MDFieldVectorRight(PHX::MDField<T>& a);
+  KOKKOS_INLINE_FUNCTION ref_t operator[](const int i) const;  
   
 private:
-  PHX::MDField<T>& a_;
+  Kokkos::DynRankView<T, PHX::Device> a_;
   typename PHX::DataLayout::size_type dim0, dim1, dim2, dim3, dim4;
   int rank_;
 };

--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -35,7 +35,8 @@ MDFieldIterator (PHX::MDField<T>& a) : a_(a) {
 }
 
 template<typename T> MDFieldVectorRight<T>::
-MDFieldVectorRight (PHX::MDField<T>& a) : a_(a) {
+MDFieldVectorRight (PHX::MDField<T>& a) {
+  a_ = a.get_static_view();
   rank_ = a_.rank();
   TEUCHOS_TEST_FOR_EXCEPTION(rank_ <= 0, std::logic_error, "MDFieldVectorRight is not implemented for fields of rank <= 0.\n");
   TEUCHOS_TEST_FOR_EXCEPTION(rank_ >  5, std::logic_error, "MDFieldVectorRight is not implemented for fields of rank > 5.\n");
@@ -46,7 +47,7 @@ MDFieldVectorRight (PHX::MDField<T>& a) : a_(a) {
   dim4 = (rank_ > 4) ? a.extent(4) : 0;
 }
 
-template<typename T> KOKKOS_INLINE_FUNCTION typename Ref<T>::type
+template<typename T> KOKKOS_INLINE_FUNCTION MDFieldVectorRight<T>::ref_t
 MDFieldVectorRight<T>::operator[] (const int i) const {
   int idx0, idx1, idx2, idx3, idx4;
   if (rank_ == 1) {

--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -34,6 +34,50 @@ MDFieldIterator (PHX::MDField<T>& a) : a_(a) {
   i_ = 0;
 }
 
+template<typename T> MDFieldVectorRight<T>::
+MDFieldVectorRight (PHX::MDField<T>& a) : a_(a) {
+  rank_ = a_.rank();
+  TEUCHOS_TEST_FOR_EXCEPTION(rank_ <= 0, std::logic_error, "MDFieldVectorRight is not implemented for fields of rank <= 0.\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(rank_ >  5, std::logic_error, "MDFieldVectorRight is not implemented for fields of rank > 5.\n");
+  dim0 = a.extent(0);
+  dim1 = (rank_ > 1) ? a.extent(1) : 0;
+  dim2 = (rank_ > 2) ? a.extent(2) : 0;
+  dim3 = (rank_ > 3) ? a.extent(3) : 0;
+  dim4 = (rank_ > 4) ? a.extent(4) : 0;
+}
+
+template<typename T> KOKKOS_INLINE_FUNCTION typename Ref<T>::type
+MDFieldVectorRight<T>::operator[] (const int i) const {
+  int idx0, idx1, idx2, idx3, idx4;
+  if (rank_ == 1) {
+    idx0 = i;
+    return a_(idx0);
+  } else if (rank_ == 2) {
+    idx1 = i % dim1;
+    idx0 = i / dim1;
+    return a_(idx0, idx1);
+  } else if (rank_ == 3) {
+    idx2 = i % dim2;
+    idx1 = (i / dim2) % dim1;
+    idx0 = i / (dim2 * dim1);
+    return a_(idx0, idx1, idx2);
+  } else if (rank_ == 4) {
+    idx3 = i % dim3;
+    idx2 = (i / dim3) % dim2;
+    idx1 = (i / (dim3*dim2)) % dim1;
+    idx0 = i / (dim3*dim2*dim1);
+    return a_(idx0, idx1, idx2, idx3);
+  } else {
+    idx4 = i % dim4;
+    idx3 = (i / dim4) % dim3;
+    idx2 = (i / (dim4*dim3)) % dim2;
+    idx1 = (i / (dim4*dim3*dim2)) % dim1;
+    idx0 = i / (dim4*dim3*dim2*dim1);
+    return a_(idx0, idx1, idx2, idx3, idx4);
+  }
+}
+
+
 template<typename T> inline MDFieldIterator<T>&
 MDFieldIterator<T>::operator++ () {
   for (int i = rank_ - 1; i >= 0; --i)

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -101,7 +101,7 @@ struct Workset
   Teuchos::RCP<const Albany::SideSetList> sideSets;
   Teuchos::RCP<const Albany::LocalSideSetInfoList> sideSetViews;
 
-  Teuchos::RCP<const std::map<std::string, Kokkos::View<LO****, PHX::Device>>> localDOFViews;
+  Teuchos::RCP<const std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>> localDOFViews;
 
   // jacobian and mass matrix coefficients for matrix fill
   double j_coeff;

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -169,7 +169,7 @@ public:
   getSideSetViews(const int ws) const = 0;
 
   //! Get local DOF views for GatherVerticallyContractedSolution
-  virtual const std::map<std::string, Kokkos::View<LO****, PHX::Device>>&
+  virtual const std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>&
   getLocalDOFViews(const int workset) const = 0;
 
   //! Get Dof Manager of field field_name

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -9,6 +9,7 @@
 
 #include "Albany_KokkosTypes.hpp"
 #include "Albany_ScalarOrdinalTypes.hpp"
+#include "Kokkos_DualView.hpp"
 
 #include "Intrepid2_Basis.hpp"
 #include "Teuchos_ArrayRCP.hpp"

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -79,22 +79,22 @@ public:
   int max_sideset_length;
 
   // (num_local_worksets)
-  Kokkos::View<int*, Kokkos::LayoutRight> sideset_sizes;
+  Kokkos::DualView<int*, Kokkos::LayoutRight, PHX::Device> sideset_sizes;
 
   // (num_local_worksets, max_sideset_length)
-  Kokkos::View<GO**, Kokkos::LayoutRight>   side_GID;
-  Kokkos::View<GO**, Kokkos::LayoutRight>   elem_GID;
-  Kokkos::View<int**, Kokkos::LayoutRight>  ws_elem_idx;
-  Kokkos::View<int**, Kokkos::LayoutRight>  elem_ebIndex;
-  Kokkos::View<int**, Kokkos::LayoutRight>  side_pos;
+  Kokkos::DualView<GO**, Kokkos::LayoutRight, PHX::Device>   side_GID;
+  Kokkos::DualView<GO**, Kokkos::LayoutRight, PHX::Device>   elem_GID;
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>  ws_elem_idx;
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>  elem_ebIndex;
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>  side_pos;
 
   int max_sides;
   // (num_local_worksets, max_sides)
-  Kokkos::View<int**, Kokkos::LayoutRight>  numCellsOnSide;
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>  numCellsOnSide;
 
   // (num_local_worksets, max_sides, max_sideset_length)
-  Kokkos::View<int***, Kokkos::LayoutRight>   cellsOnSide;
-  Kokkos::View<int***, Kokkos::LayoutRight>   sideSetIdxOnSide;
+  Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>   cellsOnSide;
+  Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>   sideSetIdxOnSide;
 };
 
 using GlobalSideSetList = std::map<std::string, GlobalSideSetInfo>;
@@ -103,16 +103,16 @@ class LocalSideSetInfo
 {
 public:
   int size;
-  Kokkos::View<GO*, Kokkos::LayoutRight>    side_GID;      // (size)
-  Kokkos::View<GO*, Kokkos::LayoutRight>    elem_GID;      // (size)
-  Kokkos::View<int*, Kokkos::LayoutRight>   ws_elem_idx;   // (size)
-  Kokkos::View<int*, Kokkos::LayoutRight>   elem_ebIndex;  // (size)
-  Kokkos::View<int*, Kokkos::LayoutRight>   side_pos;      // (size)
+  Kokkos::DualView<GO*, Kokkos::LayoutRight, PHX::Device>    side_GID;      // (size)
+  Kokkos::DualView<GO*, Kokkos::LayoutRight, PHX::Device>    elem_GID;      // (size)
+  Kokkos::DualView<int*, Kokkos::LayoutRight, PHX::Device>   ws_elem_idx;   // (size)
+  Kokkos::DualView<int*, Kokkos::LayoutRight, PHX::Device>   elem_ebIndex;  // (size)
+  Kokkos::DualView<int*, Kokkos::LayoutRight, PHX::Device>   side_pos;      // (size)
 
   int numSides;
-  Kokkos::View<int*, Kokkos::LayoutRight>      numCellsOnSide;   // (sides)
-  Kokkos::View<int**, Kokkos::LayoutRight>     cellsOnSide;      // (numSides, sides)
-  Kokkos::View<int**, Kokkos::LayoutRight>     sideSetIdxOnSide; // (numSides, sides)
+  Kokkos::DualView<int*, Kokkos::LayoutRight, PHX::Device>      numCellsOnSide;   // (sides)
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>     cellsOnSide;      // (numSides, sides)
+  Kokkos::DualView<int**, Kokkos::LayoutRight, PHX::Device>     sideSetIdxOnSide; // (numSides, sides)
 };
 using LocalSideSetInfoList = std::map<std::string, LocalSideSetInfo>;
 

--- a/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
+++ b/src/disc/stk/Albany_BlockedSTKDiscretization.hpp
@@ -209,12 +209,12 @@ namespace Albany
     }
 
     //! Get local DOF views for GatherVerticallyContractedSolution
-    const std::map<std::string, Kokkos::View<LO ****, PHX::Device>> &
+    const std::map<std::string, Kokkos::DualView<LO ****, PHX::Device>> &
     getLocalDOFViews(const int workset) const
     {
       return this->getLocalDOFViews(0, workset);
     }
-    const std::map<std::string, Kokkos::View<LO ****, PHX::Device>> &
+    const std::map<std::string, Kokkos::DualView<LO ****, PHX::Device>> &
     getLocalDOFViews(const size_t i_block, const int workset) const
     {
       return m_blocks[i_block]->getLocalDOFViews(workset);

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1757,14 +1757,23 @@ STKDiscretization::computeSideSets()
         globalSideSetViews[ss_key].side_pos.h_view(current_index, j) = ss_val[j].side_pos;
       }
 
-      globalSideSetViews[ss_key].side_GID.sync<PHX::Device>();
-      globalSideSetViews[ss_key].elem_GID.sync<PHX::Device>();
-      globalSideSetViews[ss_key].ws_elem_idx.sync<PHX::Device>();
-      globalSideSetViews[ss_key].elem_ebIndex.sync<PHX::Device>();
-      globalSideSetViews[ss_key].side_pos.sync<PHX::Device>();
-      globalSideSetViews[ss_key].numCellsOnSide.sync<PHX::Device>();
-      globalSideSetViews[ss_key].cellsOnSide.sync<PHX::Device>();
-      globalSideSetViews[ss_key].sideSetIdxOnSide.sync<PHX::Device>();
+      globalSideSetViews[ss_key].side_GID.modify_host();
+      globalSideSetViews[ss_key].elem_GID.modify_host();
+      globalSideSetViews[ss_key].ws_elem_idx.modify_host();
+      globalSideSetViews[ss_key].elem_ebIndex.modify_host();
+      globalSideSetViews[ss_key].side_pos.modify_host();
+      globalSideSetViews[ss_key].numCellsOnSide.modify_host();
+      globalSideSetViews[ss_key].cellsOnSide.modify_host();
+      globalSideSetViews[ss_key].sideSetIdxOnSide.modify_host();
+
+      globalSideSetViews[ss_key].side_GID.sync_device();
+      globalSideSetViews[ss_key].elem_GID.sync_device();
+      globalSideSetViews[ss_key].ws_elem_idx.sync_device();
+      globalSideSetViews[ss_key].elem_ebIndex.sync_device();
+      globalSideSetViews[ss_key].side_pos.sync_device();
+      globalSideSetViews[ss_key].numCellsOnSide.sync_device();
+      globalSideSetViews[ss_key].cellsOnSide.sync_device();
+      globalSideSetViews[ss_key].sideSetIdxOnSide.sync_device();
 
       current_local_index[ss_key]++;
     }
@@ -1918,7 +1927,8 @@ STKDiscretization::computeSideSets()
           }
         }
 
-        globalDOFView.sync<PHX::Device>();
+        globalDOFView.modify_host();
+        globalDOFView.sync_device();
 
         // Set workset-local sub-view
         std::pair<int,int> range(sideset_idx_offset[ss_key], sideset_idx_offset[ss_key]+ss_val.size());

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1369,6 +1369,7 @@ STKDiscretization::computeWorksetInfo()
               state_h(i, j) = *stk::mesh::field_data(field, rowNode);
             }
           }
+          state.sync_to_dev();
           break;
         }
         case 3:  // vector
@@ -1387,6 +1388,7 @@ STKDiscretization::computeWorksetInfo()
               }
             }
           }
+          state.sync_to_dev();
           break;
         }
         case 4:  // tensor
@@ -1409,6 +1411,7 @@ STKDiscretization::computeWorksetInfo()
               }
             }
           }
+          state.sync_to_dev();
           break;
         }
       }

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1701,15 +1701,15 @@ STKDiscretization::computeSideSets()
 
     globalSideSetViews[ss_key].num_local_worksets = num_local_worksets[ss_key];
     globalSideSetViews[ss_key].max_sideset_length = max_sideset_length[ss_key];
-    globalSideSetViews[ss_key].side_GID         = Kokkos::View<GO**,   Kokkos::LayoutRight>("side_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
-    globalSideSetViews[ss_key].elem_GID         = Kokkos::View<GO**,   Kokkos::LayoutRight>("elem_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
-    globalSideSetViews[ss_key].ws_elem_idx      = Kokkos::View<int**,  Kokkos::LayoutRight>("ws_elem_idx", num_local_worksets[ss_key], max_sideset_length[ss_key]);
-    globalSideSetViews[ss_key].elem_ebIndex     = Kokkos::View<int**,  Kokkos::LayoutRight>("elem_ebIndex", num_local_worksets[ss_key], max_sideset_length[ss_key]);
-    globalSideSetViews[ss_key].side_pos         = Kokkos::View<int**,  Kokkos::LayoutRight>("side_pos", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].side_GID         = Kokkos::DualView<GO**,   Kokkos::LayoutRight, PHX::Device>("side_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].elem_GID         = Kokkos::DualView<GO**,   Kokkos::LayoutRight, PHX::Device>("elem_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].ws_elem_idx      = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("ws_elem_idx", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].elem_ebIndex     = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("elem_ebIndex", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].side_pos         = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("side_pos", num_local_worksets[ss_key], max_sideset_length[ss_key]);
     globalSideSetViews[ss_key].max_sides        = max_sides[ss_key];
-    globalSideSetViews[ss_key].numCellsOnSide   = Kokkos::View<int**,  Kokkos::LayoutRight>("numCellsOnSide", num_local_worksets[ss_key], max_sides[ss_key]);
-    globalSideSetViews[ss_key].cellsOnSide      = Kokkos::View<int***, Kokkos::LayoutRight>("cellsOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
-    globalSideSetViews[ss_key].sideSetIdxOnSide = Kokkos::View<int***, Kokkos::LayoutRight>("sideSetIdxOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].numCellsOnSide   = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("numCellsOnSide", num_local_worksets[ss_key], max_sides[ss_key]);
+    globalSideSetViews[ss_key].cellsOnSide      = Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>("cellsOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].sideSetIdxOnSide = Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>("sideSetIdxOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
   }
 
   // 3) Populate global views
@@ -1738,24 +1738,33 @@ STKDiscretization::computeSideSets()
       }
 
       for (int side = 0; side < numSides; ++side) {
-        globalSideSetViews[ss_key].numCellsOnSide(current_index, side) = numCellsOnSide[side];
+        globalSideSetViews[ss_key].numCellsOnSide.h_view(current_index, side) = numCellsOnSide[side];
         for (int j = 0; j < numCellsOnSide[side]; ++j) {
-          globalSideSetViews[ss_key].cellsOnSide(current_index, side, j) = cellsOnSide[side][j];
-          globalSideSetViews[ss_key].sideSetIdxOnSide(current_index, side, j) = sideSetIdxOnSide[side][j];
+          globalSideSetViews[ss_key].cellsOnSide.h_view(current_index, side, j) = cellsOnSide[side][j];
+          globalSideSetViews[ss_key].sideSetIdxOnSide.h_view(current_index, side, j) = sideSetIdxOnSide[side][j];
         }
         for (int j = numCellsOnSide[side]; j < max_sideset_length[ss_key]; ++j) {
-          globalSideSetViews[ss_key].cellsOnSide(current_index, side, j) = -1;
-          globalSideSetViews[ss_key].sideSetIdxOnSide(current_index, side, j) = -1;
+          globalSideSetViews[ss_key].cellsOnSide.h_view(current_index, side, j) = -1;
+          globalSideSetViews[ss_key].sideSetIdxOnSide.h_view(current_index, side, j) = -1;
         }
       }
 
       for (size_t j = 0; j < ss_val.size(); ++j) {
-        globalSideSetViews[ss_key].side_GID(current_index, j)      = ss_val[j].side_GID;
-        globalSideSetViews[ss_key].elem_GID(current_index, j)      = ss_val[j].elem_GID;
-        globalSideSetViews[ss_key].ws_elem_idx(current_index, j)   = ss_val[j].ws_elem_idx;
-        globalSideSetViews[ss_key].elem_ebIndex(current_index, j)  = ss_val[j].elem_ebIndex;
-        globalSideSetViews[ss_key].side_pos(current_index, j) = ss_val[j].side_pos;
+        globalSideSetViews[ss_key].side_GID.h_view(current_index, j)      = ss_val[j].side_GID;
+        globalSideSetViews[ss_key].elem_GID.h_view(current_index, j)      = ss_val[j].elem_GID;
+        globalSideSetViews[ss_key].ws_elem_idx.h_view(current_index, j)   = ss_val[j].ws_elem_idx;
+        globalSideSetViews[ss_key].elem_ebIndex.h_view(current_index, j)  = ss_val[j].elem_ebIndex;
+        globalSideSetViews[ss_key].side_pos.h_view(current_index, j) = ss_val[j].side_pos;
       }
+
+      globalSideSetViews[ss_key].side_GID.sync<PHX::Device>();
+      globalSideSetViews[ss_key].elem_GID.sync<PHX::Device>();
+      globalSideSetViews[ss_key].ws_elem_idx.sync<PHX::Device>();
+      globalSideSetViews[ss_key].elem_ebIndex.sync<PHX::Device>();
+      globalSideSetViews[ss_key].side_pos.sync<PHX::Device>();
+      globalSideSetViews[ss_key].numCellsOnSide.sync<PHX::Device>();
+      globalSideSetViews[ss_key].cellsOnSide.sync<PHX::Device>();
+      globalSideSetViews[ss_key].sideSetIdxOnSide.sync<PHX::Device>();
 
       current_local_index[ss_key]++;
     }
@@ -1830,7 +1839,7 @@ STKDiscretization::computeSideSets()
     // Allocate total localDOFView for each sideset name
     for (auto& ss_it : num_local_worksets) {
       std::string ss_key = ss_it.first;
-      allLocalDOFViews[ss_key] = Kokkos::View<LO****, PHX::Device>(ss_key + " localDOFView", total_sideset_idx[ss_key], maxSideNodes, numLayers+1, numComps);
+      allLocalDOFViews[ss_key] = Kokkos::DualView<LO****, PHX::Device>(ss_key + " localDOFView", total_sideset_idx[ss_key], maxSideNodes, numLayers+1, numComps);
     }
   }
 
@@ -1861,7 +1870,7 @@ STKDiscretization::computeSideSets()
     for (int ws=0; ws<getNumWorksets(); ++ws) {
 
       // Need to look at localDOFViews for each i so that there is a view available for each workset even if it is empty
-      std::map<std::string, Kokkos::View<LO****, PHX::Device>>& wsldofViews = wsLocalDOFViews[ws];
+      std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>& wsldofViews = wsLocalDOFViews[ws];
 
       const auto& elem_lids = getElementLIDs_host(ws);
 
@@ -1871,7 +1880,7 @@ STKDiscretization::computeSideSets()
         std::string             ss_key = ss_it.first;
         std::vector<SideStruct> ss_val = ss_it.second;
 
-        Kokkos::View<LO****, PHX::Device>& globalDOFView = allLocalDOFViews[ss_key];
+        Kokkos::DualView<LO****, PHX::Device>& globalDOFView = allLocalDOFViews[ss_key];
 
         for (unsigned int sideSet_idx = 0; sideSet_idx < ss_val.size(); ++sideSet_idx) {
           const auto& side = ss_val[sideSet_idx];
@@ -1896,18 +1905,20 @@ STKDiscretization::computeSideSets()
             for (int j=0; j<numSideNodes; ++j) {
               for (int il=0; il<numLayers; ++il) {
                 const LO layer_elem_LID = cell_layers_data->getId(basal_elem_LID,il);
-                globalDOFView(sideSet_idx + sideset_idx_offset[ss_key], j, il, eq) =
+                globalDOFView.h_view(sideSet_idx + sideset_idx_offset[ss_key], j, il, eq) =
                   elem_dof_lids(layer_elem_LID,sol_bot_offsets[j]);
               }
 
               // Add top side in last layer
               const int il = numLayers-1;
               const LO layer_elem_LID = cell_layers_data->getId(basal_elem_LID,il);
-              globalDOFView(sideSet_idx + sideset_idx_offset[ss_key], j, il+1, eq) =
+              globalDOFView.h_view(sideSet_idx + sideset_idx_offset[ss_key], j, il+1, eq) =
                 elem_dof_lids(layer_elem_LID,sol_top_offsets[j]);
             }
           }
         }
+
+        globalDOFView.sync<PHX::Device>();
 
         // Set workset-local sub-view
         std::pair<int,int> range(sideset_idx_offset[ss_key], sideset_idx_offset[ss_key]+ss_val.size());
@@ -1918,7 +1929,7 @@ STKDiscretization::computeSideSets()
     }
   } else {
     // We still need this view to be present (even if of size 0), so create them
-    std::map<std::string, Kokkos::View<LO****, PHX::Device>> dummy;
+    std::map<std::string, Kokkos::DualView<LO****, PHX::Device>> dummy;
     for (int ws=0; ws<getNumWorksets(); ++ws) {
       wsLocalDOFViews.emplace(std::make_pair(ws,dummy));
     }

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -93,7 +93,7 @@ public:
   }
 
   //! Get local DOF views for GatherVerticallyContractedSolution
-  const std::map<std::string, Kokkos::View<LO****, PHX::Device>>&
+  const std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>&
   getLocalDOFViews(const int workset) const
   {
     return wsLocalDOFViews.at(workset);
@@ -481,8 +481,8 @@ public:
   std::map<int, LocalSideSetInfoList> sideSetViews;
 
   //! GatherVerticallyContractedSolution connectivity
-  std::map<std::string, Kokkos::View<LO****, PHX::Device>> allLocalDOFViews;
-  std::map<int, std::map<std::string, Kokkos::View<LO****, PHX::Device>>> wsLocalDOFViews;
+  std::map<std::string, Kokkos::DualView<LO****, PHX::Device>> allLocalDOFViews;
+  std::map<int, std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>> wsLocalDOFViews;
 
   mutable Teuchos::ArrayRCP<double>                                 coordinates;
   Teuchos::RCP<Thyra_MultiVector>                                   coordMV;

--- a/src/evaluators/gather/PHAL_GatherSolutionSide_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolutionSide_Def.hpp
@@ -151,9 +151,9 @@ evaluateFields(typename Traits::EvalData workset)
 
   constexpr auto ALL = Kokkos::ALL();
   for (int iside=0; iside<sideSet.size; ++iside) {
-    const int ws_elem_idx = sideSet.ws_elem_idx(iside);
+    const int ws_elem_idx = sideSet.ws_elem_idx.h_view(iside);
     const int elem_LID = elem_lids(ws_elem_idx);
-    const int side_pos = sideSet.side_pos(iside);
+    const int side_pos = sideSet.side_pos.h_view(iside);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
 
     for (int eq=0; eq<numFields; ++eq) {
@@ -212,9 +212,9 @@ evaluateFields(PHAL::AlbanyTraits::EvalData workset)
   constexpr auto ALL = Kokkos::ALL();
 
   for (int iside=0; iside<sideSet.size; ++iside) {
-    const int icell = sideSet.ws_elem_idx(iside);
+    const int icell = sideSet.ws_elem_idx.h_view(iside);
     const int elem_LID = elem_lids(icell);
-    const int side_pos = sideSet.side_pos(iside);
+    const int side_pos = sideSet.side_pos.h_view(iside);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
 
     for (int eq=0; eq<numFields; ++eq) {
@@ -298,9 +298,9 @@ evaluateFields(PHAL::AlbanyTraits::EvalData workset)
 
   constexpr auto ALL = Kokkos::ALL();
   for (int iside=0; iside<sideSet.size; ++iside) {
-    const int icell = sideSet.ws_elem_idx(iside);
+    const int icell = sideSet.ws_elem_idx.h_view(iside);
     const int elem_LID = elem_lids(icell);
-    const int side_pos = sideSet.side_pos(iside);
+    const int side_pos = sideSet.side_pos.h_view(iside);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
 
     for (int eq=0; eq<numFields; ++eq) {

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -182,6 +182,13 @@ postRegistrationSetup(typename Traits::SetupData d,
         device_sol.val_dotdot_kokkos[i]=this->val_dotdot[i].get_static_view();
       }
     }
+    device_sol.val_kokkos.host_to_device();
+    if (enableTransient){
+      device_sol.val_dot_kokkos.host_to_device();
+    }
+    if (enableAcceleration){
+      device_sol.val_dotdot_kokkos.host_to_device();
+    }
 #endif
   } else if (tensorRank == 1) {
     this->utils.setFieldData(valVec,fm);

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide.hpp
@@ -42,7 +42,7 @@ private:
   std::string                     sideSetName;
   std::vector<int>                dims;
 
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
 
   Albany::LocalSideSetInfo sideSet;
 

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
@@ -105,7 +105,8 @@ DOFCellToSideBase(const Teuchos::ParameterList& p,
         sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
       }
     }
-    sideNodes.sync<PHX::Device>();
+    sideNodes.modify_host();
+    sideNodes.sync_device();
   }
 }
 

--- a/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFCellToSide_Def.hpp
@@ -136,8 +136,8 @@ void DOFCellToSideBase<EvalT, Traits, ScalarT>::
 operator() (const CellToSide_Tag&, const int& sideSet_idx) const {
 
   // Get the local data of side and cell
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   switch (layout)
   {

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation.hpp
@@ -144,7 +144,7 @@ public:
   KOKKOS_INLINE_FUNCTION
   void operator() (const FastSolutionVecGradInterpolationBase_Jacobian_Tag& tag, const int& cell) const;
 
-  int num_dof, neq;
+  int neq;
 
 #endif
 };

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation_Def.hpp
@@ -134,6 +134,7 @@ namespace PHAL {
   KOKKOS_INLINE_FUNCTION
   void FastSolutionVecGradInterpolationBase<PHAL::AlbanyTraits::Jacobian, Traits, typename PHAL::AlbanyTraits::Jacobian::ScalarT>::
   operator() (const FastSolutionVecGradInterpolationBase_Jacobian_Tag& tag, const int& cell) const {
+    const int num_dof = this->val_node(0,0,0).size();
     for (size_t qp=0; qp < this->numQPs; ++qp) {
           for (size_t i=0; i<this->vecDim; i++) {
             for (size_t dim=0; dim<this->numDims; dim++) {
@@ -180,7 +181,6 @@ namespace PHAL {
   auto start = std::chrono::high_resolution_clock::now();
 #endif
 
-   num_dof = this->val_node(0,0,0).size();
    neq = workset.disc->getDOFManager()->getNumFields();
 
    Kokkos::parallel_for(FastSolutionVecGradInterpolationBase_Jacobian_Policy(0,workset.numCells),*this);

--- a/src/evaluators/interpolation/PHAL_DOFVecInterpolation_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecInterpolation_Def.hpp
@@ -11,6 +11,8 @@
 
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
+#include "KokkosExp_View_Fad.hpp"
+
 #ifdef ALBANY_TIMER
 #include <chrono>
 #endif
@@ -194,10 +196,9 @@ template<typename Traits>
 void FastSolutionVecInterpolationBase<PHAL::AlbanyTraits::Jacobian, Traits, typename PHAL::AlbanyTraits::Jacobian::ScalarT>::
 evaluateFields(typename Traits::EvalData workset)
 {
-  int num_dof = this->val_node(0,0,0).size();
+  const int num_dof = Kokkos::dimension_scalar(this->val_node.get_view());
 #ifndef ALBANY_KOKKOS_UNDER_DEVELOPMENT
   const int neq = workset.disc->getDOFManager()->getNumFields();
-
   for (std::size_t cell=0; cell < workset.numCells; ++cell) {
     for (std::size_t qp=0; qp < this->numQPs; ++qp) {
       for (std::size_t i=0; i<this->vecDim; i++) {

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
@@ -187,7 +187,7 @@ evaluateFields(typename Traits::EvalData workset)
         for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
         {
           // Get the local data of cell
-          const int cell = sideSet.ws_elem_idx(sideSet_idx);
+          const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
           ScalarT sum = 0;
           for (int qp=0; qp<numQPs; ++qp)
@@ -208,7 +208,7 @@ evaluateFields(typename Traits::EvalData workset)
         for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
         {
           // Get the local data of cell
-          const int cell = sideSet.ws_elem_idx(sideSet_idx);
+          const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
           ScalarT sum = 0;
           for (int qp=0; qp<numQPs; ++qp)
@@ -239,7 +239,7 @@ evaluateFields(typename Traits::EvalData workset)
         for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
         {
           // Get the local data of cell
-          const int cell = sideSet.ws_elem_idx(sideSet_idx);
+          const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
           ScalarT sum = 0;
           for (int qp=0; qp<numQPs; ++qp)

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -105,6 +105,7 @@ postRegistrationSetup(typename Traits::SetupData d,
       // Get MDField views from std::vector
       device_resid.val_kokkos[eq]=this->val[eq].get_static_view();
     }
+    device_resid.val_kokkos.host_to_device();
 #endif
     numNodes = val[0].extent(1);
   } else  if (tensorRank == 1) {

--- a/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
@@ -136,7 +136,7 @@ loadNodeState(typename Traits::EvalData workset)
   auto sideSet = workset.sideSetViews->at(sideSetName);
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
     // Get the side GID
-    const int side_GID = sideSet.side_GID(sideSet_idx);
+    const int side_GID = sideSet.side_GID.h_view(sideSet_idx);
 
     // Get the lid ordering map
     // Recall: map[i] = j means that the i-th node in the 3d side is the j-th node in the 2d cell
@@ -210,7 +210,7 @@ loadElemState(typename Traits::EvalData workset)
   auto sideSet = workset.sideSetViews->at(sideSetName);
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
     // Get the side GID
-    const int side_GID = sideSet.side_GID(sideSet_idx);
+    const int side_GID = sideSet.side_GID.h_view(sideSet_idx);
 
     // Get the cell in the 2d mesh
     const auto cell2d = bulkData.get_entity(stk::topology::ELEM_RANK, side_GID+1);

--- a/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadSideSetStateField_Def.hpp
@@ -147,21 +147,27 @@ loadNodeState(typename Traits::EvalData workset)
     const auto cell2d = bulkData.get_entity(stk::topology::ELEM_RANK, cell2d_GID+1);
     const auto nodes2d = bulkData.begin_nodes(cell2d);
 
-    for (int inode=0; inode<numNodes; ++inode) {
-      const double* data = stk::mesh::field_data(*stk_field,nodes2d[node_map[inode]]);
-      switch (dims.size()) {
-        case 2:          
-          field(sideSet_idx,inode) = *data;
-          break;
-        case 3:
-          for (int idim=0; idim<static_cast<int>(dims[2]); ++idim) {
-            field(sideSet_idx,inode,idim) = data[idim];
-          }
-          break;
-        default:
-          TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
-              "Error! Unsupported field dimension. However, you should have gotten an error before!\n");
+    if (dims.size() == 2) {
+      auto field_d_view = Kokkos::subview(field.get_view(), sideSet_idx, Kokkos::ALL);
+      auto field_h_mirror = Kokkos::create_mirror_view(field_d_view);
+      for (int inode=0; inode<numNodes; ++inode) {
+        const double* data = stk::mesh::field_data(*stk_field,nodes2d[node_map[inode]]);
+        field_h_mirror(inode) = *data;
       }
+      Kokkos::deep_copy(field_d_view, field_h_mirror);
+    } else if (dims.size() == 3) {
+      auto field_d_view = Kokkos::subview(field.get_view(), sideSet_idx, Kokkos::ALL, Kokkos::ALL);
+      auto field_h_mirror = Kokkos::create_mirror_view(field_d_view);
+      for (int inode=0; inode<numNodes; ++inode) {
+        const double* data = stk::mesh::field_data(*stk_field,nodes2d[node_map[inode]]);
+        for (int idim=0; idim<static_cast<int>(dims[2]); ++idim) {
+          field_h_mirror(inode,idim) = data[idim];
+        }
+      }
+      Kokkos::deep_copy(field_d_view, field_h_mirror);
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
+          "Error! Unsupported field dimension. However, you should have gotten an error before!\n");
     }
   }
 }
@@ -216,18 +222,18 @@ loadElemState(typename Traits::EvalData workset)
     const auto cell2d = bulkData.get_entity(stk::topology::ELEM_RANK, side_GID+1);
 
     const double* data = stk::mesh::field_data(*stk_field,cell2d);
-    switch (dims.size()) {
-      case 1:
-        field(sideSet_idx) = *data;
-        break;
-      case 2:
-        for (int idim=0; idim<static_cast<int>(dims[1]); ++idim) {
-          field(sideSet_idx,idim) = data[idim];
-        }
-        break;
-      default:
-        TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
-            "Error! Unsupported field dimension. However, you should have gotten an error before!\n");
+    if (dims.size() == 1) {
+      auto field_d_view = Kokkos::subview(field.get_view(), sideSet_idx);
+      Kokkos::deep_copy(field_d_view, *data);
+    } else if (dims.size() == 2) {
+      auto field_d_view = Kokkos::subview(field.get_view(), sideSet_idx, Kokkos::ALL);
+      auto field_h_mirror = Kokkos::create_mirror_view(field_d_view);
+      for (int idim=0; idim<static_cast<int>(dims[1]); ++idim) {
+        field_h_mirror(sideSet_idx,idim) = data[idim];
+      }
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
+          "Error! Unsupported field dimension. However, you should have gotten an error before!\n");
     }
   }
 }

--- a/src/evaluators/state/PHAL_LoadStateField.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField.hpp
@@ -40,6 +40,8 @@ private:
   std::string stateName;
 
   MDFieldMemoizer<Traits> memoizer;
+
+  MDFieldVectorRight<ScalarType> dataVec;
 };
 
 template<typename EvalT, typename Traits>
@@ -64,6 +66,8 @@ private:
   std::string stateName;
 
   MDFieldMemoizer<Traits> memoizer;
+
+  MDFieldVectorRight<ParamScalarT> dataVec;
 };
 
 // Shortcut names

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -54,46 +54,11 @@ void LoadStateFieldBase<EvalT, Traits, ScalarType>::evaluateFields(typename Trai
   auto stateData   = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
 
-  std::vector<size_t> data_dims;
-  data.dimensions(data_dims);
-
-  const int d1 = data_dims[0];
-  const int d2 = (data_dims.size() > 1) ? data_dims[1] : 0;
-  const int d3 = (data_dims.size() > 2) ? data_dims[2] : 0;
-  const int d4 = (data_dims.size() > 3) ? data_dims[3] : 0;
-  const int d5 = (data_dims.size() > 4) ? data_dims[4] : 0;
-
-  const int data_dims_size = data_dims.size();
+  PHAL::MDFieldVectorRight<ScalarType> dataVec(data);
 
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
-    if (data_dims_size == 1) {
-      data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 2) {
-      int i2 = i % d2;
-      int i1 = i / d2;
-      data(i1,i2) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 3) {
-      int i3 = i % d3;
-      int i2 = (i / d3) % d2;
-      int i1 = i / (d3 * d2);
-      data(i1,i2,i3) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 4) {
-      int i4 = i % d4;
-      int i3 = (i / d4) % d3;
-      int i2 = (i / (d4*d3)) % d2;
-      int i1 = i / (d4*d3*d2);
-      data(i1,i2,i3,i4) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 5) {
-      int i5 = i % d5;
-      int i4 = (i / d5) % d4;
-      int i3 = (i / (d5*d4)) % d3;
-      int i2 = (i / (d5*d4*d3)) % d2;
-      int i1 = i / (d5*d4*d3*d2);
-      data(i1,i2,i3,i4,i5) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else {
-      // Exception
-    }
+    dataVec[i] = (i < stateToLoad_size) ? stateData(i) : 0.0;
   });
 }
 
@@ -136,46 +101,11 @@ void LoadStateField<EvalT, Traits>::evaluateFields(typename Traits::EvalData wor
   auto stateData   = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
 
-  std::vector<size_t> data_dims;
-  data.dimensions(data_dims);
-
-  const int d1 = data_dims[0];
-  const int d2 = (data_dims.size() > 1) ? data_dims[1] : 0;
-  const int d3 = (data_dims.size() > 2) ? data_dims[2] : 0;
-  const int d4 = (data_dims.size() > 3) ? data_dims[3] : 0;
-  const int d5 = (data_dims.size() > 4) ? data_dims[4] : 0;
-
-  const int data_dims_size = data_dims.size();
+  MDFieldVectorRight<ParamScalarT> dataVec(data);
 
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
-    if (data_dims_size == 1) {
-      data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 2) {
-      int i2 = i % d2;
-      int i1 = i / d2;
-      data(i1,i2) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 3) {
-      int i3 = i % d3;
-      int i2 = (i / d3) % d2;
-      int i1 = i / (d3 * d2);
-      data(i1,i2,i3) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 4) {
-      int i4 = i % d4;
-      int i3 = (i / d4) % d3;
-      int i2 = (i / (d4*d3)) % d2;
-      int i1 = i / (d4*d3*d2);
-      data(i1,i2,i3,i4) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else if (data_dims_size == 5) {
-      int i5 = i % d5;
-      int i4 = (i / d5) % d4;
-      int i3 = (i / (d5*d4)) % d3;
-      int i2 = (i / (d5*d4*d3)) % d2;
-      int i1 = i / (d5*d4*d3*d2);
-      data(i1,i2,i3,i4,i5) = (i < stateToLoad_size) ? stateData(i) : 0.0;
-    } else {
-      // Exception
-    }
+    dataVec[i] = (i < stateToLoad_size) ? stateData(i) : 0.0;
   });
 }
 

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -50,11 +50,11 @@ void LoadStateFieldBase<EvalT, Traits, ScalarType>::evaluateFields(typename Trai
   //       If dev data has changed, it should be synced to host by
   //       whomever changed the data.
   const auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
-  Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
-  auto stateData   = stateToLoad.dev();
+  auto stateData = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
 
-  PHAL::MDFieldVectorRight<ScalarType> dataVec(data);
+  MDFieldVectorRight<ScalarType> g(data);
+  dataVec = g;
 
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
@@ -97,12 +97,12 @@ void LoadStateField<EvalT, Traits>::evaluateFields(typename Traits::EvalData wor
   //       If dev data has changed, it should be synced to host by
   //       whomever changed the data.
   const auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
-  Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
-  auto stateData   = stateToLoad.dev();
+  auto stateData = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
 
-  MDFieldVectorRight<ParamScalarT> dataVec(data);
-
+  MDFieldVectorRight<ParamScalarT> g(data);
+  dataVec = g;
+  
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
     dataVec[i] = (i < stateToLoad_size) ? stateData(i) : 0.0;

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -53,10 +53,47 @@ void LoadStateFieldBase<EvalT, Traits, ScalarType>::evaluateFields(typename Trai
   Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
   auto stateData   = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
-  
+
+  std::vector<size_t> data_dims;
+  data.dimensions(data_dims);
+
+  const int d1 = data_dims[0];
+  const int d2 = (data_dims.size() > 1) ? data_dims[1] : 0;
+  const int d3 = (data_dims.size() > 2) ? data_dims[2] : 0;
+  const int d4 = (data_dims.size() > 3) ? data_dims[3] : 0;
+  const int d5 = (data_dims.size() > 4) ? data_dims[4] : 0;
+
+  const int data_dims_size = data_dims.size();
+
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
-    data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    if (data_dims_size == 1) {
+      data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 2) {
+      int i2 = i % d2;
+      int i1 = i / d2;
+      data(i1,i2) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 3) {
+      int i3 = i % d3;
+      int i2 = (i / d3) % d2;
+      int i1 = i / (d3 * d2);
+      data(i1,i2,i3) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 4) {
+      int i4 = i % d4;
+      int i3 = (i / d4) % d3;
+      int i2 = (i / (d4*d3)) % d2;
+      int i1 = i / (d4*d3*d2);
+      data(i1,i2,i3,i4) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 5) {
+      int i5 = i % d5;
+      int i4 = (i / d5) % d4;
+      int i3 = (i / (d5*d4)) % d3;
+      int i2 = (i / (d5*d4*d3)) % d2;
+      int i1 = i / (d5*d4*d3*d2);
+      data(i1,i2,i3,i4,i5) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else {
+      // Exception
+    }
   });
 }
 
@@ -94,14 +131,51 @@ void LoadStateField<EvalT, Traits>::evaluateFields(typename Traits::EvalData wor
   // NOTE: we don't sync to host, since we don't know if it's needed.
   //       If dev data has changed, it should be synced to host by
   //       whomever changed the data.
-  auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
+  const auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
   Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
   auto stateData   = stateToLoad.dev();
   const int stateToLoad_size = stateToLoad.size();
-  
+
+  std::vector<size_t> data_dims;
+  data.dimensions(data_dims);
+
+  const int d1 = data_dims[0];
+  const int d2 = (data_dims.size() > 1) ? data_dims[1] : 0;
+  const int d3 = (data_dims.size() > 2) ? data_dims[2] : 0;
+  const int d4 = (data_dims.size() > 3) ? data_dims[3] : 0;
+  const int d5 = (data_dims.size() > 4) ? data_dims[4] : 0;
+
+  const int data_dims_size = data_dims.size();
+
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
-    data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    if (data_dims_size == 1) {
+      data(i) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 2) {
+      int i2 = i % d2;
+      int i1 = i / d2;
+      data(i1,i2) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 3) {
+      int i3 = i % d3;
+      int i2 = (i / d3) % d2;
+      int i1 = i / (d3 * d2);
+      data(i1,i2,i3) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 4) {
+      int i4 = i % d4;
+      int i3 = (i / d4) % d3;
+      int i2 = (i / (d4*d3)) % d2;
+      int i1 = i / (d4*d3*d2);
+      data(i1,i2,i3,i4) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else if (data_dims_size == 5) {
+      int i5 = i % d5;
+      int i4 = (i / d5) % d4;
+      int i3 = (i / (d5*d4)) % d3;
+      int i2 = (i / (d5*d4*d3)) % d2;
+      int i1 = i / (d5*d4*d3*d2);
+      data(i1,i2,i3,i4,i5) = (i < stateToLoad_size) ? stateData(i) : 0.0;
+    } else {
+      // Exception
+    }
   });
 }
 

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -13,6 +13,8 @@
 #include "PHAL_Utilities.hpp"
 #include "PHAL_LoadStateField.hpp"
 
+#include <cstdio>
+
 namespace PHAL {
 
 template<typename EvalT, typename Traits, typename ScalarType>
@@ -50,8 +52,9 @@ void LoadStateFieldBase<EvalT, Traits, ScalarType>::evaluateFields(typename Trai
   //       If dev data has changed, it should be synced to host by
   //       whomever changed the data.
   const auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
+  Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
   auto stateData   = stateToLoad.dev();
-  const size_t stateToLoad_size = stateToLoad.size();
+  const int stateToLoad_size = stateToLoad.size();
   
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
@@ -94,8 +97,9 @@ void LoadStateField<EvalT, Traits>::evaluateFields(typename Traits::EvalData wor
   //       If dev data has changed, it should be synced to host by
   //       whomever changed the data.
   auto& stateToLoad = (*workset.stateArrayPtr)[stateName];
+  Kokkos::deep_copy(stateToLoad.dev(), stateToLoad.host());
   auto stateData   = stateToLoad.dev();
-  const size_t stateToLoad_size = stateToLoad.size();
+  const int stateToLoad_size = stateToLoad.size();
   
   Kokkos::parallel_for(Kokkos::RangePolicy(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -13,8 +13,6 @@
 #include "PHAL_Utilities.hpp"
 #include "PHAL_LoadStateField.hpp"
 
-#include <cstdio>
-
 namespace PHAL {
 
 template<typename EvalT, typename Traits, typename ScalarType>

--- a/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
@@ -132,7 +132,7 @@ saveElemState(typename Traits::EvalData workset)
   double tan_cell_val, meas;
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
     // Get the side GID
-    const int side_GID = sideSet.side_GID(sideSet_idx);
+    const int side_GID = sideSet.side_GID.h_view(sideSet_idx);
 
     // Get the cell in the 2d mesh
     const auto cell2d = bulkData.get_entity(stk::topology::ELEM_RANK, side_GID+1);
@@ -222,7 +222,7 @@ saveNodeState(typename Traits::EvalData workset)
   auto sideSet = workset.sideSetViews->at(sideSetName);
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
     // Get the side GID
-    const int side_GID = sideSet.side_GID(sideSet_idx);
+    const int side_GID = sideSet.side_GID.h_view(sideSet_idx);
 
     // Get the lid ordering map
     // Recall: map[i] = j means that the i-th node in the 3d side is the j-th node in the 2d cell

--- a/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_SaveSideSetStateField_Def.hpp
@@ -127,6 +127,10 @@ saveElemState(typename Traits::EvalData workset)
   TEUCHOS_TEST_FOR_EXCEPTION (stk_field==nullptr, std::runtime_error,
     "Error! STK Field ptr is null.\n");
 
+  const auto field_d_view = field.get_view();
+  const auto field_h_mirror = Kokkos::create_mirror_view(field_d_view);
+  Kokkos::deep_copy(field_h_mirror, field_d_view);
+
   // Loop on the sides of this sideSet that are in this workset
   auto sideSet = workset.sideSetViews->at(sideSetName);
   double tan_cell_val, meas;
@@ -140,11 +144,11 @@ saveElemState(typename Traits::EvalData workset)
     double* data = stk::mesh::field_data(*stk_field,cell2d);
     switch (rank) {
       case FRT::Scalar:
-        *data = field(sideSet_idx);
+        *data = field_h_mirror(sideSet_idx);
         break;
       case FRT::Vector:
         for (int idim=0; idim<static_cast<int>(dims[1]); ++idim) {
-          data[idim] = field(sideSet_idx,idim);
+          data[idim] = field_h_mirror(sideSet_idx,idim);
         }
         break;
       case FRT::Gradient:
@@ -159,14 +163,14 @@ saveElemState(typename Traits::EvalData workset)
             for (int qp=0; qp<numQPs; ++qp) {
               tan_cell_val += tangents(sideSet_idx,qp,idim,itan)*w_measure(sideSet_idx,qp);
             }
-            data[idim] +=  (tan_cell_val/meas) * field(sideSet_idx,itan);
+            data[idim] +=  (tan_cell_val/meas) * field_h_mirror(sideSet_idx,itan);
           }
         }
         break;
       case FRT::Tensor:
         for (int idim=0; idim<static_cast<int>(dims[1]); ++idim) {
           for (int jdim=0; jdim<static_cast<int>(dims[2]); ++jdim) {
-            data[idim*dims[1]+jdim] = field(sideSet_idx,idim,jdim);
+            data[idim*dims[1]+jdim] = field_h_mirror(sideSet_idx,idim,jdim);
         }}
         break;
     }
@@ -218,6 +222,10 @@ saveNodeState(typename Traits::EvalData workset)
   TEUCHOS_TEST_FOR_EXCEPTION (stk_field==nullptr, std::runtime_error,
       "Error! STK field ptr is null.\n");
 
+  const auto field_d_view = field.get_view();
+  const auto field_h_mirror = Kokkos::create_mirror_view(field_d_view);
+  Kokkos::deep_copy(field_h_mirror, field_d_view);
+
   // Loop on the sides of this sideSet that are in this workset
   auto sideSet = workset.sideSetViews->at(sideSetName);
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
@@ -236,17 +244,17 @@ saveNodeState(typename Traits::EvalData workset)
       double* data = stk::mesh::field_data(*stk_field,nodes2d[node_map[inode]]);
       switch (rank) {
         case FRT::Scalar:
-          *data = field(sideSet_idx,inode);
+          *data = field_h_mirror(sideSet_idx,inode);
           break;
         case FRT::Vector:
           for (int idim=0; idim<static_cast<int>(dims[2]); ++idim) {
-            data[idim] = field(sideSet_idx,inode,idim);
+            data[idim] = field_h_mirror(sideSet_idx,inode,idim);
           }
           break;
         case FRT::Gradient:
           for (int idim=0; idim<static_cast<int>(dims[2]); ++idim) {
             for (int jdim=0; jdim<static_cast<int>(dims[3]); ++jdim) {
-              data[idim*dims[2]+jdim] = field(sideSet_idx,inode,idim,jdim);
+              data[idim*dims[2]+jdim] = field_h_mirror(sideSet_idx,inode,idim,jdim);
           }}
           break;
         default:

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
@@ -114,13 +114,14 @@ postRegistrationSetup(typename Traits::SetupData d,
   intrepidBasis->getValues(grad_at_cub_points, cub_points, Intrepid2::OPERATOR_GRAD);
 
   // BF does not depend on the current element, so we fill it now
-  for (unsigned int cellside = 0; cellside < BF.extent(0); ++cellside) {
+  Kokkos::parallel_for(Kokkos::RangePolicy(0,BF.extent(0)),
+                       KOKKOS_CLASS_LAMBDA(const int cellside) { 
     for (unsigned int node=0; node<numSideNodes; ++node) {
       for (unsigned int qp=0; qp<numSideQPs; ++qp) {
         BF(cellside,node,qp) = val_at_cub_points(node,qp);
       }
     }
-  }
+  });
 
   d.fill_field_dependencies(this->dependentFields(),this->evaluatedFields());
   if (d.memoizer_active()) memoizer.enable_memoizer();

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
@@ -209,7 +209,7 @@ operator() (const ScatterCoordVec_Tag& tag, const int& iCell) const {
 
   for (std::size_t node=0; node < numNodes; ++node)
     for (std::size_t dim=0; dim < numCellDims; ++dim)
-      physPointsCell(iCell, node, dim) = coordVec(sideSet.cellsOnSide(currentSide,iCell),node,dim);
+      physPointsCell(iCell, node, dim) = coordVec(sideSet.cellsOnSide.d_view(currentSide,iCell),node,dim);
 
 }
 
@@ -222,7 +222,7 @@ operator() (const GatherNormals_Tag& tag, const int& iCell) const {
   //   therefore should not cause a race condition here on device
   for (unsigned int icoor=0; icoor<numCellDims; ++icoor)
     for (unsigned int qp=0; qp<numSideQPs; ++qp)
-      normals(sideSet.sideSetIdxOnSide(currentSide,iCell),qp, icoor) = normals_view(iCell,qp,icoor);
+      normals(sideSet.sideSetIdxOnSide.d_view(currentSide,iCell),qp, icoor) = normals_view(iCell,qp,icoor);
 
 }
 
@@ -248,7 +248,7 @@ evaluateFields(typename Traits::EvalData workset)
       // Current side needs to be stored as a member of this object so it can be used in device kernel
       currentSide = side;
 
-      unsigned int numCells_ = sideSet.numCellsOnSide(side);
+      unsigned int numCells_ = sideSet.numCellsOnSide.h_view(side);
       if( numCells_ == 0) continue;
 
       Kokkos::DynRankView<MeshScalarT, PHX::Device> normal_lengths = Kokkos::createDynRankView(sideCoordVec.get_view(),"normal_lengths", numCells_, numSideQPs);

--- a/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_MapToPhysicalFrameSide_Def.hpp
@@ -87,7 +87,7 @@ void MapToPhysicalFrameSide<EvalT, Traits>::
 operator() (const MapToPhysicalFrameSide_Tag& tag, const int& sideSet_idx) const {
   
   // Get the local data of side
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   for (int qp=0; qp<numSideQPs; ++qp) {
     for (int dim=0; dim<numDim; ++dim) {

--- a/src/evaluators/utility/PHAL_SharedParameter.hpp
+++ b/src/evaluators/utility/PHAL_SharedParameter.hpp
@@ -130,9 +130,9 @@ public:
   void evaluateFields(typename Traits::EvalData /*d*/)
   {
     if (log_parameter) {
-      param_as_field(0) = std::exp(accessor->getValue());
+      param_as_field.deep_copy(std::exp(accessor->getValue()));
     } else {
-      param_as_field(0) = accessor->getValue();
+      param_as_field.deep_copy(accessor->getValue());
     }
   }
 

--- a/src/landIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
+++ b/src/landIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
@@ -89,10 +89,6 @@ private:
   double overburden_fraction;  // [adim]
   double pressure_smoothing_length_scale; //[km]
 
-  ParamScalarT mu;
-  ParamScalarT lambda;
-  ParamScalarT power;
-
   int numNodes;
   int numQPs;
   int dim;

--- a/src/landIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
+++ b/src/landIce/evaluators/LandIce_BasalFrictionCoefficient.hpp
@@ -55,6 +55,8 @@ private:
   ScalarT printedLambda;
   ScalarT printedQ;
 
+  ParamScalarT mu, lambda, power;
+
   double beta_val;   // beta value [kPa yr/m] (for CONSTANT only)
   double N_val; // effective pressure value [kPa]
 

--- a/src/landIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
+++ b/src/landIce/evaluators/LandIce_BasalFrictionCoefficient_Def.hpp
@@ -528,6 +528,89 @@ evaluateFields (typename Traits::EvalData workset)
   if (memoizer.have_saved_data(workset,this->evaluatedFields()))
     return;
 
+  if ( (beta_type == BETA_TYPE::POWER_LAW) || (beta_type == BETA_TYPE::REGULARIZED_COULOMB) ) {
+    if (logParameters) {
+        auto hostPower_view = Kokkos::create_mirror_view(powerParam.get_view());
+        Kokkos::deep_copy(hostPower_view, powerParam.get_view());
+        ScalarT hostPower = hostPower_view(0);
+        power = std::exp(Albany::convertScalar<ParamScalarT>(hostPower));
+        if (mu_type == FIELD_TYPE::CONSTANT) {
+          auto hostMu_view = Kokkos::create_mirror_view(muParam.get_view());
+          Kokkos::deep_copy(hostMu_view, muParam.get_view());
+          ScalarT hostMu = hostMu_view(0);
+          mu = std::exp(Albany::convertScalar<ParamScalarT>(hostMu));
+        }
+      } else {
+        auto hostPower_view = Kokkos::create_mirror_view(powerParam.get_view());
+        Kokkos::deep_copy(hostPower_view, powerParam.get_view());
+        ScalarT hostPower = hostPower_view(0);
+        power = std::exp(Albany::convertScalar<ParamScalarT>(hostPower));
+        if (mu_type == FIELD_TYPE::CONSTANT) {
+          auto hostMu_view = Kokkos::create_mirror_view(muParam.get_view());
+          Kokkos::deep_copy(hostMu_view, muParam.get_view());
+          ScalarT hostMu = hostMu_view(0);
+          mu = Albany::convertScalar<ParamScalarT>(hostMu);
+        }
+      }
+  #ifdef OUTPUT_TO_SCREEN
+      Teuchos::RCP<Teuchos::FancyOStream> output(Teuchos::VerboseObjectBase::getDefaultOStream());
+      int procRank = Teuchos::GlobalMPISession::getRank();
+      int numProcs = Teuchos::GlobalMPISession::getNProc();
+      output->setProcRankAndSize (procRank, numProcs);
+      output->setOutputToRootOnly (0);
+
+      if (mu_type==FIELD_TYPE::CONSTANT && printedMu!=mu) {
+        *output << "[Basal Friction Coefficient" << PHX::print<EvalT>() << "] mu = " << mu << " [kPa yr^q m^{-q}]\n";
+        printedMu = mu;
+      }
+
+      if (printedQ!=power) {
+        *output << "[Basal Friction Coefficient" << PHX::print<EvalT>() << "] power = " << power << "\n";
+        printedQ = power;
+      }
+#endif
+      TEUCHOS_TEST_FOR_EXCEPTION (
+          power<0, Teuchos::Exceptions::InvalidParameter,
+          "Error in LandIce::BasalFrictionCoefficient: 'Power Exponent' must be >= 0.\n"
+          "   Input value: " + std::to_string(Albany::ADValue(mu)) + "\n");
+      TEUCHOS_TEST_FOR_EXCEPTION (
+          mu_type==FIELD_TYPE::CONSTANT && mu<0, Teuchos::Exceptions::InvalidParameter,
+          "Error in LandIce::BasalFrictionCoefficient: 'Coulomb Friction Coefficient' must be >= 0.\n"
+          "   Input value: " + std::to_string(Albany::ADValue(mu)) + "\n");
+  }
+
+  if (beta_type== BETA_TYPE::REGULARIZED_COULOMB) {
+      if (logParameters) {
+        if (lambda_type == FIELD_TYPE::CONSTANT) {
+          auto hostLambda_view = Kokkos::create_mirror_view(lambdaParam.get_view());
+          Kokkos::deep_copy(hostLambda_view, lambdaParam.get_view());
+          ScalarT hostLambda = hostLambda_view(0);
+          lambda = std::exp(Albany::convertScalar<ParamScalarT>(hostLambda));
+        }
+      } else {
+        if (lambda_type == FIELD_TYPE::CONSTANT) {
+          auto hostLambda_view = Kokkos::create_mirror_view(lambdaParam.get_view());
+          Kokkos::deep_copy(hostLambda_view, lambdaParam.get_view());
+          ScalarT hostLambda = hostLambda_view(0);
+          lambda = Albany::convertScalar<ParamScalarT>(hostLambda);
+        }
+      }
+#ifdef OUTPUT_TO_SCREEN
+      Teuchos::RCP<Teuchos::FancyOStream> output(Teuchos::VerboseObjectBase::getDefaultOStream());
+      int procRank = Teuchos::GlobalMPISession::getRank();
+      int numProcs = Teuchos::GlobalMPISession::getNProc();
+      output->setProcRankAndSize (procRank, numProcs);
+      output->setOutputToRootOnly (0);
+
+      if (lambda_type==FIELD_TYPE::CONSTANT && printedLambda!=lambda) {
+        *output << "[Basal Friction Coefficient" << PHX::print<EvalT>() << "] lambda = " << lambda << "\n";
+        printedLambda = lambda;
+      }
+#endif
+      TEUCHOS_TEST_FOR_EXCEPTION ((lambda_type == FIELD_TYPE::CONSTANT) && lambda<0, Teuchos::Exceptions::InvalidParameter,
+                                  "\nError in LandIce::BasalFrictionCoefficient: \"Bed Roughness\" must be >= 0.\n");
+  } 
+
   dim = nodal ? numNodes : numQPs;
 
   if (is_side_equation) {

--- a/src/landIce/evaluators/LandIce_EnthalpyBasalResid.hpp
+++ b/src/landIce/evaluators/LandIce_EnthalpyBasalResid.hpp
@@ -64,7 +64,7 @@ private:
   
   Albany::LocalSideSetInfo sideSet;
 
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
   std::string                     basalSideName;
 
   unsigned int numCellNodes;

--- a/src/landIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
@@ -76,8 +76,8 @@ operator() (const Enthalpy_Basal_Residual_Tag& tag, const int& sideSet_idx) cons
 
   constexpr int maxNumNodesPerSide = 4;
 
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   ScalarT val[maxNumNodesPerSide];
   for (unsigned int node = 0; node < numSideNodes; ++node) {

--- a/src/landIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_EnthalpyBasalResid_Def.hpp
@@ -65,7 +65,8 @@ EnthalpyBasalResid(const Teuchos::ParameterList& p, const Teuchos::RCP<Albany::L
       sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
-  sideNodes.sync<PHX::Device>();
+  sideNodes.modify_host();
+  sideNodes.sync_device();
 
   this->setName("Enthalpy Basal Residual" + PHX::print<EvalT>());
 }

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -155,13 +155,13 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto sol = device_sol;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos(iside);
+    const auto pos = sideSet.side_pos.h_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};
       for(int il=0; il<=nlayers; ++il) {
         for(int comp=0; comp<ncomps; ++comp)
-          contrSol[comp] += x_data(localDOF(iside, node, il, comp+l_offset))*w(il);
+          contrSol[comp] += x_data(localDOF.d_view(iside, node, il, comp+l_offset))*w(il);
       }
       for (int comp=0; comp<ncomps; ++comp) {
         sol.get_ref(iside,node,comp) = contrSol[comp];
@@ -211,13 +211,13 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto j_coeff = workset.j_coeff;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos(iside);
+    const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};
       for(int il=0; il<=nlayers; ++il) {
         for(int comp=0; comp<ncomps; ++comp)
-          contrSol[comp] += x_data(localDOF(iside, node, il, comp+l_offset))*w(il);
+          contrSol[comp] += x_data(localDOF.d_view(iside, node, il, comp+l_offset))*w(il);
       }
       for (int comp=0; comp<ncomps; ++comp) {
         auto val = sol.get_ref(iside,node,comp);
@@ -268,13 +268,13 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto sol = device_sol;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos(iside);
+    const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};
       for(int il=0; il<=nlayers; ++il) {
         for(int comp=0; comp<ncomps; ++comp)
-          contrSol[comp] += x_data(localDOF(iside, node, il, comp+l_offset))*w(il);
+          contrSol[comp] += x_data(localDOF.d_view(iside, node, il, comp+l_offset))*w(il);
       }
       for (int comp=0; comp<ncomps; ++comp) {
         sol.get_ref(iside,node,comp) = contrSol[comp];
@@ -316,13 +316,13 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto sol = device_sol;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos(iside);
+    const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};
       for(int il=0; il<=nlayers; ++il) {
         for(int comp=0; comp<ncomps; ++comp)
-          contrSol[comp] += x_data(localDOF(iside, node, il, comp+l_offset))*w(il);
+          contrSol[comp] += x_data(localDOF.d_view(iside, node, il, comp+l_offset))*w(il);
       }
       for (int comp=0; comp<ncomps; ++comp) {
         sol.get_ref(iside,node,comp) = contrSol[comp];
@@ -404,16 +404,16 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto j_coeff = workset.j_coeff;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos(iside);
+    const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};
       double contrDir[3] = {0.0, 0.0, 0.0};
       for(int il=0; il<=nlayers; ++il) {
         for(int comp=0; comp<ncomps; ++comp) {
-          contrSol[comp] += x_data(localDOF(iside, node, il, comp+l_offset))*w(il);
+          contrSol[comp] += x_data(localDOF.d_view(iside, node, il, comp+l_offset))*w(il);
           if (g_xx_is_active||g_px_is_active) {
-            contrDir[comp] += direction_x_data(localDOF(iside,node,il,comp+l_offset))*w(il);
+            contrDir[comp] += direction_x_data(localDOF.d_view(iside,node,il,comp+l_offset))*w(il);
           }
         }
       }

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -155,7 +155,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto sol = device_sol;
   Kokkos::parallel_for(RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
-    const auto pos = sideSet.side_pos.h_view(iside);
+    const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
     for (int node=0; node<numSideNodes; ++node) {
       double contrSol[3] = {0.0, 0.0, 0.0};

--- a/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
+++ b/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual.hpp
@@ -34,7 +34,7 @@ public:
 private:
 
   std::string sideName, bdEdgesName;
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
   Teuchos::RCP<shards::CellTopology> cellType;
 
   unsigned int numNodes;

--- a/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
+++ b/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
@@ -133,8 +133,8 @@ void LandIce::L2ProjectedBoundaryLaplacianResidualBase<EvalT, Traits, FieldScala
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of side and cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
-      const int side = sideSet.side_pos(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
+      const int side = sideSet.side_pos.h_view(sideSet_idx);
 
       MeshScalarT trapezoid_weights= 0;
       for (unsigned int qp=0; qp<numBasalQPs; ++qp)
@@ -165,11 +165,11 @@ void LandIce::L2ProjectedBoundaryLaplacianResidualBase<EvalT, Traits, FieldScala
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of side and cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
-      const int side = sideSet.side_pos(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
+      const int side = sideSet.side_pos.h_view(sideSet_idx);
       shards::CellTopology cell2dType(cellType->getCellTopologyData(sideDim,side));
       auto side_disc = workset.disc->getSideSetDiscretizations().at(sideName);
-      auto side_gid = sideSet.side_GID(sideSet_idx);
+      auto side_gid = sideSet.side_GID.h_view(sideSet_idx);
 
       // The following line associates to each 3d-side GID the corresponding 2d-cell.
       // It's needed when the 3d mesh is not built online

--- a/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
+++ b/src/landIce/evaluators/LandIce_L2ProjectedBoundaryLaplacianResidual_Def.hpp
@@ -91,7 +91,8 @@ L2ProjectedBoundaryLaplacianResidualBase(Teuchos::ParameterList& p, const Teucho
       sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
-  sideNodes.sync<PHX::Device>();
+  sideNodes.modify_host();
+  sideNodes.sync_device();
 }
 
 // **********************************************************************

--- a/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual.hpp
+++ b/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual.hpp
@@ -37,7 +37,7 @@ namespace LandIce {
     Albany::LocalSideSetInfo sideSet;
 
     std::string sideName;
-    Kokkos::View<int**, PHX::Device> sideNodes;
+    Kokkos::DualView<int**, PHX::Device> sideNodes;
     Teuchos::RCP<shards::CellTopology> cellType;
     Teuchos::RCP<shards::CellTopology> sideType;
     

--- a/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
+++ b/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
@@ -134,8 +134,8 @@ void LandIce::LaplacianRegularizationResidual<EvalT, Traits>::
 operator() (const LaplacianRegularization_Side_Tag& tag, const int& sideSet_idx) const {
 
   // Get the local data of side and cell
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   MeshScalarT side_trapezoid_weights= 0;
   for (unsigned int qp=0; qp<numSideQPs; ++qp)

--- a/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
+++ b/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
@@ -86,7 +86,8 @@ LaplacianRegularizationResidual(Teuchos::ParameterList& p, const Teuchos::RCP<Al
       sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
-  sideNodes.sync<PHX::Device>();
+  sideNodes.modify_host();
+  sideNodes.sync_device();
 }
 
 // **********************************************************************

--- a/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
+++ b/src/landIce/evaluators/LandIce_LaplacianRegularizationResidual_Def.hpp
@@ -79,13 +79,14 @@ LaplacianRegularizationResidual(Teuchos::ParameterList& p, const Teuchos::RCP<Al
     unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
     nodeMax = std::max(nodeMax, thisSideNodes);
   }
-  sideNodes = Kokkos::View<int**, PHX::Device>("sideNodes", numSides, nodeMax);
+  sideNodes = Kokkos::DualView<int**, PHX::Device>("sideNodes", numSides, nodeMax);
   for (unsigned int side=0; side<numSides; ++side) {
     unsigned int thisSideNodes = cellType->getNodeCount(sideDim,side);
     for (unsigned int node=0; node<thisSideNodes; ++node) {
-      sideNodes(side,node) = cellType->getNodeMap(sideDim,side,node);
+      sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
+  sideNodes.sync<PHX::Device>();
 }
 
 // **********************************************************************
@@ -143,7 +144,7 @@ operator() (const LaplacianRegularization_Side_Tag& tag, const int& sideSet_idx)
   side_trapezoid_weights /= numSideNodes;
 
   for (unsigned int inode=0; inode<numSideNodes; ++inode) {
-    auto cell_node = sideNodes(side,inode);
+    auto cell_node = sideNodes.d_view(side,inode);
     residual(cell,cell_node) += robin_coeff*field(cell,cell_node)* side_trapezoid_weights;
   }
 

--- a/src/landIce/evaluators/LandIce_PressureCorrectedTemperature.hpp
+++ b/src/landIce/evaluators/LandIce_PressureCorrectedTemperature.hpp
@@ -59,6 +59,9 @@ private:
   int numQPs;
 
   PHAL::MDFieldMemoizer<Traits> memoizer;
+
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 } // Namespace LandIce

--- a/src/landIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseBoundarySquaredL2Norm_Def.hpp
@@ -112,7 +112,7 @@ void LandIce::ResponseBoundarySquaredL2Norm<EvalT, Traits>::evaluateFields(typen
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
       MeshScalarT trapezoid_weight = 0;
       for (unsigned int qp=0; qp<numSideQPs; ++qp)

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -127,7 +127,7 @@ evaluateFields(typename Traits::EvalData workset)
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
       for (unsigned int inode=0; inode<numSideNodes; ++inode) {
         gl_func(inode) = rho_i*thickness(sideSet_idx,inode)+rho_w*bed(sideSet_idx,inode);

--- a/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -143,7 +143,7 @@ evaluateFields(typename Traits::EvalData workset)
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
       ScalarT t = 0;
       for (unsigned int qp=0; qp<numBasalQPs; ++qp) {
@@ -162,7 +162,7 @@ evaluateFields(typename Traits::EvalData workset)
       for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
       {
         // Get the local data of cell
-        const int cell = sideSet.ws_elem_idx(sideSet_idx);
+        const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
         ScalarT tr = 0, tH =0;
         for (unsigned int qp=0; qp<numBasalQPs; ++qp)
         {

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
@@ -175,7 +175,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
       ScalarT t = 0;
       ScalarT data = 0;
@@ -227,7 +227,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
         for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
         {
           // Get the local data of cell
-          const int cell = sideSet.ws_elem_idx(sideSet_idx);\
+          const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);\
 
           ScalarT t = 0;
           for (unsigned int qp=0; qp<numBasalQPs; ++qp)
@@ -253,7 +253,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
     for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
     {
       // Get the local data of \cell
-      const int cell = sideSet.ws_elem_idx(sideSet_idx);\
+      const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);\
 
       ScalarT t = 0;
       for (unsigned int qp=0; qp<numBasalQPs; ++qp)

--- a/src/landIce/evaluators/LandIce_StokesFOBasalResid.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOBasalResid.hpp
@@ -56,7 +56,7 @@ private:
   // Output:
   PHX::MDField<ScalarT,Cell,Node,VecDim> residual;
 
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
   std::string                     basalSideName;
 
   unsigned int numSideNodes;

--- a/src/landIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
@@ -75,7 +75,8 @@ StokesFOBasalResid<EvalT, Traits, BetaScalarT>::StokesFOBasalResid (const Teucho
       sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
-  sideNodes.sync<PHX::Device>();
+  sideNodes.modify_host();
+  sideNodes.sync_device();
 
   this->setName("StokesFOBasalResid"+PHX::print<EvalT>());
 }

--- a/src/landIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOBasalResid_Def.hpp
@@ -101,8 +101,8 @@ void StokesFOBasalResid<EvalT, Traits, BetaScalarT>::
 operator() (const StokesFOBasalResid_Tag&, const int& sideSet_idx) const {
   
   // Get the local data of side and cell
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   ScalarT local_res[2];
 

--- a/src/landIce/evaluators/LandIce_StokesFOLateralResid.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOLateralResid.hpp
@@ -63,7 +63,7 @@ private:
   // Output:
   PHX::MDField<OutputScalarT,Cell,Node,VecDim> residual;
 
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
   std::string                      lateralSideName;
   
   double rho_w;  // [Kg m^{-3}]

--- a/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
@@ -98,14 +98,15 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
     int thisSideNodes = cellType->getNodeCount(sideDim,side);
     nodeMax = std::max(nodeMax, thisSideNodes);
   }
-  sideNodes = Kokkos::View<int**, PHX::Device>("sideNodes", numSides, nodeMax);
+  sideNodes = Kokkos::DualView<int**, PHX::Device>("sideNodes", numSides, nodeMax);
   for (unsigned int side=0; side<numSides; ++side) {
     // Need to get the subcell exact count, since different sides may have different number of nodes (e.g., Wedge)
     int thisSideNodes = cellType->getNodeCount(sideDim,side);
     for (int node=0; node<thisSideNodes; ++node) {
-      sideNodes(side,node) = cellType->getNodeMap(sideDim,side,node);
+      sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
+  sideNodes.sync<PHX::Device>();
 
   this->setName("StokesFOLateralResid"+PHX::print<EvalT>());
 }
@@ -158,7 +159,7 @@ operator() (const GivenImmersedRatio_Tag&, const int& sideSet_idx) const {
       w_normal_stress *= h;
     }
     for (unsigned int node=0; node<numSideNodes; ++node) {
-      int sideNode = sideNodes(side,node);
+      int sideNode = sideNodes.d_view(side,node);
       // NOTE: we are RELYING on the fact that the lateral side is vertical, so that u*n = ux*nx+uy*ny.
       const OutputScalarT w_normal_stress_bf = w_normal_stress * BF(sideSet_idx,node,qp);
       for (unsigned int dim=0; dim<vecDimFO; ++dim) {
@@ -201,7 +202,7 @@ operator() (const ComputedImmersedRatio_Tag&, const int& sideSet_idx) const {
       w_normal_stress *= h;
     }
     for (unsigned int node=0; node<numSideNodes; ++node) {
-      int sideNode = sideNodes(side,node);
+      int sideNode = sideNodes.d_view(side,node);
       // The immersed ratio should be between 0 and 1. If s>=H, it is 0, since the ice bottom is at s-H, which is >=0.
       // If s<=0, it is 1, since the top is already under water. If 0<s<H it is somewhere in (0,1), since the top is above the sea level,
       // but the bottom is s-H<0, which is below the sea level.

--- a/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
@@ -106,7 +106,8 @@ StokesFOLateralResid (const Teuchos::ParameterList& p,
       sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
     }
   }
-  sideNodes.sync<PHX::Device>();
+  sideNodes.modify_host();
+  sideNodes.sync_device();
 
   this->setName("StokesFOLateralResid"+PHX::print<EvalT>());
 }

--- a/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOLateralResid_Def.hpp
@@ -140,8 +140,8 @@ operator() (const GivenImmersedRatio_Tag&, const int& sideSet_idx) const {
   const double scale = 1e-6; //[k^2]
 
   // Get the local data of side and cell
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   for (unsigned int qp=0; qp<numSideQPs; ++qp) {
     const ThicknessScalarT H = thickness(sideSet_idx,qp); //[km]
@@ -177,8 +177,8 @@ operator() (const ComputedImmersedRatio_Tag&, const int& sideSet_idx) const {
   const double scale = 1e-6; //[k^2]
 
   // Get the local data of side and cell
-  const int cell = sideSet.ws_elem_idx(sideSet_idx);
-  const int side = sideSet.side_pos(sideSet_idx);
+  const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
+  const int side = sideSet.side_pos.d_view(sideSet_idx);
 
   const OutputScalarT zero (0.0);
   const ThicknessScalarT threshold (1e-8);

--- a/src/landIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOSynteticTestBC_Def.hpp
@@ -178,8 +178,8 @@ void StokesFOSynteticTestBC<EvalT, Traits, betaScalarT>::evaluateFields (typenam
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx)
   {
     // Get the local data of side and cell
-    const int cell = sideSet.ws_elem_idx(sideSet_idx);
-    const int side = sideSet.side_pos(sideSet_idx);
+    const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
+    const int side = sideSet.side_pos.h_view(sideSet_idx);
 
     Kokkos::deep_copy(qp_temp,0.0);
     

--- a/src/landIce/evaluators/LandIce_w_Resid.hpp
+++ b/src/landIce/evaluators/LandIce_w_Resid.hpp
@@ -56,7 +56,7 @@ private:
   Albany::LocalSideSetInfo sideSet;
 
   std::string sideName;
-  Kokkos::View<int**, PHX::Device> sideNodes;
+  Kokkos::DualView<int**, PHX::Device> sideNodes;
   unsigned int numNodes;
   unsigned int numSideNodes;
   unsigned int numQPs;

--- a/src/landIce/evaluators/LandIce_w_Resid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_w_Resid_Def.hpp
@@ -77,7 +77,8 @@ namespace LandIce
         sideNodes.h_view(side,node) = cellType->getNodeMap(sideDim,side,node);
       }
     }
-    sideNodes.sync<PHX::Device>();
+    sideNodes.modify_host();
+    sideNodes.sync_device();
 
     this->addDependentField(GradVelocity);
     this->addDependentField(velocity);

--- a/src/landIce/evaluators/LandIce_w_Resid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_w_Resid_Def.hpp
@@ -121,8 +121,8 @@ namespace LandIce
   operator() (const wResid_Side_Tag& tag, const int& side_idx) const {
 
     // Get the local data of side and cell
-    const int cell = sideSet.ws_elem_idx(side_idx);
-    const int side = sideSet.side_pos(side_idx);
+    const int cell = sideSet.ws_elem_idx.d_view(side_idx);
+    const int side = sideSet.side_pos.d_view(side_idx);
 
     for (unsigned int snode=0; snode<numSideNodes; ++snode){
       int cnode = sideNodes(side,snode);

--- a/src/landIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn_Def.hpp
+++ b/src/landIce/evaluators/hydrology/LandIce_HydrologyResidualCavitiesEqn_Def.hpp
@@ -184,7 +184,7 @@ evaluateFieldsSide (typename Traits::EvalData workset)
   sideSet = workset.sideSetViews->at(sideSetName);
   for (int sideSet_idx = 0; sideSet_idx < sideSet.size; ++sideSet_idx) {
     // Get the local data of cell
-    const int cell = sideSet.ws_elem_idx(sideSet_idx);
+    const int cell = sideSet.ws_elem_idx.h_view(sideSet_idx);
 
     for (unsigned int node=0; node < numNodes; ++node) {
       res_node = 0;


### PR DESCRIPTION
This PR makes a number of changes to Albany to allow for a velocity problem to be solved when Albany is built against Trilinos that has Cuda UVM disabled. The following changes were made in order to ensure data is accessed only in the proper execution space during runtime:

1) Kokkos views (mostly related to sidesets) were replaced with Kokkos DualView's and are synced to device after being populated on host.
2) Added a sync for a DualView in GatherSolution that caused a bug only when UVM is disabled.
3) Fully ported some evaluators that had some dangling code that still ran on host

The changes from this branch have been tested successfully (with UVM disabled) on Greenland and Humboldt velocity solves and on the full suite of tests with UVM enabled. The only tests that currently fail are the two SHMIP tests that are known to be failing.

Notes:
-Responses are not currently ported to device so they will need to be disabled if running a velocity problem with UVM disabled.
-Some exception checks related to invalid parameters were lost when porting BasalFrictionCoefficient to device, can these exceptions be thrown within a device kernel? The values live on device so if the exceptions can only be thrown on host, I'll need to figure something out.