### PR TITLE
Store Omega_h::Mesh objects via pointers

### DIFF
--- a/src/disc/omegah/Albany_OmegahBoxMesh_Def.hpp
+++ b/src/disc/omegah/Albany_OmegahBoxMesh_Def.hpp
@@ -58,20 +58,20 @@ OmegahBoxMesh (const Teuchos::RCP<Teuchos::ParameterList>& params,
   // Create the omegah mesh obj
   Topo_type elem_topo;
   if (topo_str=="Simplex") {
-    m_mesh = Omega_h::build_box(get_omegah_lib().world(),OMEGA_H_SIMPLEX,
-                                scalex,scaley,scalez,nelemx,nelemy,nelemz);
+    m_mesh = Teuchos::rcp(new Omega_h::Mesh(Omega_h::build_box(get_omegah_lib().world(),OMEGA_H_SIMPLEX,
+                                            scalex,scaley,scalez,nelemx,nelemy,nelemz)));
     elem_topo = Dim==3 ? Topo_type::tetrahedron
                        : Dim==2 ? Topo_type::triangle : Topo_type::edge;
   } else {
-    m_mesh = Omega_h::build_box(get_omegah_lib().world(),OMEGA_H_HYPERCUBE,
-                                scalex,scaley,scalez,nelemx,nelemy,nelemz);
+    m_mesh = Teuchos::rcp(new Omega_h::Mesh(Omega_h::build_box(get_omegah_lib().world(),OMEGA_H_HYPERCUBE,
+                                            scalex,scaley,scalez,nelemx,nelemy,nelemz)));
 
     elem_topo = Dim==3 ? Topo_type::hexahedron
                        : Dim==2 ? Topo_type::quadrilateral : Topo_type::edge;
   }
 
-  m_mesh.set_parting(OMEGA_H_ELEM_BASED);
-  m_coords_d = m_mesh.coords().view();
+  m_mesh->set_parting(OMEGA_H_ELEM_BASED);
+  m_coords_d = m_mesh->coords().view();
   m_coords_h = Kokkos::create_mirror_view(m_coords_d);
   Kokkos::deep_copy(m_coords_h,m_coords_d);
 
@@ -95,7 +95,7 @@ OmegahBoxMesh (const Teuchos::RCP<Teuchos::ParameterList>& params,
 
   std::vector<NsSpecs> nsSpecs;
   Omega_h::Read<I8> tag;
-  for (int idim=0; idim<m_mesh.dim(); ++idim) {
+  for (int idim=0; idim<m_mesh->dim(); ++idim) {
     nsNames.push_back("NodeSet" + std::to_string(idim*2));
     tag = create_ns_tag(nsNames.back(),idim,0);
     this->declare_part(nsNames.back(),Topo_type::vertex,tag,false);
@@ -121,7 +121,7 @@ OmegahBoxMesh (const Teuchos::RCP<Teuchos::ParameterList>& params,
 
   this->meshSpecs.resize(1);
   this->meshSpecs[0] = Teuchos::rcp(new MeshSpecsStruct(*ctd, Dim,
-                             nsNames, ssNames, m_mesh.nelems(), ebName,
+                             nsNames, ssNames, m_mesh->nelems(), ebName,
                              ebNameToIndex));
 }
 
@@ -131,7 +131,7 @@ create_ns_tag (const std::string& name,
                const int comp,
                const double tgt_value) const
 {
-  Omega_h::Write<Omega_h::I8> tag (m_mesh.nverts(),1);
+  Omega_h::Write<Omega_h::I8> tag (m_mesh->nverts(),1);
   auto coords = m_coords_d;
   auto mdim = Dim;
   auto f = OMEGA_H_LAMBDA (LO inode) {

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -50,7 +50,7 @@ updateMesh ()
   // NOTE: these arrays are all of size 1, for the foreseable future.
   //       Still, make impl generic (where possible), in case things change.
   const auto& ms = m_mesh_struct->meshSpecs[0];
-  const auto& mesh = m_mesh_struct->getOmegahMesh();
+  const auto& mesh = *m_mesh_struct->getOmegahMesh();
   int nelems = mesh.nelems();
   int max_ws_size = ms->worksetSize;
   int num_ws = 1 + (nelems-1) / max_ws_size;
@@ -119,7 +119,7 @@ computeNodeSets ()
   using Omega_h::I32;
   using Omega_h::I8;
 
-  auto& mesh = m_mesh_struct->getOmegahMesh();
+  auto& mesh = *m_mesh_struct->getOmegahMesh();
 
   auto v2e = mesh.ask_up(0,mesh.dim());
   auto v2e_a2ab = hostRead(v2e.a2ab);

--- a/src/disc/omegah/Albany_OmegahGenericMesh.cpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.cpp
@@ -33,13 +33,13 @@ declare_part (const std::string& name, const Topo_type topo)
       "  - new  topo: " << e2str(topo) << "\n");
 
   // Check that this topo matches the topo of one of the element sub-entities topos
-  TEUCHOS_TEST_FOR_EXCEPTION (not m_mesh.has_ents(topo_dim(topo)), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not m_mesh->has_ents(topo_dim(topo)), std::logic_error,
       "[OmegahGenericMesh::declare_part] Mesh does not store any entity of the input topology.\n"
       "  - part name: " << name << "\n"
       "  - part dim : " << topo_dim(topo) << "\n"
       "  - part topo: " << e2str(topo) << "\n"
-      "  - mesh dim : " << m_mesh.dim() << "\n"
-      "  - mesh type: " << e2str(m_mesh.family()) << "\n");
+      "  - mesh dim : " << m_mesh->dim() << "\n"
+      "  - mesh type: " << e2str(m_mesh->family()) << "\n");
 
   // All good, store it
   m_part_topo[name] = topo;
@@ -65,18 +65,18 @@ mark_part_entities (const std::string& name,
 
   auto dim = topo_dim(m_part_topo[name]);
 
-  TEUCHOS_TEST_FOR_EXCEPTION (is_entity_in_part.size()!=m_mesh.nents(dim), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (is_entity_in_part.size()!=m_mesh->nents(dim), std::logic_error,
       "[OmegahGenericMesh::set_part_entities] Error! Input array has the wrong dimensions.\n"
       "  - part name: " << name << "\n"
       "  - part dim : " << dim << "\n"
-      "  - num ents : " << m_mesh.nents(dim) << "\n"
+      "  - num ents : " << m_mesh->nents(dim) << "\n"
       "  - array dim: " << is_entity_in_part.size() << "\n");
-  TEUCHOS_TEST_FOR_EXCEPTION (m_mesh.has_tag(dim,name), std::runtime_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (m_mesh->has_tag(dim,name), std::runtime_error,
       "[OmegahGenericMesh::set_part_entities] Error! A tag with this name was already set.\n"
       "  - part name: " << name << "\n"
       "  - part dim : " << dim << "\n");
 
-  m_mesh.add_tag(dim,name,1,is_entity_in_part);
+  m_mesh->add_tag(dim,name,1,is_entity_in_part);
 
   if (markDownward) {
     TEUCHOS_TEST_FOR_EXCEPTION (dim==0, std::logic_error,
@@ -96,11 +96,11 @@ mark_part_entities (const std::string& name,
     while (topo!=Topo_type::vertex) {
       const auto down_topo = get_side_topo(topo);
 
-      Omega_h::Write<Omega_h::I8> downMarked (m_mesh.nents(topo_dim(down_topo)),0);
+      Omega_h::Write<Omega_h::I8> downMarked (m_mesh->nents(topo_dim(down_topo)),0);
 
       const int deg = Omega_h::element_degree(topo,down_topo);
 
-      auto adj = m_mesh.ask_down(topo_dim(topo),topo_dim(down_topo));
+      auto adj = m_mesh->ask_down(topo_dim(topo),topo_dim(down_topo));
       auto f = OMEGA_H_LAMBDA (LO i) {
         if (upMarked[i]) {
           for (int j=0; j<deg; ++j) {
@@ -110,8 +110,8 @@ mark_part_entities (const std::string& name,
           }
         }
       };
-      Kokkos::parallel_for ("OmegahGenericMesh::set_part_entities::markDownward",m_mesh.nents(topo_dim(topo)),f);
-      m_mesh.add_tag(topo_dim(down_topo),name,1,read(downMarked));
+      Kokkos::parallel_for ("OmegahGenericMesh::set_part_entities::markDownward",m_mesh->nents(topo_dim(topo)),f);
+      m_mesh->add_tag(topo_dim(down_topo),name,1,read(downMarked));
       upMarked = downMarked;
 
       topo = down_topo;

--- a/src/disc/omegah/Albany_OmegahGenericMesh.hpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.hpp
@@ -25,8 +25,8 @@ public:
 
   Teuchos::RCP<OmegahMeshFieldAccessor> get_field_accessor () const { return m_field_accessor; }
 
-  const Omega_h::Mesh& getOmegahMesh () const { return m_mesh; }
-        Omega_h::Mesh& getOmegahMesh ()       { return m_mesh; }
+        Teuchos::RCP<const Omega_h::Mesh>  getOmegahMesh () const { return m_mesh.getConst(); }
+  const Teuchos::RCP<      Omega_h::Mesh>& getOmegahMesh ()       { return m_mesh; }
 
   bool hasRestartSolution () const { return m_has_restart_solution; }
 
@@ -49,7 +49,7 @@ public:
 
 protected:
 
-  Omega_h::Mesh  m_mesh;
+  Teuchos::RCP<Omega_h::Mesh>  m_mesh;
 
   // Given a part name, returns its topology (in the form of an Omega_h enum
   std::map<std::string,Topo_type>  m_part_topo;

--- a/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
+++ b/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
@@ -5,7 +5,7 @@
 namespace Albany {
 
 OmegahMeshFieldAccessor::
-OmegahMeshFieldAccessor (const Omega_h::Mesh& mesh)
+OmegahMeshFieldAccessor (const Teuchos::RCP<Omega_h::Mesh>& mesh)
  : m_mesh (mesh)
 {
   // Nothing to do here
@@ -20,8 +20,8 @@ addFieldOnMesh (const std::string& name,
   switch (fe_type) {
     case FE_Type::HGRAD:
     {
-      Omega_h::Write<ST> f(m_mesh.nverts(),name);
-      m_mesh.add_tag<ST>(OMEGA_H_VERT,name,numComps,f,false);
+      Omega_h::Write<ST> f(m_mesh->nverts(),name);
+      m_mesh->add_tag<ST>(OMEGA_H_VERT,name,numComps,f,false);
       break;
     }
     default:
@@ -107,10 +107,10 @@ fillVector (Thyra_Vector&        field_vector,
   const int nelems = elems.size();
   const int ncomps = field_dof_mgr->getNumFields();
 
-  auto owned_h = hostRead(m_mesh.owned(dim));
-  auto mesh_data_h  = hostRead(m_mesh.get_array<ST>(dim,field_name));
+  auto owned_h = hostRead(m_mesh->owned(dim));
+  auto mesh_data_h  = hostRead(m_mesh->get_array<ST>(dim,field_name));
   auto thyra_data_h = getNonconstLocalData(field_vector);
-  auto elem_ents_h = hostRead(m_mesh.ask_down(m_mesh.dim(),dim).ab2b);
+  auto elem_ents_h = hostRead(m_mesh->ask_down(m_mesh->dim(),dim).ab2b);
   auto nents_per_elem = elem_ents_h.size() / nelems;
   for (int ielem=0; ielem<nelems; ++ielem) {
     for (int icmp=0; icmp<field_dof_mgr->getNumFields(); ++icmp) {
@@ -158,10 +158,10 @@ saveVector (const Thyra_Vector&  field_vector,
   const int nelems = elems.size();
   const int ncomps = field_dof_mgr->getNumFields();
 
-  auto mesh_data_h = hostWrite<ST>(m_mesh.nents(dim)*ncomps,field_name);
-  auto owned_h = hostRead(m_mesh.owned(dim));
+  auto mesh_data_h = hostWrite<ST>(m_mesh->nents(dim)*ncomps,field_name);
+  auto owned_h = hostRead(m_mesh->owned(dim));
   auto thyra_data_h = getLocalData(field_vector);
-  auto elem_ents_h = hostRead(m_mesh.ask_down(m_mesh.dim(),dim).ab2b);
+  auto elem_ents_h = hostRead(m_mesh->ask_down(m_mesh->dim(),dim).ab2b);
   auto nents_per_elem = elem_ents_h.size() / nelems;
   for (int ielem=0; ielem<nelems; ++ielem) {
     for (int icmp=0; icmp<field_dof_mgr->getNumFields(); ++icmp) {
@@ -179,6 +179,8 @@ saveVector (const Thyra_Vector&  field_vector,
       }
     }
   }
+
+  m_mesh->set_tag(dim,field_name,read(mesh_data_h.write()),false);
 }
 
 } // namespace Albany

--- a/src/disc/omegah/Albany_OmegahMeshFieldAccessor.hpp
+++ b/src/disc/omegah/Albany_OmegahMeshFieldAccessor.hpp
@@ -11,7 +11,7 @@ namespace Albany {
 class OmegahMeshFieldAccessor : public AbstractMeshFieldAccessor
 {
 public:
-  OmegahMeshFieldAccessor (const Omega_h::Mesh& mesh);
+  OmegahMeshFieldAccessor (const Teuchos::RCP<Omega_h::Mesh>& mesh);
   ~OmegahMeshFieldAccessor () = default;
 
   void addStateStructs(const Teuchos::RCP<StateInfoStruct>& sis) override;
@@ -90,7 +90,7 @@ public:
   }
 
 protected:
-  Omega_h::Mesh   m_mesh;
+  Teuchos::RCP<Omega_h::Mesh>   m_mesh;
 };
 
 } // namespace Albany


### PR DESCRIPTION
While trying to hack the code to get an output file from an Omega_h test, I realized that we were copying around Omega_h::Mesh objects, but that's not safe, since they are not fully shallow objects. E.g., adding a tag to one copy of the mesh will not add it to the original mesh object.

This PR stores the raw Omega_h::Mesh in our wrappers as an RCP, and passes it around as an RCP. With this, I was able to save the mesh in vtk format, and visualize the solution on paraview.

Note: I am not committing the code that saves the mesh, since it was a bit of a hack. In particular, I haven't figured out how to add multiple time slices of fields. I will tackle that another time.