### PR TITLE
Add gcc/intel python env on blake

### DIFF
--- a/doc/dashboards/blake.sandia.gov/blake_gcc_modules.sh
+++ b/doc/dashboards/blake.sandia.gov/blake_gcc_modules.sh
@@ -2,7 +2,6 @@
 module purge
 module load git cmake
 module load python/3.10.10
-export PATH=${HOME}/.local/bin:${PATH} # Append local python install bin to path for pip3
 module load gcc/12.2.0
 module load boost/1.82.0
 module load metis/5.1.0
@@ -15,4 +14,5 @@ module load superlu-dist/8.1.2
 module load parallel-netcdf/1.12.3
 module load netcdf-c/4.9.2
 module load netcdf-fortran/4.6.0
+source /home/projects/albany/tpls/python/gcc/12.2.0/openmpi/4.1.5/gcc-env/bin/activate # activate python env
 module list

--- a/doc/dashboards/blake.sandia.gov/blake_intel_modules.sh
+++ b/doc/dashboards/blake.sandia.gov/blake_intel_modules.sh
@@ -2,7 +2,6 @@
 module purge
 module load git cmake
 module load python/3.10.10
-export PATH=${HOME}/.local/bin:${PATH} # Append local python install bin to path for pip3
 module load intel-oneapi-compilers/2023.2.0
 module load metis/5.1.0
 module load intel-oneapi-mkl/2023.2.0
@@ -14,5 +13,6 @@ module load superlu-dist/8.1.2
 module load parallel-netcdf/1.12.3
 module load netcdf-c/4.9.2
 module load netcdf-fortran/4.6.1
+source /home/projects/albany/tpls/python/oneapi/2023.2.0/mpi/2021.10.0/oneapi-env/bin/activate # activate python env
 ulimit -l unlimited # Unlimited memory locking. Error: map_hfi_mem: mmap of rcvhdr_bufbase size 262144 failed: Resource temporarily unavailable
 module list

--- a/doc/dashboards/blake.sandia.gov/run_gcc.batch
+++ b/doc/dashboards/blake.sandia.gov/run_gcc.batch
@@ -16,7 +16,6 @@ source blake_gcc_modules.sh >& gcc_modules.out
 bash nightly_cron_script_trilinos_blake_gcc_release.sh
 bash nightly_cron_script_trilinos_blake_gcc_debug.sh
 cd /home/projects/albany/nightlyCDashAlbanyBlake
-source install_python_packages.sh
 bash nightly_cron_script_albany_blake_gcc_release.sh
 bash nightly_cron_script_albany_blake_gcc_debug.sh
 bash nightly_cron_script_albany_blake_gcc_sfad.sh sfad6

--- a/doc/dashboards/blake.sandia.gov/run_intel.batch
+++ b/doc/dashboards/blake.sandia.gov/run_intel.batch
@@ -15,6 +15,5 @@ cd /home/projects/albany/nightlyCDashTrilinosBlake
 source blake_intel_modules.sh >& intel_modules.out
 bash nightly_cron_script_trilinos_blake_intel_release.sh
 cd /home/projects/albany/nightlyCDashAlbanyBlake
-source install_python_packages.sh
 bash nightly_cron_script_albany_blake_intel_release.sh
 

--- a/doc/dashboards/blake.sandia.gov/setup_python_env.sh
+++ b/doc/dashboards/blake.sandia.gov/setup_python_env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# gcc-env
+python -m venv /home/projects/albany/tpls/python/gcc/12.2.0/openmpi/4.1.5/gcc-env
+source /home/projects/albany/tpls/python/gcc/12.2.0/openmpi/4.1.5/gcc-env/bin/activate
+pip install -r requirements.txt --no-cache-dir
+deactivate
+
+# oneapi-env
+python -m venv /home/projects/albany/tpls/python/oneapi/2023.2.0/mpi/2021.10.0/oneapi-env
+source /home/projects/albany/tpls/python/oneapi/2023.2.0/mpi/2021.10.0/oneapi-env/bin/activate
+export MPICC=/projects/x86-64-icelake-rocky8/tpls/intel-oneapi-mpi/2021.10.0/oneapi/2023.2.0/base/7jy7xel/mpi/2021.10.0/bin/mpiicc
+export MPICXX=/projects/x86-64-icelake-rocky8/tpls/intel-oneapi-mpi/2021.10.0/oneapi/2023.2.0/base/7jy7xel/mpi/2021.10.0/bin/mpiicpc
+export MPIF90=/projects/x86-64-icelake-rocky8/tpls/intel-oneapi-mpi/2021.10.0/oneapi/2023.2.0/base/7jy7xel/mpi/2021.10.0/bin/mpiifx
+pip install -r requirements.txt --no-cache-dir
+

--- a/pyAlbany/requirements.txt
+++ b/pyAlbany/requirements.txt
@@ -1,0 +1,5 @@
+# pyAlbany Requirements
+numpy
+scipy
+mpi4py
+pybind11


### PR DESCRIPTION
The intel build requires it's own mpi4py installation so I added two separate gcc/intel python environments on blake. This should fix the intel pyAlbany tests.