### PR TITLE
Fix PyAlbany_MatrixOperations_MPI

### DIFF
--- a/pyAlbany/tests/linearAlgebra/CMakeLists.txt
+++ b/pyAlbany/tests/linearAlgebra/CMakeLists.txt
@@ -15,5 +15,5 @@ set_tests_properties(PyAlbany_MatrixOperations
 
 add_test(PyAlbany_MatrixOperations_MPI "${MPIEX}" "${MPINPF}" "${ALBANY_PYTHON_N_MPI}" "${PYTHON_EXECUTABLE}" "${CMAKE_CURRENT_BINARY_DIR}/matrixOperations.py")
 
-set_tests_properties(PyAlbany_MatrixOperations
+set_tests_properties(PyAlbany_MatrixOperations_MPI
     PROPERTIES ENVIRONMENT "${PYALBANY_PYTHONPATH}")


### PR DESCRIPTION
This PR should fix our nightly issue: #1038

The environment property of the MPI version of the test was not set correctly and therefore the test was unable to find the required Python libraries.

@mperego @ikalash 