### PR TITLE
Fix CUDA build error related to Omega_h disc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ if (ALBANY_TRILINOS_DIR)
 endif()
 message ("-- Looking for trilinos installation ...")
 message ("     ALBANY_TRILINOS_DIR: ${ALBANY_TRILINOS_DIR}") 
-find_package(Trilinos 14.1 REQUIRED)
+find_package(Trilinos 15.1 REQUIRED)
 message("-- Looking for trilinos installation ... Found.\n")
 
 # Trilinos_BIN_DIRS probably should be defined in the Trilinos config. Until it is, set it here.

--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -39,8 +39,6 @@ using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,MemSpace>;
 // NOTE: Tpetra may use a different LO type (Albany uses int32, while tpetra uses int). When extracting local views/matrices,
 //       be careful about this. At worst, you may need to extract pointers and reinterpret_cast them.
 
-template<typename ST, typename MemSpace = DeviceMemSpace>
-using View1d = ViewLR<ST*,MemSpace>;
 using DevLayout = PHX::Device::array_layout;
 
 // kokkos 1d and 2d views to be used for on-device kernels

--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -41,12 +41,13 @@ using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,MemSpace>;
 
 template<typename ST, typename MemSpace = DeviceMemSpace>
 using View1d = ViewLR<ST*,MemSpace>;
+using DevLayout = PHX::Device::array_layout;
 
 // kokkos 1d and 2d views to be used for on-device kernels
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView1d = Kokkos::View<Scalar*, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
+using DeviceView1d = Kokkos::View<Scalar*, DevLayout, PHX::Device, MemoryTraits>;
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView2d = Kokkos::View<Scalar**, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
+using DeviceView2d = Kokkos::View<Scalar**, DevLayout, PHX::Device, MemoryTraits>;
 
 // Kokkos types for local graphs/matrices, to be used for on-device kernels
 using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, KokkosNode::device_type, void, size_t>;

--- a/src/disc/omegah/Albany_OmegahGenericMesh.hpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.hpp
@@ -39,8 +39,8 @@ public:
 
   bool hasRestartSolution () const { return m_has_restart_solution; }
 
-  View1d<const double>             coords_dev  () const { return m_coords_d; }
-  View1d<      double>::HostMirror coords_host () const { return m_coords_h; }
+  DeviceView1d<const double>             coords_dev  () const { return m_coords_d; }
+  DeviceView1d<      double>::HostMirror coords_host () const { return m_coords_h; }
 
   int part_dim (const std::string& part_name) const;
 
@@ -67,8 +67,8 @@ protected:
 
   Teuchos::RCP<OmegahMeshFieldAccessor>    m_field_accessor;
 
-  View1d<const double>                m_coords_d;
-  View1d<      double>::HostMirror    m_coords_h;
+  DeviceView1d<const double>                m_coords_d;
+  DeviceView1d<      double>::HostMirror    m_coords_h;
 
   bool m_has_restart_solution = false;
 };


### PR DESCRIPTION
This PR fixes a few things:

- The typedef used for the coords views in Albany Omega_h meshes did not match what Omega_h objects.
- DeviceView2d was hard-coding layout left, but this is not right for CPU builds. @jewatkins I don't know if our perf on CPU has looked bad recently, but using a layout left for 2d views (for 1d it's irrelevant) may have made us a tad slower. This would only be used inside the gather/scatter kernels for the Jacobian, so the impact is limited.
- Require Trilinos 15.1. @ikalash I am not sure why I get the error while nightlies don't, but basically, on my laptop the current (15.1) installation of Trilinos is rejected. My guess was that 15.1 is somewhat marked as incompatible with previous versions (indeed, some packages are removed), so our call to `find_package (Trilinos 14.1 REQUIRED)` would fail. But the fact that nightlies happily built makes me second guessing my guess. That said, I think changing the required version to 14.1 should not break anything, so maybe it's ok?

Fixes #1011 

Edit: @mperego do you know if Trilinos 15.1 was supposed to break code requesting an old Trilinos version (like 14.1)?