### PR TITLE
Remove Albany timers and add kernel names

### DIFF
--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -265,10 +265,6 @@ template<typename Traits>
 void GatherSolution<PHAL::AlbanyTraits::Residual, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-#ifdef ALBANY_TIMER
-  auto start = std::chrono::high_resolution_clock::now();
-#endif
-
   const auto& x       = workset.x;
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
@@ -299,7 +295,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto elem_lids_dev     = Kokkos::subview(elem_lids.dev(),ws,ALL);
   const auto elem_dof_lids_dev = elem_dof_lids.dev();
   const auto fields_offsets = m_fields_offsets.dev();
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids_dev(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids.dev(),elem_LID,ALL);
@@ -316,14 +313,6 @@ evaluateFields(typename Traits::EvalData workset)
       }
     }
   });
-
-#ifdef ALBANY_TIMER
-  PHX::Device::fence();
-  auto elapsed = std::chrono::high_resolution_clock::now() - start;
-  long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-  long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-  std::cout<< "GaTher Solution Residual time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
 }
 
 // **********************************************************************
@@ -352,10 +341,6 @@ template<typename Traits>
 void GatherSolution<PHAL::AlbanyTraits::Jacobian, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-#ifdef ALBANY_TIMER
-  auto start = std::chrono::high_resolution_clock::now();
-#endif
-
   const auto& x       = workset.x;
   const auto& xdot    = workset.xdot;
   const auto& xdotdot = workset.xdotdot;
@@ -391,7 +376,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto elem_lids_dev     = Kokkos::subview(elem_lids.dev(),ws,ALL);
   const auto elem_dof_lids_dev = elem_dof_lids.dev();
   const auto fields_offsets = m_fields_offsets.dev();
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA (const int& cell) {
     const auto elem_LID = elem_lids_dev(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids.dev(),elem_LID,ALL);
@@ -418,14 +404,6 @@ evaluateFields(typename Traits::EvalData workset)
       }
     }
   });
-
-#ifdef ALBANY_TIMER
-  PHX::Device::fence();
-  auto elapsed = std::chrono::high_resolution_clock::now() - start;
-  long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-  long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-  std::cout<< "GaTher Solution Jacobian time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
 }
 
 // **********************************************************************
@@ -505,7 +483,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto jcoeff = workset.j_coeff;
   const auto mcoeff = workset.m_coeff;
   const auto ncoeff = workset.n_coeff;
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids_dev(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids.dev(),elem_LID,ALL);
@@ -704,7 +683,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto& first_dof = this->offset;
 
   const auto elem_lids_dev = Kokkos::subview(elem_lids.dev(),ws,ALL);
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids_dev(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);

--- a/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFVecGradInterpolation_Def.hpp
@@ -11,10 +11,6 @@
 
 #include "Intrepid2_FunctionSpaceTools.hpp"
 
-#ifdef ALBANY_TIMER
-#include <chrono>
-#endif
-
 namespace PHAL {
 
   //**********************************************************************
@@ -88,20 +84,8 @@ namespace PHAL {
   {
     if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
-#ifdef ALBANY_TIMER
-    PHX::Device::fence();
-    auto start = std::chrono::high_resolution_clock::now();
-#endif
     //Kokkos::deep_copy(grad_val_qp.get_kokkos_view(), 0.0);
-    Kokkos::parallel_for(DOFVecGradInterpolationBase_Residual_Policy(0,workset.numCells),*this);
-
-#ifdef ALBANY_TIMER
-    PHX::Device::fence();
-    auto elapsed = std::chrono::high_resolution_clock::now() - start;
-    long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-    std::cout<< "DOFVecGradInterpolationBase Residual time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
+    Kokkos::parallel_for(this->getName(),DOFVecGradInterpolationBase_Residual_Policy(0,workset.numCells),*this);
   }
 
   // Specialization for Jacobian evaluation taking advantage of known sparsity
@@ -132,20 +116,8 @@ namespace PHAL {
   void FastSolutionVecGradInterpolationBase<PHAL::AlbanyTraits::Jacobian, Traits, typename PHAL::AlbanyTraits::Jacobian::ScalarT>::
   evaluateFields(typename Traits::EvalData workset)
   {
-#ifdef ALBANY_TIMER
-    auto start = std::chrono::high_resolution_clock::now();
-#endif
-
     neq = workset.disc->getDOFManager()->getNumFields();
-    Kokkos::parallel_for(FastSolutionVecGradInterpolationBase_Jacobian_Policy(0,workset.numCells),*this);
-
-#ifdef ALBANY_TIMER
-    PHX::Device::fence();
-    auto elapsed = std::chrono::high_resolution_clock::now() - start;
-    long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-    long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-    std::cout<< "FastSolutionVecGradInterpolationBase Jacobian time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
+    Kokkos::parallel_for(this->getName(),FastSolutionVecGradInterpolationBase_Jacobian_Policy(0,workset.numCells),*this);
   }
 
 } // Namespace PHAL

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -4,10 +4,6 @@
 //    in the file "license.txt" in the top-level Albany directory  //
 //*****************************************************************//
 
-#ifdef ALBANY_TIMER
-#include <chrono>
-#endif
-
 #include "Teuchos_TestForException.hpp"
 #include "Phalanx_DataLayout.hpp"
 
@@ -160,10 +156,6 @@ template<typename Traits>
 void ScatterResidual<AlbanyTraits::Residual, Traits>::
 evaluateFields(typename Traits::EvalData workset)
 {
-#ifdef ALBANY_TIMER
-  auto start = std::chrono::high_resolution_clock::now();
-#endif
-
   const auto f = workset.f;
 
   constexpr auto ALL = Kokkos::ALL();
@@ -179,7 +171,8 @@ evaluateFields(typename Traits::EvalData workset)
   auto f_data = Albany::getNonconstDeviceData(f);
 
   const auto& fields_offsets = m_fields_offsets.dev();
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
@@ -190,14 +183,6 @@ evaluateFields(typename Traits::EvalData workset)
       }
     }
   });
-
-#ifdef ALBANY_TIMER
-  PHX::Device::fence();
-  auto elapsed = std::chrono::high_resolution_clock::now() - start;
-  long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-  long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-  std::cout<< "Scatter Residual time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
 }
 
 // **********************************************************************
@@ -247,10 +232,6 @@ evaluateFields(typename Traits::EvalData workset)
     m_volume_eqns_offsets.sync_to_dev();
   }
 
-#ifdef ALBANY_TIMER
-  auto start = std::chrono::high_resolution_clock::now();
-#endif
-
   constexpr auto ALL = Kokkos::ALL();
 
   const int ws  = workset.wsIndex;
@@ -278,7 +259,8 @@ evaluateFields(typename Traits::EvalData workset)
     m_lids.resize("",nunk);
   }
   const auto lids = m_lids.dev();
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int cell) {
     ST vals[500];
     const auto elem_LID = elem_lids(cell);
@@ -307,14 +289,6 @@ evaluateFields(typename Traits::EvalData workset)
       }
     }
   });
-
-#ifdef ALBANY_TIMER
-  PHX::Device::fence();
-  auto elapsed = std::chrono::high_resolution_clock::now() - start;
-  long long microseconds = std::chrono::duration_cast<std::chrono::microseconds>(elapsed).count();
-  long long millisec= std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count();
-  std::cout<< "Scatter Jacobian time = "  << millisec << "  "  << microseconds << std::endl;
-#endif
 }
 
 // **********************************************************************
@@ -369,7 +343,8 @@ evaluateFields(typename Traits::EvalData workset)
   const auto ncolsp = workset.num_cols_p;
   const auto paramoffset = workset.param_offset;
 
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),
+                       RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids(cell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);

--- a/src/utility/Albany_UnivariateDistribution.hpp
+++ b/src/utility/Albany_UnivariateDistribution.hpp
@@ -23,6 +23,7 @@ namespace Albany
       {
         // Nothing to be done here
       }
+      virtual ~UnivariatDistribution() = default;
       virtual double cdf(const double x) = 0;
       virtual double cdf_dx(const double x) = 0;
       virtual double cdf_dx_dx(const double x) = 0;


### PR DESCRIPTION
We should use kokkos-tools instead. This also fixes a warning about non virtual destructor.