### PR TITLE
Gather/scatter porting towards uvm-optional Albany

### DIFF
--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -39,13 +39,11 @@ using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,MemSpace>;
 // NOTE: Tpetra may use a different LO type (Albany uses int32, while tpetra uses int). When extracting local views/matrices,
 //       be careful about this. At worst, you may need to extract pointers and reinterpret_cast them.
 
-using DevLayout = PHX::Device::array_layout;
-
 // kokkos 1d and 2d views to be used for on-device kernels
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView1d = Kokkos::View<Scalar*, DevLayout, PHX::Device, MemoryTraits>;
+using DeviceView1d = Kokkos::View<Scalar*, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView2d = Kokkos::View<Scalar**, DevLayout, PHX::Device, MemoryTraits>;
+using DeviceView2d = Kokkos::View<Scalar**, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
 
 // Kokkos types for local graphs/matrices, to be used for on-device kernels
 using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, KokkosNode::device_type, void, size_t>;

--- a/src/Albany_KokkosTypes.hpp
+++ b/src/Albany_KokkosTypes.hpp
@@ -39,11 +39,19 @@ using ViewLR = Kokkos::View<DT,Kokkos::LayoutRight,MemSpace>;
 // NOTE: Tpetra may use a different LO type (Albany uses int32, while tpetra uses int). When extracting local views/matrices,
 //       be careful about this. At worst, you may need to extract pointers and reinterpret_cast them.
 
+using DevLayout = PHX::Device::array_layout;
+
 // kokkos 1d and 2d views to be used for on-device kernels
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView1d = Kokkos::View<Scalar*, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
+using DeviceView1d = Kokkos::View<Scalar*, DevLayout, PHX::Device, MemoryTraits>;
 template<typename Scalar, typename MemoryTraits = Kokkos::MemoryUnmanaged>
-using DeviceView2d = Kokkos::View<Scalar**, Kokkos::LayoutLeft, PHX::Device, MemoryTraits>;
+using DeviceView2d = Kokkos::View<Scalar**, DevLayout, PHX::Device, MemoryTraits>;
+
+// Thyra view types for underlying Tpetra kokkos views
+template<typename Scalar>
+using ThyraVDeviceView = Kokkos::View<Scalar*, Kokkos::LayoutLeft, PHX::Device>;
+template<typename Scalar>
+using ThyraMVDeviceView = Kokkos::View<Scalar**, Kokkos::LayoutLeft, PHX::Device>;
 
 // Kokkos types for local graphs/matrices, to be used for on-device kernels
 using DeviceLocalGraph  = Kokkos::StaticCrsGraph<LO, Kokkos::LayoutLeft, KokkosNode::device_type, void, size_t>;

--- a/src/PHAL_Workset.hpp
+++ b/src/PHAL_Workset.hpp
@@ -92,7 +92,7 @@ struct Workset
   Teuchos::RCP<Thyra_MultiVector> fpV;
   Teuchos::RCP<Thyra_MultiVector> Vp_bc;
 
-  Albany::DeviceView1d<ST>        f_kokkos;
+  Albany::ThyraVDeviceView<ST>        f_kokkos;
   Albany::DeviceLocalMatrix<ST>   Jac_kokkos;
 
   Teuchos::RCP<const Albany::NodeSetList>      nodeSets;

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -341,6 +341,9 @@ public:
   void evaluateFields(typename Traits::EvalData d);
 private:
   typedef typename PHAL::AlbanyTraits::HessianVec::ParamScalarT ParamScalarT;
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter.hpp
@@ -71,6 +71,9 @@ public:
   void evaluateFields(typename Traits::EvalData d);
 private:
   typedef typename EvalT::ParamScalarT ParamScalarT;
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 // General version for most evaluation types

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter_Def.hpp
@@ -425,7 +425,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   // Distributed parameter vector
   const auto p      = workset.distParamLib->get(this->param_name);
-  Albany::DeviceView1d<const ST> p_data = Albany::getDeviceData(p->overlapped_vector().getConst());
+  Albany::ThyraVDeviceView<const ST> p_data = Albany::getDeviceData(p->overlapped_vector().getConst());
 
   // Direction vector for the Hessian-vector product
   const auto vvec = workset.hessianWorkset.direction_p;
@@ -459,7 +459,7 @@ evaluateFields(typename Traits::EvalData workset)
       "\nError in GatherScalarNodalParameter<HessianVec, Traits>: "
       "direction_p is not set and the direction is active.\n");
   
-  Albany::DeviceView1d<const ST> vvec_data;
+  Albany::ThyraVDeviceView<const ST> vvec_data;
   if (is_p_direction_active) vvec_data = Albany::getDeviceData(vvec->col(0).getConst());
 
   const int ws = workset.wsIndex;

--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -272,10 +272,9 @@ private:
   using Base::numFields;
   using Base::m_fields_offsets;
 
-#ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
-private:
+protected:
   using RangePolicy = typename Base::RangePolicy;
-#endif
+
 };
 
 // **************************************************************
@@ -519,6 +518,7 @@ private:
   using Base::numFields;
   using Base::m_fields_offsets;
 
+protected:
   using RangePolicy = typename Base::RangePolicy;
 };
 

--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -518,6 +518,8 @@ private:
   using Base::get_ref_dotdot;
   using Base::numFields;
   using Base::m_fields_offsets;
+
+  using RangePolicy = typename Base::RangePolicy;
 };
 
 } // namespace PHAL

--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -271,6 +271,11 @@ private:
   using Base::get_ref_dotdot;
   using Base::numFields;
   using Base::m_fields_offsets;
+
+#ifdef ALBANY_KOKKOS_UNDER_DEVELOPMENT
+private:
+  using RangePolicy = typename Base::RangePolicy;
+#endif
 };
 
 // **************************************************************

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -287,7 +287,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   // Do everything on device
   // Get kokkos views from thyra vectors
-  Albany::DeviceView1d<const ST> x_data, xdot_data, xdotdot_data;
+  Albany::ThyraVDeviceView<const ST> x_data, xdot_data, xdotdot_data;
   x_data = Albany::getDeviceData(x);
   if(!xdot.is_null()) {
     xdot_data = Albany::getDeviceData(xdot);
@@ -378,7 +378,7 @@ evaluateFields(typename Traits::EvalData workset)
   const auto n_coeff = workset.n_coeff;
 
   // Get kokkos views from thyra vectors
-  Albany::DeviceView1d<const ST> x_data, xdot_data, xdotdot_data;
+  Albany::ThyraVDeviceView<const ST> x_data, xdot_data, xdotdot_data;
   x_data = Albany::getDeviceData(x);
   if(!xdot.is_null()) {
     xdot_data = Albany::getDeviceData(xdot);
@@ -480,8 +480,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto elem_dof_lids  = dof_mgr->elem_dof_lids();
   constexpr auto ALL = Kokkos::ALL;
 
-  Albany::DeviceView1d<const ST> x_data, xdot_data, xdotdot_data;
-  Albany::DeviceView2d<const ST> Vx_data, Vxdot_data, Vxdotdot_data;
+  Albany::ThyraVDeviceView<const ST> x_data, xdot_data, xdotdot_data;
+  Albany::ThyraMVDeviceView<const ST> Vx_data, Vxdot_data, Vxdotdot_data;
 
   //get const (read-only) view of x
   x_data = Albany::getDeviceData(x);
@@ -661,7 +661,7 @@ evaluateFields(typename Traits::EvalData workset)
   bool f_px_is_active = !hessian_ws.hess_vec_prod_f_px.is_null();
 
   //get const (read-only) view of x and xdot
-  using const_data_t = Albany::DeviceView1d<const ST>;
+  using const_data_t = Albany::ThyraVDeviceView<const ST>;
   const_data_t x_data, xdot_data, xdotdot_data, direction_x_data;
 
   x_data = Albany::getDeviceData(x);

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -549,12 +549,9 @@ evaluateFields(typename Traits::EvalData workset)
     }
   }
 #else
+
   //get const (read-only) view of x
-  // using const_data_t = Teuchos::ArrayRCP<const ST>;
-  // using const_mv_data_t = Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>>;
-  // const_data_t x_data, xdot_data, xdotdot_data;
-  // const_mv_data_t Vx_data, Vxdot_data, Vxdotdot_data;
-  
+
   Albany::DeviceView1d<const ST> x_data, xdot_data, xdotdot_data;
   Albany::DeviceView2d<const ST> Vx_data, Vxdot_data, Vxdotdot_data;
 

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -593,7 +593,7 @@ evaluateFields(typename Traits::EvalData workset)
         if (gather_Vx) {
           valref = TanFadType(valref.size(), x_data(lid));
           for (int k=0; k<ncolsx; ++k)
-            valref.fastAccessDx(k) = jcoeff*Vx_data(k,lid);
+            valref.fastAccessDx(k) = jcoeff*Vx_data(lid,k);
         } else {
           valref = TanFadType(x_data(lid));
         }
@@ -603,7 +603,7 @@ evaluateFields(typename Traits::EvalData workset)
           valref_dot = TanFadType(valref_dot.size(), xdot_data(lid));
           if (gather_Vxdot) {
             for (int k=0; k<ncolsx; ++k)
-              valref_dot.fastAccessDx(k) = mcoeff*Vxdot_data(k,lid);
+              valref_dot.fastAccessDx(k) = mcoeff*Vxdot_data(lid,k);
           }
         }
 
@@ -612,7 +612,7 @@ evaluateFields(typename Traits::EvalData workset)
           valref_dotdot = TanFadType(valref_dotdot.size(), xdotdot_data(lid));
           if (gather_Vxdotdot) {
             for (int k=0; k<ncolsx; ++k)
-              valref_dotdot.fastAccessDx(k) = ncoeff*Vxdotdot_data(k,lid);
+              valref_dotdot.fastAccessDx(k) = ncoeff*Vxdotdot_data(lid,k);
           }
         }
       }

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -228,6 +228,8 @@ public:
 protected:
   using Base = ScatterResidualBase<AlbanyTraits::Tangent, Traits>;
   using ScalarT = typename Base::ScalarT;
+  using ExecutionSpace = typename Base::ExecutionSpace;
+  using RangePolicy = typename Base::RangePolicy;
 
   using Base::get_resid;
   using Base::numFields;

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -427,16 +427,16 @@ evaluateFields(typename Traits::EvalData workset)
         const auto res = resid.get(cell,node,eq);
 
         if (scatter_f) {
-          Kokkos::atomic_add(f_data(lid), res.val());
+          KU::atomic_add<ExecutionSpace>(&f_data(lid), res.val());
         }
         if (scatter_JV) {
           for (int col=0; col<ncolsx; ++col) {
-            Kokkos::atomic_add(JV_data(lid,col), res.dx(col));
+            KU::atomic_add<ExecutionSpace>(&JV_data(lid,col), res.dx(col));
           }
         }
         if (scatter_fp) {
           for (int col=0; col<ncolsp; ++col) {
-            Kokkos::atomic_add(fp_data(lid,col), res.dx(col + paramoffset));
+            KU::atomic_add<ExecutionSpace>(&fp_data(lid,col), res.dx(col + paramoffset));
           }
         }
       }

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -263,7 +263,7 @@ evaluateFields(typename Traits::EvalData workset)
   const int neq  = dof_mgr->getNumFields();
 
   // Get Kokkos vector view and local matrix
-  Albany::DeviceView1d<ST> f_data;
+  Albany::ThyraVDeviceView<ST> f_data;
   const bool scatter_f = Teuchos::nonnull(workset.f);
   if (scatter_f) {
     f_data = workset.f_kokkos;
@@ -350,8 +350,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto dof_mgr = workset.disc->getDOFManager();
   this->gather_fields_offsets (dof_mgr);
 
-  Albany::DeviceView1d<ST> f_data;
-  Albany::DeviceView2d<ST> JV_data, fp_data;
+  Albany::ThyraVDeviceView<ST> f_data;
+  Albany::ThyraMVDeviceView<ST> JV_data, fp_data;
 
   const auto ws_elem_lids = workset.disc->getWsElementLIDs().dev();
   const auto elem_lids = Kokkos::subview(ws_elem_lids,ws,ALL);

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -394,7 +394,6 @@ evaluateFields(typename Traits::EvalData workset)
       }
     }
   });
-  cudaCheckError();
 }
 
 // **********************************************************************

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -366,7 +366,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   // .val().fastAccessDx().
   const bool is_x_direction_active = g_xx_is_active || g_px_is_active || f_xx_is_active || f_px_is_active;
 
-  Albany::DeviceView1d<const ST> direction_x_data;
+  Albany::ThyraVDeviceView<const ST> direction_x_data;
   if (is_x_direction_active) {
     const auto direction_x = hws.direction_x;
     TEUCHOS_TEST_FOR_EXCEPTION(

--- a/src/utility/Albany_ThyraUtils.cpp
+++ b/src/utility/Albany_ThyraUtils.cpp
@@ -734,6 +734,23 @@ DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector
   return dummy;
 }
 
+DeviceView2d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv)
+{
+  // Allow failure, since we don't know what the underlying linear algebra is
+  auto tv = getTpetraMultiVector(mv,false);
+  if (!tv.is_null()) {
+    DeviceView2d<ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadWrite));
+    return data;
+  }
+
+  // If all the tries above are unsuccessful, throw an error.
+  TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getNonconstDeviceData! Could not cast Thyra_Vector to any of the supported concrete types.\n");
+
+  // Dummy return value, to silence compiler warnings
+  DeviceView2d<ST> dummy;
+  return dummy;
+}
+
 void scale_and_update (const Teuchos::RCP<Thyra_Vector> y, const ST y_coeff,
                        const Teuchos::RCP<const Thyra_Vector> x, const ST x_coeff)
 {

--- a/src/utility/Albany_ThyraUtils.cpp
+++ b/src/utility/Albany_ThyraUtils.cpp
@@ -717,6 +717,23 @@ DeviceView1d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v)
   return dummy;
 }
 
+DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv)
+{
+  // Allow failure, since we don't know what the underlying linear algebra is
+  auto tv = getConstTpetraMultiVector(mv,false);
+  if (!tv.is_null()) {
+    DeviceView2d<const ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadOnly));
+    return data;
+  }
+
+  // If all the tries above are unsuccessful, throw an error.
+  TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getDeviceData! Could not cast Thyra_MultiVector to any of the supported concrete types.\n");
+
+  // Dummy return value, to silence compiler warnings
+  DeviceView2d<const ST> dummy;
+  return dummy;
+}
+
 void scale_and_update (const Teuchos::RCP<Thyra_Vector> y, const ST y_coeff,
                        const Teuchos::RCP<const Thyra_Vector> x, const ST x_coeff)
 {

--- a/src/utility/Albany_ThyraUtils.cpp
+++ b/src/utility/Albany_ThyraUtils.cpp
@@ -681,13 +681,13 @@ Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>> getLocalData (const Thyra_MultiVe
   return data;
 }
 
-DeviceView1d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v)
+ThyraVDeviceView<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v)
 {
   // Allow failure, since we don't know what the underlying linear algebra is
   auto tv = getConstTpetraVector(v,false);
   if (!tv.is_null()) {
     auto data2d = tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadOnly);
-    DeviceView1d<const ST> data = Kokkos::subview(data2d, Kokkos::ALL(), 0);
+    ThyraVDeviceView<const ST> data = Kokkos::subview(data2d, Kokkos::ALL(), 0);
     return data;
   }
 
@@ -695,17 +695,17 @@ DeviceView1d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v)
   TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getDeviceData! Could not cast Thyra_Vector to any of the supported concrete types.\n");
 
   // Dummy return value, to silence compiler warnings
-  DeviceView1d<const ST> dummy;
+  ThyraVDeviceView<const ST> dummy;
   return dummy;
 }
 
-DeviceView1d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v)
+ThyraVDeviceView<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v)
 {
   // Allow failure, since we don't know what the underlying linear algebra is
   auto tv = getTpetraVector(v,false);
   if (!tv.is_null()) {
     auto data2d = tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadWrite);
-    DeviceView1d<ST> data = Kokkos::subview(data2d, Kokkos::ALL(), 0);
+    ThyraVDeviceView<ST> data = Kokkos::subview(data2d, Kokkos::ALL(), 0);
     return data;
   }
 
@@ -713,16 +713,16 @@ DeviceView1d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v)
   TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getNonconstDeviceData! Could not cast Thyra_Vector to any of the supported concrete types.\n");
 
   // Dummy return value, to silence compiler warnings
-  DeviceView1d<ST> dummy;
+  ThyraVDeviceView<ST> dummy;
   return dummy;
 }
 
-DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv)
+ThyraMVDeviceView<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv)
 {
   // Allow failure, since we don't know what the underlying linear algebra is
   auto tv = getConstTpetraMultiVector(mv,false);
   if (!tv.is_null()) {
-    DeviceView2d<const ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadOnly));
+    ThyraMVDeviceView<const ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadOnly));
     return data;
   }
 
@@ -730,16 +730,16 @@ DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector
   TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getDeviceData! Could not cast Thyra_MultiVector to any of the supported concrete types.\n");
 
   // Dummy return value, to silence compiler warnings
-  DeviceView2d<const ST> dummy;
+  ThyraMVDeviceView<const ST> dummy;
   return dummy;
 }
 
-DeviceView2d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv)
+ThyraMVDeviceView<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv)
 {
   // Allow failure, since we don't know what the underlying linear algebra is
   auto tv = getTpetraMultiVector(mv,false);
   if (!tv.is_null()) {
-    DeviceView2d<ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadWrite));
+    ThyraMVDeviceView<ST> data(tv->getLocalView<KokkosNode::execution_space>(Tpetra::Access::ReadWrite));
     return data;
   }
 
@@ -747,7 +747,7 @@ DeviceView2d<ST> getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& m
   TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error, "Error in getNonconstDeviceData! Could not cast Thyra_Vector to any of the supported concrete types.\n");
 
   // Dummy return value, to silence compiler warnings
-  DeviceView2d<ST> dummy;
+  ThyraMVDeviceView<ST> dummy;
   return dummy;
 }
 

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -150,6 +150,7 @@ DeviceView1d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v)
 DeviceView1d<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v);
 
 DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv);
+DeviceView2d<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv);
 
 // This is just a utility routine, that mildly extend the update method of Thyra_Vector,
 // but does not have the complex signature of the linear_combination method of Thyra_Vector.

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -149,6 +149,8 @@ Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>> getLocalData (const Thyra_MultiVe
 DeviceView1d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v);
 DeviceView1d<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v);
 
+DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv);
+
 // This is just a utility routine, that mildly extend the update method of Thyra_Vector,
 // but does not have the complex signature of the linear_combination method of Thyra_Vector.
 // In fact, the update method only allows to do y = y + alpha*x, while often one wants

--- a/src/utility/Albany_ThyraUtils.hpp
+++ b/src/utility/Albany_ThyraUtils.hpp
@@ -146,11 +146,11 @@ Teuchos::ArrayRCP<const ST> getLocalData (const Thyra_Vector& v);
 Teuchos::ArrayRCP<Teuchos::ArrayRCP<ST>> getNonconstLocalData (Thyra_MultiVector& mv);
 Teuchos::ArrayRCP<Teuchos::ArrayRCP<const ST>> getLocalData (const Thyra_MultiVector& mv);
 
-DeviceView1d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v);
-DeviceView1d<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v);
+ThyraVDeviceView<const ST> getDeviceData (const Teuchos::RCP<const Thyra_Vector>& v);
+ThyraVDeviceView<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_Vector>& v);
 
-DeviceView2d<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv);
-DeviceView2d<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv);
+ThyraMVDeviceView<const ST> getDeviceData (const Teuchos::RCP<const Thyra_MultiVector>& mv);
+ThyraMVDeviceView<ST>       getNonconstDeviceData (const Teuchos::RCP<Thyra_MultiVector>& mv);
 
 // This is just a utility routine, that mildly extend the update method of Thyra_Vector,
 // but does not have the complex signature of the linear_combination method of Thyra_Vector.

--- a/tests/unit/evaluators/DOFInterpolation.cpp
+++ b/tests/unit/evaluators/DOFInterpolation.cpp
@@ -87,15 +87,17 @@ TEUCHOS_UNIT_TEST(DOFInterpolation, Scalar)
   nodal_f.deep_copy(6);
 
   auto coord_vec = PHX::allocateUnmanagedMDField<Scalar,Cell,Vertex,Dim>(Albany::coord_vec_name, dl->vertices_vector);
+  auto coord_vec_dev  = coord_vec.get_view();
+  auto coord_vec_host = Kokkos::create_mirror_view(coord_vec_dev);
   auto coord_mesh = disc->getCoords();
   for (int cell=0; cell<num_cells; ++cell) {
     for (int node=0; node<nodes_per_element; ++node) {
       for (int dim=0; dim<num_dims; ++dim) {
-        coord_vec(cell,node,dim) = coord_mesh[0][cell][node][dim];
+        coord_vec_host(cell,node,dim) = coord_mesh[0][cell][node][dim];
       }
     }
   }
-  Kokkos::fence();
+  Kokkos::deep_copy(coord_vec_dev, coord_vec_host);
 
   // Create expected field
   auto qp_f = PHX::allocateUnmanagedMDField<Scalar,Cell,QuadPoint>("x", dl->qp_scalar);

--- a/tests/unit/evaluators/ScatterResidual.cpp
+++ b/tests/unit/evaluators/ScatterResidual.cpp
@@ -115,24 +115,26 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
   ov_hess_vec_prod_f_px_out->assign(0.0);
   ov_hess_vec_prod_f_pp_out->assign(0.0);
 
-  auto ov_hess_vec_prod_f_xx_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xx_out);
-  auto ov_hess_vec_prod_f_xp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xp_out);
-  auto ov_hess_vec_prod_f_px_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_px_out);
-  auto ov_hess_vec_prod_f_pp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_pp_out);
+  {
+    auto ov_hess_vec_prod_f_xx_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xx_out);
+    auto ov_hess_vec_prod_f_xp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xp_out);
+    auto ov_hess_vec_prod_f_px_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_px_out);
+    auto ov_hess_vec_prod_f_pp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_pp_out);
 
-  auto p_elem_dof_lids = p_dof_mgr->elem_dof_lids().host();
-  auto x_elem_dof_lids = x_dof_mgr->elem_dof_lids().host();
-  for (int cell=0; cell<num_cells; ++cell) {
-    // NOTE: in this test, we have 1 workset, so cell==elem_LID
-    auto p_dof_lids = Kokkos::subview(p_elem_dof_lids,cell,ALL);
-    auto x_dof_lids = Kokkos::subview(x_elem_dof_lids,cell,ALL);
-    for (size_t i=0; i<p_dof_lids.size(); ++i) {
-      ov_hess_vec_prod_f_px_out_data[p_dof_lids[i]] += 4.0;
-      ov_hess_vec_prod_f_pp_out_data[p_dof_lids[i]] += 4.0;
-    }
-    for (size_t i=0; i<x_dof_lids.size(); ++i) {
-      ov_hess_vec_prod_f_xx_out_data[x_dof_lids[i]] += 4.0;
-      ov_hess_vec_prod_f_xp_out_data[x_dof_lids[i]] += 4.0;
+    auto p_elem_dof_lids = p_dof_mgr->elem_dof_lids().host();
+    auto x_elem_dof_lids = x_dof_mgr->elem_dof_lids().host();
+    for (int cell=0; cell<num_cells; ++cell) {
+      // NOTE: in this test, we have 1 workset, so cell==elem_LID
+      auto p_dof_lids = Kokkos::subview(p_elem_dof_lids,cell,ALL);
+      auto x_dof_lids = Kokkos::subview(x_elem_dof_lids,cell,ALL);
+      for (size_t i=0; i<p_dof_lids.size(); ++i) {
+        ov_hess_vec_prod_f_px_out_data[p_dof_lids[i]] += 4.0;
+        ov_hess_vec_prod_f_pp_out_data[p_dof_lids[i]] += 4.0;
+      }
+      for (size_t i=0; i<x_dof_lids.size(); ++i) {
+        ov_hess_vec_prod_f_xx_out_data[x_dof_lids[i]] += 4.0;
+        ov_hess_vec_prod_f_xp_out_data[x_dof_lids[i]] += 4.0;
+      }
     }
   }
 
@@ -170,11 +172,14 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank0)
   std::vector<PHX::index_size_type> deriv_dims;
   deriv_dims.push_back(nodes_per_element * neq);
   auto residual = PHX::allocateUnmanagedMDField<Scalar, Cell, Node>("res", dl->node_scalar, deriv_dims);
+  auto residual_dev = residual.get_view();
+  auto residual_host = Kokkos::create_mirror_view(residual_dev);
 
   for (int cell=0; cell<num_cells; ++cell)
     for (int node1=0; node1<nodes_per_element; ++node1)
       for (int node2=0; node2<nodes_per_element; ++node2)
-        residual(cell, node1).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+        residual_host(cell, node1).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+  Kokkos::deep_copy(residual_dev, residual_host);
 
   // Create evaluator
   Teuchos::ParameterList p("ScatterResidual Unit Test");
@@ -467,24 +472,26 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank1)
   ov_hess_vec_prod_f_px_out->assign(0.0);
   ov_hess_vec_prod_f_pp_out->assign(0.0);
 
-  auto ov_hess_vec_prod_f_xx_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xx_out);
-  auto ov_hess_vec_prod_f_xp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xp_out);
-  auto ov_hess_vec_prod_f_px_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_px_out);
-  auto ov_hess_vec_prod_f_pp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_pp_out);
+  {
+    auto ov_hess_vec_prod_f_xx_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xx_out);
+    auto ov_hess_vec_prod_f_xp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_xp_out);
+    auto ov_hess_vec_prod_f_px_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_px_out);
+    auto ov_hess_vec_prod_f_pp_out_data = Albany::getNonconstLocalData(ov_hess_vec_prod_f_pp_out);
 
-  auto p_elem_dof_lids = p_dof_mgr->elem_dof_lids().host();
-  auto x_elem_dof_lids = x_dof_mgr->elem_dof_lids().host();
-  for (int cell=0; cell<num_cells; ++cell) {
-    // NOTE: in this test, we have 1 workset, so cell==elem_LID
-    auto p_dof_lids = Kokkos::subview(p_elem_dof_lids,cell,ALL);
-    auto x_dof_lids = Kokkos::subview(x_elem_dof_lids,cell,ALL);
-    for (size_t i=0; i<p_dof_lids.size(); ++i) {
-      ov_hess_vec_prod_f_px_out_data[p_dof_lids[i]] += 12.0;
-      ov_hess_vec_prod_f_pp_out_data[p_dof_lids[i]] += 12.0;
-    }
-    for (size_t i=0; i<x_dof_lids.size(); ++i) {
-      ov_hess_vec_prod_f_xx_out_data[x_dof_lids[i]] += 12.0;
-      ov_hess_vec_prod_f_xp_out_data[x_dof_lids[i]] += 12.0;
+    auto p_elem_dof_lids = p_dof_mgr->elem_dof_lids().host();
+    auto x_elem_dof_lids = x_dof_mgr->elem_dof_lids().host();
+    for (int cell=0; cell<num_cells; ++cell) {
+      // NOTE: in this test, we have 1 workset, so cell==elem_LID
+      auto p_dof_lids = Kokkos::subview(p_elem_dof_lids,cell,ALL);
+      auto x_dof_lids = Kokkos::subview(x_elem_dof_lids,cell,ALL);
+      for (size_t i=0; i<p_dof_lids.size(); ++i) {
+        ov_hess_vec_prod_f_px_out_data[p_dof_lids[i]] += 12.0;
+        ov_hess_vec_prod_f_pp_out_data[p_dof_lids[i]] += 12.0;
+      }
+      for (size_t i=0; i<x_dof_lids.size(); ++i) {
+        ov_hess_vec_prod_f_xx_out_data[x_dof_lids[i]] += 12.0;
+        ov_hess_vec_prod_f_xp_out_data[x_dof_lids[i]] += 12.0;
+      }
     }
   }
 
@@ -522,14 +529,18 @@ TEUCHOS_UNIT_TEST(evaluator_unit_tester, scatterResidualHessianVecTensorRank1)
   std::vector<PHX::index_size_type> deriv_dims;
   deriv_dims.push_back(nodes_per_element * neq);
   auto residual = PHX::allocateUnmanagedMDField<Scalar, Cell, Node, VecDim>("res", dl->node_vector, deriv_dims);
+  auto residual_dev = residual.get_view();
+  auto residual_host = Kokkos::create_mirror_view(residual_dev);
   residual.deep_copy(0.0);
+  Kokkos::deep_copy(residual_host, residual_dev);
 
   for (int cell=0; cell<num_cells; ++cell)
     for (int node1=0; node1<nodes_per_element; ++node1)
       for (int dim=0; dim<neq; ++dim)
         for (int node2=0; node2<nodes_per_element*neq; ++node2)
           // residual(cell, node1, dim).fastAccessDx(node2*neq+oim).fastAccessDx(0) = 0.5;
-          residual(cell, node1, dim).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+          residual_host(cell, node1, dim).fastAccessDx(node2).fastAccessDx(0) = 0.5;
+  Kokkos::deep_copy(residual_dev, residual_host);
 
   // Create evaluator
   Teuchos::ParameterList p("ScatterResidual Unit Test");


### PR DESCRIPTION
This PR ports a number of gather and scatter specializations to run on device and some additional utilities in ThyraUtils for getting device views from Thyra_Multivectors. Additionally, unit tests were updated to avoid ambiguous host/device accesses causing them to fail with uvm-free builds.