### PR TITLE
Fix bug related to Kokkos::vector replacement

### DIFF
--- a/src/evaluators/gather/PHAL_GatherSolution.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution.hpp
@@ -130,8 +130,8 @@ protected:
 public:
   struct SolAccessor {
     using DynRankView = Kokkos::DynRankView<ScalarT, PHX::Device>;
-    using KV = Kokkos::DualView<DynRankView*, PHX::Device>;
-    using t_dev = typename KV::t_dev;
+    using DRVDualView = Kokkos::DualView<DynRankView*, PHX::Device>;
+    using t_dev = typename DRVDualView::t_dev;
     
     KOKKOS_INLINE_FUNCTION
     ref_t get_ref (const int cell, const int node, const int eq) const {
@@ -174,7 +174,7 @@ public:
 
     int tensorRank;
     int numDim;
-    KV val_kokkos, val_dot_kokkos, val_dotdot_kokkos;
+    DRVDualView val_kokkos, val_dot_kokkos, val_dotdot_kokkos;
     t_dev d_val, d_val_dot, d_val_dotdot;
     DynRankView d_valVec, d_valVec_dot, d_valVec_dotdot;
     DynRankView d_valTensor, d_valTensor_dot, d_valTensor_dotdot;

--- a/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherSolution_Def.hpp
@@ -138,10 +138,16 @@ GatherSolutionBase(const Teuchos::ParameterList& p,
 
   if ( tensorRank == 0 ) {
     device_sol.val_kokkos.resize(numFields);
+    device_sol.val_kokkos.sync_host();
+    device_sol.val_kokkos.sync_device();
     if (enableTransient)
       device_sol.val_dot_kokkos.resize(numFields);
+      device_sol.val_dot_kokkos.sync_host();
+      device_sol.val_dot_kokkos.sync_device();
     if (enableAcceleration)
       device_sol.val_dotdot_kokkos.resize(numFields);
+      device_sol.val_dotdot_kokkos.sync_host();
+      device_sol.val_dotdot_kokkos.sync_device();
   }
 
   if (p.isType<int>("Offset of First DOF"))

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -96,8 +96,8 @@ protected:
 public:
   struct ResidAccessor {
     using DynRankView = Kokkos::DynRankView<const ScalarT, PHX::Device>;
-    using KV = Kokkos::DualView<DynRankView*, PHX::Device>;
-    using t_dev = typename KV::t_dev;
+    using DRVDualView = Kokkos::DualView<DynRankView*, PHX::Device>;
+    using t_dev = typename DRVDualView::t_dev;
 
     KOKKOS_INLINE_FUNCTION
     ScalarT get (const int cell, const int node, const int eq) const {
@@ -114,7 +114,7 @@ public:
 
     int tensorRank;
     int numDim;
-    KV val_kokkos;
+    DRVDualView val_kokkos;
     t_dev d_val;
     DynRankView d_valVec, d_valTensor;
   };

--- a/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual_Def.hpp
@@ -71,6 +71,8 @@ ScatterResidualBase(const Teuchos::ParameterList& p,
 
   if (tensorRank == 0) {
     device_resid.val_kokkos.resize(numFields);
+    device_resid.val_kokkos.sync_host();
+    device_resid.val_kokkos.sync_device();
   }
 
   if (p.isType<int>("Offset of First DOF")) {


### PR DESCRIPTION
This PR fixes a bug that only shows up in debug builds and was introduced by the recent changes to replace Kokkos::vector. DualView's `resize` sets the modify flag on device and then a later call to `modify_host` causes the modify flag to be true on both host and device. With a debug build, this situation causes an exception to be thrown.

This fix adds a sync after the resize to clear the modify flags. Looking at the implementation of DualView's `resize`, it looks like there might be situations where the host modify flag is set instead. Therefore, I've added syncs for host and device just in case. It's not an elegant solution but whichever one is unnecessary will be a no-op.