### PR TITLE
Omega_h Connectivity Manager: implement getOwnership and getConnectivityStart

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,3 +12,4 @@
 #docs/*  docs@example.com
 
 src/LandIce/*  @mperego
+src/disc/omegah/Omegah* @cwsmith

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -107,7 +107,6 @@ int main(int argc, char *argv[])
 
 #if defined(ALBANY_OMEGAH)
     Albany::init_omegah_lib(argc,argv,comm);
-    fprintf(stderr, "initialized omegah lib\n");
 #endif
 
     // Connect vtune for performance profiling

--- a/src/disc/Albany_ConnManager.hpp
+++ b/src/disc/Albany_ConnManager.hpp
@@ -50,7 +50,7 @@ public:
   // Queries the dimension of a part
   virtual int part_dim (const std::string& part_name) const = 0;
   
-  /** Get vector of bools associated to connectivity for a particular element, indicating whether the entity is owned by this rank
+  /** Get array of Ownership enums associated to connectivity for a particular element, indicating whether the entity is owned by this rank
     *
     * \param[in] localElmtId Local element ID
     *

--- a/src/disc/omegah/OmegahConnManager.cpp
+++ b/src/disc/omegah/OmegahConnManager.cpp
@@ -486,7 +486,6 @@ OmegahConnManager::getAssociatedNeighbors(const LO& /* el */) const
 
 // Where element ielem start in the 1d connectivity array
 int OmegahConnManager::getConnectivityStart (const LO localElmtId) const {
-  static_assert(sizeof(Omega_h::GO) == sizeof(GO));
   return localElmtId*m_dofsPerElm;
 }
 

--- a/src/disc/omegah/OmegahConnManager.cpp
+++ b/src/disc/omegah/OmegahConnManager.cpp
@@ -330,7 +330,7 @@ LO OmegahConnManager::getPartConnectivitySize() const
 }
 
 Omega_h::GOs OmegahConnManager::createElementToDofConnectivityMask(
-    const std::string& tagName, const Omega_h::Adj elmToDim[3]) const
+  Omega_h::Read<Omega_h::I8> maskArray[4], const Omega_h::Adj elmToDim[3]) const
 {
   //create array that is numVtxDofs+numEdgeDofs+numFaceDofs+numElmDofs long
   const auto numEntsInPart = getNumEntsInPart(mesh, partFilter);
@@ -342,32 +342,54 @@ Omega_h::GOs OmegahConnManager::createElementToDofConnectivityMask(
   LO dofOffset = 0;
   for(int adjDim=0; adjDim<partFilter.dim; adjDim++) {
     if(m_dofsPerEnt[adjDim]) {
-      Omega_h::Read<Omega_h::I8> maskArray;
-      if( mesh.has_tag(adjDim, tagName) ) {
-        maskArray = mesh.get_array<Omega_h::I8>(adjDim, tagName);
-      } else {
-        maskArray = Omega_h::Read<Omega_h::I8>(mesh.nents(adjDim), 0);
-      }
-      setElementToEntDofConnectivityMask(mesh, partFilter, maskArray, m_dofsPerElm, adjDim, dofOffset, elmToDim[adjDim],
+      setElementToEntDofConnectivityMask(mesh, partFilter, maskArray[adjDim], m_dofsPerElm, adjDim, dofOffset, elmToDim[adjDim],
           m_dofsPerEnt[adjDim], elm2dof);
       const auto numDownAdjEntsPerElm = Omega_h::element_degree(mesh.family(), partFilter.dim, adjDim);
       dofOffset += m_dofsPerEnt[adjDim]*numDownAdjEntsPerElm;
     }
   }
   if(m_dofsPerEnt[partFilter.dim]) {
-    Omega_h::Read<Omega_h::I8> maskArray;
-    if( mesh.has_tag(partFilter.dim, tagName) ) {
-      maskArray = mesh.get_array<Omega_h::I8>(partFilter.dim, tagName);
-    } else {
-      maskArray = Omega_h::Read<Omega_h::I8>(mesh.nents(partFilter.dim), 0);
-    }
-    setElementDofConnectivityMask(mesh, partFilter.dim, partFilter.name, m_dofsPerElm, dofOffset, m_dofsPerEnt[partFilter.dim], maskArray, elm2dof);
+    setElementDofConnectivityMask(mesh, partFilter.dim, partFilter.name, m_dofsPerElm, dofOffset, m_dofsPerEnt[partFilter.dim], maskArray[partFilter.dim], elm2dof);
   }
   return elm2dof;
 }
 
-void OmegahConnManager::createElementToDofConnectivity(const Omega_h::Adj elmToDim[3],
-    const std::array<Omega_h::GOs,4>& globalDofNumbering) {
+std::vector<Ownership> OmegahConnManager::buildConnectivityOwnership() const {
+  std::stringstream ss;
+  ss << "Error! The Omega_h dofs per element is zero.  Was buildConnectivity(...) called?\n";
+  TEUCHOS_TEST_FOR_EXCEPTION (m_dofsPerElm == 0, std::runtime_error, ss.str());
+  // get element-to-[vertex|edge|face] adjacencies
+  Omega_h::Adj elmToDim[3];
+  Omega_h::Read<Omega_h::I8> owned[4];
+  for(int dim = 0; dim < partFilter.dim; dim++) {
+    if(m_dofsPerEnt[dim] > 0) {
+      elmToDim[dim] = mesh.ask_down(partFilter.dim,dim);
+      owned[dim] = mesh.owned(dim);
+    } else {
+      owned[dim] = Omega_h::Read<Omega_h::I8>(mesh.nents(dim), 0);
+    }
+  }
+  if(m_dofsPerEnt[partFilter.dim] > 0)
+    owned[partFilter.dim] = mesh.owned(partFilter.dim);
+  else
+    owned[partFilter.dim] = Omega_h::Read<Omega_h::I8>(mesh.nents(partFilter.dim), 0);
+
+  auto connOwnership = createElementToDofConnectivityMask(owned, elmToDim);
+  // transfer to host
+  auto connOwnership_h = Omega_h::HostRead(connOwnership);
+  auto begin = connOwnership_h.data();
+  std::vector<Ownership> connOwnership_vec(connOwnership_h.size());
+  for(int i=0; i<connOwnership_vec.size(); i++) {
+    if( connOwnership_h[i] )
+      connOwnership_vec[i] = Ownership::Owned;
+    else
+      connOwnership_vec[i] = Ownership::Ghosted;
+  }
+  return connOwnership_vec;
+}
+
+Omega_h::GOs OmegahConnManager::createElementToDofConnectivity(const Omega_h::Adj elmToDim[3],
+    const std::array<Omega_h::GOs,4>& globalDofNumbering) const {
   //create array that is numVtxDofs+numEdgeDofs+numFaceDofs+numElmDofs long
   const auto numEntsInPart = getNumEntsInPart(mesh, partFilter);
   Omega_h::LO totalNumDofs = m_dofsPerElm*numEntsInPart;
@@ -436,7 +458,12 @@ OmegahConnManager::buildConnectivity(const panzer::FieldPattern &fp)
     }
   }
 
-  createElementToDofConnectivity(elmToDim, m_globalDofNumbering);
+  auto elm2dof = createElementToDofConnectivity(elmToDim, m_globalDofNumbering);
+  // transfer to host
+  m_connectivity = Omega_h::HostRead(elm2dof);
+
+  // build the ownership now that the field pattern is known
+  owners = buildConnectivityOwnership();
 }
 
 Teuchos::RCP<panzer::ConnManager>
@@ -458,8 +485,9 @@ OmegahConnManager::getAssociatedNeighbors(const LO& /* el */) const
 }
 
 // Where element ielem start in the 1d connectivity array
-int OmegahConnManager::getConnectivityStart (const LO ielem) const {
-  return 0;
+int OmegahConnManager::getConnectivityStart (const LO localElmtId) const {
+  static_assert(sizeof(Omega_h::GO) == sizeof(GO));
+  return localElmtId*m_dofsPerElm;
 }
 
 // Get a mask vector (1=yes, 0=no) telling if each dof entity is contained in the given mesh part
@@ -476,15 +504,23 @@ std::vector<int> OmegahConnManager::getConnectivityMask (const std::string& sub_
   ss << "Error! The Omega_h dofs per element is zero.  Was buildConnectivity(...) called?\n";
   TEUCHOS_TEST_FOR_EXCEPTION (m_dofsPerElm == 0, std::runtime_error, ss.str());
 
-  // get element-to-[vertex|edge|face] adjacencies
+  // get element-to-[vertex|edge|face] adjacencies and maskarray
   Omega_h::Adj elmToDim[3];
+  Omega_h::Read<Omega_h::I8> mask[4];
   for(int dim = 0; dim < partFilter.dim; dim++) {
     if(m_dofsPerEnt[dim] > 0) {
       elmToDim[dim] = mesh.ask_down(partFilter.dim,dim);
+      mask[dim] = mesh.get_array<Omega_h::I8>(dim, sub_part_name);
+    } else {
+      mask[dim] = Omega_h::Read<Omega_h::I8>(mesh.nents(dim), 0);
     }
   }
+  if(m_dofsPerEnt[partFilter.dim] > 0)
+    mask[partFilter.dim] = mesh.get_array<Omega_h::I8>(partFilter.dim, sub_part_name);
+  else
+    mask[partFilter.dim] = Omega_h::Read<Omega_h::I8>(mesh.nents(partFilter.dim), 0);
 
-  auto elm2dofMask = createElementToDofConnectivityMask(sub_part_name, elmToDim);
+  auto elm2dofMask = createElementToDofConnectivityMask(mask, elmToDim);
   // transfer to host
   auto elm2dofMask_h = Omega_h::HostRead(elm2dofMask);
   std::vector<int> elm2dofMask_vec(elm2dofMask_h.data(), elm2dofMask_h.data()+elm2dofMask_h.size());
@@ -499,6 +535,13 @@ std::vector<int> OmegahConnManager::getConnectivityMask (const std::string& sub_
 int OmegahConnManager::part_dim (const std::string&) const //FIXME
 {
   return partFilter.dim;
+}
+
+const Ownership* OmegahConnManager::getOwnership(LO localElmtId) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (owners.size()==0, std::logic_error,
+      "Error! Cannot call getOwnership before connectivity is built.\n");
+  return &owners.at(localElmtId*m_dofsPerElm);
 }
 
 } // namespace Albany

--- a/src/disc/omegah/OmegahConnManager.hpp
+++ b/src/disc/omegah/OmegahConnManager.hpp
@@ -31,17 +31,19 @@ private:
   const OmegahPartFilter partFilter;
   std::vector<LO> localElmIds;
   std::vector<LO> emptyHaloVec;
-  std::vector<Ownership> m_ownership;
+  std::vector<Ownership> owners;
   LO m_dofsPerElm = 0;
   std::array<LO,4> m_dofsPerEnt;
   std::array<Omega_h::GOs,4> m_globalDofNumbering;
   Omega_h::HostRead<Omega_h::GO> m_connectivity;
   LO getPartConnectivitySize() const;
   std::array<Omega_h::GOs,4> createGlobalDofNumbering() const;
-  void createElementToDofConnectivity(const Omega_h::Adj elmToDim[3],
-    const std::array<Omega_h::GOs,4>& globalDofNumbering);
-  Omega_h::GOs createElementToDofConnectivityMask(const std::string& tagName,
+  Omega_h::GOs createElementToDofConnectivity(const Omega_h::Adj elmToDim[3],
+    const std::array<Omega_h::GOs,4>& globalDofNumbering) const;
+  Omega_h::GOs createElementToDofConnectivityMask(
+    Omega_h::Read<Omega_h::I8> maskArray[4],
     const Omega_h::Adj elmToDim[3]) const;
+  std::vector<Ownership> buildConnectivityOwnership() const;
 public:
   OmegahConnManager(Omega_h::Mesh& in_mesh);
   OmegahConnManager(Omega_h::Mesh& in_mesh, std::string partId, const int partDim);
@@ -217,17 +219,20 @@ public:
     return false;
   }
 
-  int getConnectivityStart (const LO ielem) const;
-  std::vector<int> getConnectivityMask (const std::string& sub_part_name) const;
+  int getConnectivityStart (const LO localElmtId) const override;
+  std::vector<int> getConnectivityMask (const std::string& sub_part_name) const override;
 
   // Queries the dimension of a part
   int part_dim (const std::string& part_name) const override;
 
-  const Ownership* getOwnership(LO localElmtId) const override {
-    TEUCHOS_TEST_FOR_EXCEPTION (m_ownership.size()==0, std::logic_error,
-        "Error! Cannot call getOwnership before connectivity is built.\n");
-    return m_ownership.data() + (localElmtId*m_dofsPerElm);
-  }
+  /** Get vector of bools associated to connectivity for a particular element, indicating whether the entity is owned by this rank
+    *
+    * \param[in] localElmtId Local element ID
+    *
+    * \returns vector of bools, with total size
+    *          equal to <code>getConnectivitySize(localElmtId)</code>
+    */
+  const Ownership* getOwnership(LO localElmtId) const override;
 };
 
 } // namespace Albany

--- a/tests/unit/disc/omegah/OmegahConMgr.cpp
+++ b/tests/unit/disc/omegah/OmegahConMgr.cpp
@@ -109,8 +109,11 @@ void checkOwnership(Omega_h::Mesh& mesh, T connMgr) {
     auto dofGids = connMgr->getConnectivity(lid);
     auto dofOwned = connMgr->getOwnership(lid);
     for(int i=0; i<dofsPerElm; i++) {
-      if(vtxGidOwned.at(dofGids[i]))
+      if(vtxGidOwned.at(dofGids[i])) {
         REQUIRE(Albany::Owned == dofOwned[i]);
+      } else {
+        REQUIRE(Albany::Ghosted == dofOwned[i]);
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds the implementation and tests for the Omega_h connectivity manager functions `getOwnership(...)` and `getConnectivityStart(...)`.