### PR TITLE
PyAlbany: upgrade pybind11 and replace assertTrue

### DIFF
--- a/pyAlbany/src/CMakeLists.txt
+++ b/pyAlbany/src/CMakeLists.txt
@@ -108,7 +108,7 @@ include(FetchContent)
 FetchContent_Declare(
 	pybind11
 	GIT_REPOSITORY https://github.com/pybind/pybind11.git
-	GIT_TAG        v2.6.2
+	GIT_TAG        v2.10.4
 	GIT_SHALLOW    TRUE
 )
 

--- a/pyAlbany/tests/extremeEvent/thermal_steady.py
+++ b/pyAlbany/tests/extremeEvent/thermal_steady.py
@@ -83,12 +83,12 @@ class TestExtremeEvent(unittest.TestCase):
                     print('i = ' + str(i) + ': P IS: expected value = ' + str(expected_P_IS[i]) + ', computed value = ' + str(P_IS[i]) + ', and diff = ' + str(expected_P_IS[i]-P_IS[i]))
                     print('i = ' + str(i) + ': P mixed: expected value = ' + str(expected_P_mixed[i]) + ', computed value = ' + str(P_mixed[i]) + ', and diff = ' + str(expected_P_mixed[i]-P_mixed[i]))
 
-            self.assertTrue(np.amax(np.abs(expected_theta_star - theta_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_I_star - I_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_P_star - P_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_F_star - F_star)) < tol_F)
-            self.assertTrue(np.amax(np.abs(expected_P_IS - P_IS)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_P_mixed - P_mixed)) < tol)
+            self.assertLess(np.amax(np.abs(expected_theta_star - theta_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_I_star - I_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_P_star - P_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_F_star - F_star)), tol_F)
+            self.assertLess(np.amax(np.abs(expected_P_IS - P_IS)), tol)
+            self.assertLess(np.amax(np.abs(expected_P_mixed - P_mixed)), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/extremeEvent/thermal_steady_hessian.py
+++ b/pyAlbany/tests/extremeEvent/thermal_steady_hessian.py
@@ -73,11 +73,11 @@ class TestExtremeEvent(unittest.TestCase):
                     print('i = ' + str(i) + ': F star: expected value = ' + str(expected_F_star[i]) + ', computed value = ' + str(F_star[i]) + ', and diff = ' + str(expected_F_star[i]-F_star[i]))
                     print('i = ' + str(i) + ': P SO: expected value = ' + str(expected_P_SO[i]) + ', computed value = ' + str(P_SO[i]) + ', and diff = ' + str(expected_P_SO[i]-P_SO[i]))
 
-            self.assertTrue(np.amax(np.abs(expected_theta_star - theta_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_I_star - I_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_P_star - P_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_F_star - F_star)) < tol)
-            self.assertTrue(np.amax(np.abs(expected_P_SO - P_SO)) < tol)
+            self.assertLess(np.amax(np.abs(expected_theta_star - theta_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_I_star - I_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_P_star - P_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_F_star - F_star)), tol)
+            self.assertLess(np.amax(np.abs(expected_P_SO - P_SO)), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/inputOutput/io_PyAlbany.py
+++ b/pyAlbany/tests/inputOutput/io_PyAlbany.py
@@ -142,7 +142,7 @@ class TestIO(unittest.TestCase):
         mvector_target = np.array([1., -1, 3.26, -3.1])*(rank+1)
 
         for i in range(0, n_cols):
-            self.assertTrue(np.abs(mvector_view[0,i]-mvector_target[i]) < tol)
+            self.assertLess(np.abs(mvector_view[0,i]-mvector_target[i]), tol)
 
     def test_read_distributed_txt(self):
         cls = self.__class__
@@ -167,7 +167,7 @@ class TestIO(unittest.TestCase):
         tol = 1e-8
         mvector_target = np.array([1., -1, 3.26, -3.1])*(rank+1)
         for i in range(0, n_cols):
-            self.assertTrue(np.abs(mvector_view[0,i]-mvector_target[i]) < tol)
+            self.assertLess(np.abs(mvector_view[0,i]-mvector_target[i]), tol)
 
     def test_read_non_distributed_npy(self):
         cls = self.__class__
@@ -192,7 +192,7 @@ class TestIO(unittest.TestCase):
         tol = 1e-8
         mvector_target = np.array([1., -1, 3.26, -3.1])*(rank+1)
         for i in range(0, n_cols):
-            self.assertTrue(np.abs(mvector_view[0,i]-mvector_target[i]) < tol)
+            self.assertLess(np.abs(mvector_view[0,i]-mvector_target[i]), tol)
 
     def test_read_non_distributed_txt(self):
         cls = self.__class__
@@ -217,7 +217,7 @@ class TestIO(unittest.TestCase):
         tol = 1e-8
         mvector_target = np.array([1., -1, 3.26, -3.1])*(rank+1)
         for i in range(0, n_cols):
-            self.assertTrue(np.abs(mvector_view[0,i]-mvector_target[i]) < tol)
+            self.assertLess(np.abs(mvector_view[0,i]-mvector_target[i]), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/linearAlgebra/matrixOperations.py
+++ b/pyAlbany/tests/linearAlgebra/matrixOperations.py
@@ -95,11 +95,11 @@ class TestMatrixOperations(unittest.TestCase):
 
 
         if rank == 0:
-            self.assertTrue(err0 < tol0)
-            self.assertTrue(err1 < tol)
-            self.assertTrue(err2 < tol)
-            self.assertTrue(err3 < tol)
-            self.assertTrue(err4 < tol)
+            self.assertLess(err0, tol0)
+            self.assertLess(err1, tol)
+            self.assertLess(err2, tol)
+            self.assertLess(err3, tol)
+            self.assertLess(err4, tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/randCompress/adjointSolve.py
+++ b/pyAlbany/tests/randCompress/adjointSolve.py
@@ -56,8 +56,8 @@ class TestAdjointSolve(unittest.TestCase):
             expected_eigVals = 0.85552097
             expected_eigVecs = np.array([[0.43910025], [0.36382469], [0.38869418], [0.44107581], [0.57375215]])
 
-            self.assertTrue(np.abs(eigVals - expected_eigVals) < tol)
-            self.assertTrue(np.amax(np.abs(eigVecs.getLocalView() - expected_eigVecs)) < tol)
+            self.assertLess(np.abs(eigVals - expected_eigVals), tol)
+            self.assertLess(np.amax(np.abs(eigVecs.getLocalView() - expected_eigVecs)), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/randCompress/steadyHeatHODLR.py
+++ b/pyAlbany/tests/randCompress/steadyHeatHODLR.py
@@ -75,7 +75,7 @@ class TestHODLR(unittest.TestCase):
                 M12 = idx1-idx0 # rows of OD-block
                 N12 = idx2-idx1 # columns of OD-block
                 errorBound12 = (1. + 11.*np.sqrt(k+p)*np.sqrt(min(M12, N12)))*sigValsTrue[k+1]
-                self.assertTrue(error12 <= errorBound12)
+                self.assertLessEqual(error12, errorBound12)
 
 
         stackedTimer = problem.getStackedTimer()

--- a/pyAlbany/tests/randCompress/steadyHeatRSVDdoublePassNonSymmetric.py
+++ b/pyAlbany/tests/randCompress/steadyHeatRSVDdoublePassNonSymmetric.py
@@ -62,7 +62,7 @@ class TestDoublePass(unittest.TestCase):
             # see equation (5) of "Compressing rank-structured matrices via randomized sampling" Martinsson (2016)
             # for the error bound 
             errorBound = (1. + 11.*np.sqrt(k+p)*np.sqrt(N))*sigValsTrue[k+1]
-            self.assertTrue(error <= errorBound)
+            self.assertLessEqual(error, errorBound)
 
 
         stackedTimer = problem.getStackedTimer()

--- a/pyAlbany/tests/randCompress/steadyHeatRSVDdoublePassSymmetric.py
+++ b/pyAlbany/tests/randCompress/steadyHeatRSVDdoublePassSymmetric.py
@@ -61,7 +61,7 @@ class TestDoublePass(unittest.TestCase):
             # see equation (5) of "Compressing rank-structured matrices via randomized sampling" Martinsson (2016)
             # for the error bound 
             errorBound = (1. + 11.*np.sqrt(k+p)*np.sqrt(N))*sigValsTrue[k+1]
-            self.assertTrue(error <= errorBound)
+            self.assertLessEqual(error, errorBound)
 
 
         stackedTimer = problem.getStackedTimer()

--- a/pyAlbany/tests/randCompress/steadyHeatRSVDsinglePass.py
+++ b/pyAlbany/tests/randCompress/steadyHeatRSVDsinglePass.py
@@ -62,7 +62,7 @@ class TestSinglePass(unittest.TestCase):
             # for the error bound, which does not specifically hold for the additional errors incurred via the
             # singlePass algorithm 
             errorBound = (1. + 11.*np.sqrt(k+p)*np.sqrt(N))*sigValsTrue[k+1]
-            self.assertTrue(error <= errorBound)
+            self.assertLessEqual(error, errorBound)
 
 
         stackedTimer = problem.getStackedTimer()

--- a/pyAlbany/tests/steadyHeat/inv_steadyHeat.py
+++ b/pyAlbany/tests/steadyHeat/inv_steadyHeat.py
@@ -55,8 +55,8 @@ class TestSteadyHeat(unittest.TestCase):
         print(para_1_norm)
 
         if rank == 0:
-            self.assertTrue(np.abs(para_0_view[0] - p_0_target) < tol)
-            self.assertTrue(np.abs(para_1_norm - p_1_norm_target) < tol)
+            self.assertLess(np.abs(para_0_view[0] - p_0_target), tol)
+            self.assertLess(np.abs(para_1_norm - p_1_norm_target), tol)
 
         problem.performSolve()
 
@@ -66,8 +66,8 @@ class TestSteadyHeat(unittest.TestCase):
         print("Response before analysis " + str(response_before_analysis_view))
         print("Response after analysis " + str(response_after_analysis_view))
         if rank == 0:
-            self.assertTrue(np.abs(response_before_analysis_view[0] - g_target_before) < tol)
-            self.assertTrue(np.abs(response_after_analysis_view[0] - g_target_after) < tol)
+            self.assertLess(np.abs(response_before_analysis_view[0] - g_target_before), tol)
+            self.assertLess(np.abs(response_after_analysis_view[0] - g_target_after), tol)
 
         parameter_map_0 = problem.getParameterMap(0)
         para_0_new = Utils.createVector(parameter_map_0)
@@ -79,7 +79,7 @@ class TestSteadyHeat(unittest.TestCase):
         response_view = response.getLocalView()
         print("Response after setParameter " + str(response_view))
         if rank == 0:
-            self.assertTrue(np.abs(response_view[0] - g_target_2) < tol)
+            self.assertLess(np.abs(response_view[0] - g_target_2), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/steadyHeat/multiple_runs_steadyHeat.py
+++ b/pyAlbany/tests/steadyHeat/multiple_runs_steadyHeat.py
@@ -63,7 +63,7 @@ class TestSteadyHeat(unittest.TestCase):
         print("QoI = " + str(responses))
 
         if rank == 0:
-            self.assertTrue(np.abs(np.amax(responses - responses_target)) < tol)
+            self.assertLess(np.abs(np.amax(responses - responses_target)), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/steadyHeat/steadyHeat.py
+++ b/pyAlbany/tests/steadyHeat/steadyHeat.py
@@ -66,12 +66,12 @@ class TestSteadyHeat(unittest.TestCase):
 
         tol = 1e-8
         if rank == 0:
-            self.assertTrue(np.abs(g_data[0]-g_target) < tol)
-            self.assertTrue(np.abs(norm-norm_target) < tol)
-            self.assertTrue(setup_time > 0.)
-            self.assertTrue(setup_time == setup_time_2)
+            self.assertLess(np.abs(g_data[0]-g_target), tol)
+            self.assertLess(np.abs(norm-norm_target), tol)
+            self.assertGreater(setup_time, 0.)
+            self.assertEqual(setup_time, setup_time_2)
             for i in range(0,n_directions):
-                self.assertTrue(np.abs(hessian_norms[i]-h_target[i]) < tol)
+                self.assertLess(np.abs(hessian_norms[i]-h_target[i]), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/steadyHeat/steadyHeat_orthog.py
+++ b/pyAlbany/tests/steadyHeat/steadyHeat_orthog.py
@@ -42,9 +42,9 @@ class TestSteadyHeat(unittest.TestCase):
                 omegaiTomegaj = Utils.inner(omega.getVector(i), omega.getVector(j))
                 if rank == 0:
                     if i == j:
-                        self.assertTrue(abs(omegaiTomegaj - 1.0) < tol)
+                        self.assertLess(abs(omegaiTomegaj - 1.0), tol)
                     else:
-                        self.assertTrue(abs(omegaiTomegaj-0.0) < tol)
+                        self.assertLess(abs(omegaiTomegaj-0.0), tol)
 
     @classmethod
     def tearDownClass(cls):

--- a/pyAlbany/tests/steadyHeat/steadyHeat_stateMap.py
+++ b/pyAlbany/tests/steadyHeat/steadyHeat_stateMap.py
@@ -42,7 +42,7 @@ class TestSteadyHeat(unittest.TestCase):
         tol = 1.e-8
         state_view = state.getLocalView()
         state_ref_view = state_ref.getLocalView()
-        self.assertTrue(np.linalg.norm(state_ref_view - state_view) < tol)
+        self.assertLess(np.linalg.norm(state_ref_view - state_view), tol)
 
 
     @classmethod

--- a/tests/landIce/FO_Thermo/hessian_comparison.py
+++ b/tests/landIce/FO_Thermo/hessian_comparison.py
@@ -24,7 +24,7 @@ class TestHessian(unittest.TestCase):
         largest_diff = np.amax(np.abs(diff))
 
         tol = 1e-8
-        self.assertTrue(largest_diff < tol)
+        self.assertLess(largest_diff, tol)
 
 
 if __name__ == '__main__':

--- a/tests/unit/disc/stk/matrices_comparison.py
+++ b/tests/unit/disc/stk/matrices_comparison.py
@@ -37,7 +37,7 @@ class TestBlockJacobian(unittest.TestCase):
         tol = 1e-8
 
         self.assertEqual(nnz_jac, nnz_total)
-        self.assertTrue(np.amax(np.abs(A-jac)) < tol)
+        self.assertLess(np.amax(np.abs(A-jac)), tol)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR upgrades Pybind11 version that was getting older and replaces `assertTrue` with the assertion corresponding to the used comparisons.