### PR TITLE
Port responses to kokkos for uvm-free access

### DIFF
--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -107,37 +107,6 @@ int getDerivativeDimensions(const Albany::Application* app, const int ebi)
 
 namespace {
 template<typename ScalarT>
-struct A2V {
-  std::vector<ScalarT>& v;
-  A2V (std::vector<ScalarT>& v) : v(v) {}
-  void operator() (typename Ref<const ScalarT>::type a, const int i) {
-    v[i] = a;
-  }
-};
-
-template<typename ScalarT>
-struct V2A {
-  const std::vector<ScalarT>& v;
-  V2A (const std::vector<ScalarT>& v) : v(v) {}
-  void operator() (typename Ref<ScalarT>::type a, const int i) {
-    a = v[i];
-  }
-};
-
-template<typename ScalarT>
-void copy (const PHX::MDField<ScalarT>& a, std::vector<ScalarT>& v) {
-  v.resize(a.size());
-  A2V<ScalarT> a2v(v);
-  loop(a2v, a);
-}
-
-template<typename ScalarT>
-void copy (const std::vector<ScalarT>& v, PHX::MDField<ScalarT>& a) {
-  V2A<ScalarT> v2a(v);
-  loop(v2a, a);
-}
-
-template<typename ScalarT>
 void myReduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   std::vector<ScalarT>& v)
@@ -212,15 +181,6 @@ void reduceAll (
   ScalarT b = a;
   Teuchos::reduceAll(comm, reduct_type, 1, &a, &b);
   a = b;
-}
-
-template<typename ScalarT>
-void broadcast (const Teuchos_Comm& comm, const int root_rank,
-                PHX::MDField<ScalarT>& a) {
-  std::vector<ScalarT> v;
-  copy<ScalarT>(a, v);
-  Teuchos::broadcast<int, ScalarT>(comm, root_rank, v.size(), &v[0]);
-  copy<ScalarT>(v, a);
 }
 
 template int getDerivativeDimensions<PHAL::AlbanyTraits::Jacobian>(

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -186,6 +186,11 @@ void reduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   PHX::MDField<ScalarT>& a)
 {
+  // Old reduceAll implementation is not uvm-friendly and untested
+  //  for rank > 1
+  TEUCHOS_TEST_FOR_EXCEPTION(a.rank() > 1, std::logic_error,
+        "PHAL::reduceAll not implemented for MDFields with rank > 1.\n");
+        
   MDFieldHostMirror<ScalarT> a_host = Kokkos::create_mirror_view(a.get_view());
   Kokkos::deep_copy(a_host, a.get_view());
   std::vector<ScalarT> v;

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -209,9 +209,7 @@ template int getDerivativeDimensions<PHAL::AlbanyTraits::HessianVec>(
   template void reduceAll<T> (                                              \
     const Teuchos_Comm&, const Teuchos::EReductionType, PHX::MDField<T>&);  \
   template void reduceAll<T> (                                              \
-    const Teuchos_Comm&, const Teuchos::EReductionType, T&);                \
-  template void broadcast<T> (                                              \
-    const Teuchos_Comm&, const int, PHX::MDField<T>&);
+    const Teuchos_Comm&, const Teuchos::EReductionType, T&);                
 apply_to_all_ad_types(eti)
 #undef eti
 #undef apply_to_all_ad_types

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -153,6 +153,17 @@ void reduceAll (
 template<typename ScalarT>
 void reduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
+  Kokkos::View<ScalarT*,PHX::Device>& a)
+{
+  Albany::DeviceView1d<ScalarT> v(a);
+  Kokkos::deep_copy(v, a);
+  Teuchos::reduceAll(comm, Teuchos::REDUCE_SUM, static_cast<int>(a.size()), a.data(), v.data());
+  Kokkos::deep_copy(a, v);
+}
+
+template<typename ScalarT>
+void reduceAll (
+  const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   ScalarT& a)
 {
   ScalarT b = a;
@@ -191,12 +202,14 @@ template int getDerivativeDimensions<PHAL::AlbanyTraits::HessianVec>(
   macro(HessianVecFad)
 #  endif
 
-#define eti(T)                                                              \
-  template void reduceAll<T> (                                              \
-    const Teuchos_Comm&, const Teuchos::EReductionType, PHX::MDField<T>&);  \
-  template void reduceAll<T> (                                              \
-    const Teuchos_Comm&, const Teuchos::EReductionType, T&);                \
-  template void broadcast<T> (                                              \
+#define eti(T)                                                                           \
+  template void reduceAll<T> (                                                           \
+    const Teuchos_Comm&, const Teuchos::EReductionType, PHX::MDField<T>&);               \
+  template void reduceAll<T> (                                                           \
+    const Teuchos_Comm&, const Teuchos::EReductionType, Kokkos::View<T*,PHX::Device>&);  \
+  template void reduceAll<T> (                                                           \
+    const Teuchos_Comm&, const Teuchos::EReductionType, T&);                             \
+  template void broadcast<T> (                                                           \
     const Teuchos_Comm&, const int, PHX::MDField<T>&);
 apply_to_all_ad_types(eti)
 #undef eti

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -186,10 +186,17 @@ void reduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   PHX::MDField<ScalarT>& a)
 {
+  MDFieldHostMirror<ScalarT> a_host = Kokkos::create_mirror_view(a.get_view());
+  Kokkos::deep_copy(a_host, a.get_view());
   std::vector<ScalarT> v;
-  copy<ScalarT>(a, v);
+  for (size_t i = 0; i < a.size(); ++i) {
+    v.push_back(a_host(i));
+  }
   myReduceAll<ScalarT>(comm, reduct_type, v);
-  copy<ScalarT>(v, a);
+  for (size_t i = 0; i < a.size(); ++i) {
+    a_host(i) = v[i];
+  }
+  Kokkos::deep_copy(a.get_view(), a_host);
 }
 
 template<typename ScalarT>

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -153,9 +153,9 @@ void reduceAll (
 template<typename ScalarT>
 void reduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
-  Kokkos::View<ScalarT*,PHX::Device>& a)
+  typename PHX::MDField<ScalarT>::array_type& a)
 {
-  Albany::DeviceView1d<ScalarT> v(a);
+  typename PHX::MDField<ScalarT>::array_type v(a);
   Kokkos::deep_copy(v, a);
   Teuchos::reduceAll(comm, Teuchos::REDUCE_SUM, static_cast<int>(a.size()), a.data(), v.data());
   Kokkos::deep_copy(a, v);
@@ -206,7 +206,7 @@ template int getDerivativeDimensions<PHAL::AlbanyTraits::HessianVec>(
   template void reduceAll<T> (                                                           \
     const Teuchos_Comm&, const Teuchos::EReductionType, PHX::MDField<T>&);               \
   template void reduceAll<T> (                                                           \
-    const Teuchos_Comm&, const Teuchos::EReductionType, Kokkos::View<T*,PHX::Device>&);  \
+    const Teuchos_Comm&, const Teuchos::EReductionType, typename PHX::MDField<T>::array_type&);  \
   template void reduceAll<T> (                                                           \
     const Teuchos_Comm&, const Teuchos::EReductionType, T&);                             \
   template void broadcast<T> (                                                           \

--- a/src/PHAL_Utilities.cpp
+++ b/src/PHAL_Utilities.cpp
@@ -137,48 +137,6 @@ void copy (const std::vector<ScalarT>& v, PHX::MDField<ScalarT>& a) {
   loop(v2a, a);
 }
 
-template<typename ScalarT>
-void myReduceAll (
-  const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
-  std::vector<ScalarT>& v)
-{
-  typedef typename ScalarT::value_type ValueT;
-  // Size of array to hold one Fad's derivatives.
-  const int sz = v[0].size();
-  // Pack into a vector of values.
-  std::vector<ValueT> pack;
-  for (size_t i = 0; i < v.size(); ++i) {
-    pack.push_back(v[i].val());
-    for (int j = 0; j < sz; ++j)
-      pack.push_back(v[i].fastAccessDx(j));
-  }
-  // reduceAll the package.
-  switch (reduct_type) {
-  case Teuchos::REDUCE_SUM: {
-    std::vector<ValueT> send(pack);
-    Teuchos::reduceAll<int, ValueT>(
-      comm, reduct_type, pack.size(), &send[0], &pack[0]);
-  } break;
-  default: TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "not impl'ed");
-  }
-  // Unpack.
-  int slot = 0;
-  for (size_t i = 0; i < v.size(); ++i) {
-    v[i].val() = pack[slot++];
-    for (int j = 0; j < sz; ++j)
-      v[i].fastAccessDx(j) = pack[slot++];
-  }
-}
-
-template<> void myReduceAll<RealType> (
-  const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
-  std::vector<RealType>& v)
-{
-  std::vector<RealType> send(v);
-  Teuchos::reduceAll<int, RealType>(
-    comm, reduct_type, v.size(), &send[0], &v[0]);
-}
-
 } // namespace
 
 template<typename ScalarT>
@@ -186,10 +144,10 @@ void reduceAll (
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   PHX::MDField<ScalarT>& a)
 {
-  std::vector<ScalarT> v;
-  copy<ScalarT>(a, v);
-  myReduceAll<ScalarT>(comm, reduct_type, v);
-  copy<ScalarT>(v, a);
+  Kokkos::DynRankView<ScalarT,Albany::DevLayout,PHX::Device> v(a.get_view());
+  Kokkos::deep_copy(v, a.get_view());
+  Teuchos::reduceAll(comm, Teuchos::REDUCE_SUM, static_cast<int>(a.get_view().size()), a.get_view().data(), v.data());
+  Kokkos::deep_copy(a.get_view(), v);
 }
 
 template<typename ScalarT>

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -120,10 +120,6 @@ void reduceAll(
 template<typename T>
 void reduceAll(
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type, T& a);
-//! Broadcast an MDField.
-template<typename T>
-void broadcast(
-  const Teuchos_Comm& comm, const int root_rank, PHX::MDField<T>& a);
 
 /*! \brief Loop over an array and apply a functor.
  *

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -108,6 +108,9 @@ private:
   int rank_;
 };
 
+template<typename T>
+using MDFieldHostMirror = typename PHX::MDField<T>::array_type::HostMirror;
+
 //! Reduce on an MDField.
 template<typename T>
 void reduceAll(

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -94,11 +94,13 @@ private:
 template<typename T>
 class MDFieldVectorRight {
 public:
+  using array_type = typename PHX::MDField<T>::array_type;
+  using return_type = typename PHX::MDFieldReturnType<array_type>::return_type;
   MDFieldVectorRight() = default;
   MDFieldVectorRight(const MDFieldVectorRight<T>&) = default;
   MDFieldVectorRight<T>& operator=(const MDFieldVectorRight<T>&) = default;
   MDFieldVectorRight(PHX::MDField<T>& a);
-  KOKKOS_INLINE_FUNCTION typename PHAL::Ref<T>::type operator[](const int i) const;  
+  KOKKOS_INLINE_FUNCTION return_type operator[](const int i) const;  
   
 private:
   Kokkos::DynRankView<T, PHX::Device> a_;
@@ -111,6 +113,11 @@ template<typename T>
 void reduceAll(
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   PHX::MDField<T>& a);
+//! Reduce on a kokkos View.
+template<typename T>
+void reduceAll(
+  const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
+  Kokkos::View<T*,PHX::Device>& a);
 //! Reduce on a ScalarT.
 template<typename T>
 void reduceAll(

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -117,7 +117,7 @@ void reduceAll(
 template<typename T>
 void reduceAll(
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
-  Kokkos::View<T*,PHX::Device>& a);
+  typename PHX::MDField<T>::array_type& a);
 //! Reduce on a ScalarT.
 template<typename T>
 void reduceAll(

--- a/src/PHAL_Utilities.hpp
+++ b/src/PHAL_Utilities.hpp
@@ -113,11 +113,6 @@ template<typename T>
 void reduceAll(
   const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
   PHX::MDField<T>& a);
-//! Reduce on a kokkos View.
-template<typename T>
-void reduceAll(
-  const Teuchos_Comm& comm, const Teuchos::EReductionType reduct_type,
-  typename PHX::MDField<T>::array_type& a);
 //! Reduce on a ScalarT.
 template<typename T>
 void reduceAll(

--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -47,7 +47,7 @@ MDFieldVectorRight (PHX::MDField<T>& a) {
   dim4 = (rank_ > 4) ? a.extent(4) : 0;
 }
 
-template<typename T> KOKKOS_INLINE_FUNCTION MDFieldVectorRight<T>::return_type
+template<typename T> KOKKOS_INLINE_FUNCTION typename MDFieldVectorRight<T>::return_type
 MDFieldVectorRight<T>::operator[] (const int i) const {
   int idx0, idx1, idx2, idx3, idx4;
   if (rank_ == 1) {

--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -47,7 +47,7 @@ MDFieldVectorRight (PHX::MDField<T>& a) {
   dim4 = (rank_ > 4) ? a.extent(4) : 0;
 }
 
-template<typename T> KOKKOS_INLINE_FUNCTION typename PHAL::Ref<T>::type
+template<typename T> KOKKOS_INLINE_FUNCTION MDFieldVectorRight<T>::return_type
 MDFieldVectorRight<T>::operator[] (const int i) const {
   int idx0, idx1, idx2, idx3, idx4;
   if (rank_ == 1) {

--- a/src/evaluators/gather/PHAL_GatherScalarNodalParameter_Def.hpp
+++ b/src/evaluators/gather/PHAL_GatherScalarNodalParameter_Def.hpp
@@ -80,7 +80,7 @@ evaluateFields(typename Traits::EvalData workset)
   const auto elem_lids  = workset.disc->getWsElementLIDs();
   const auto elem_lids_dev = Kokkos::subview(elem_lids.dev(),ws,ALL);
 
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids_dev(cell);
     const auto dof_lids = Kokkos::subview(p_elem_dof_lids,elem_LID,ALL);
@@ -470,7 +470,7 @@ evaluateFields(typename Traits::EvalData workset)
   const auto elem_lids_dev = Kokkos::subview(elem_lids.dev(),ws,ALL);
 
   using ref_t = typename PHAL::Ref<ParamScalarT>::type;
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const int num_deriv = this->val(0,0).size();
     const auto elem_LID = elem_lids_dev(cell);

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolation.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolation.hpp
@@ -144,7 +144,6 @@ public:
   struct FastSolutionGradInterpolationBase_Jacobian_Tag{};
   typedef Kokkos::RangePolicy<ExecutionSpace, FastSolutionGradInterpolationBase_Jacobian_Tag> FastSolutionGradInterpolationBase_Jacobian_Policy;
 
-  int num_dof;
   int neq;
 
   KOKKOS_INLINE_FUNCTION

--- a/src/evaluators/interpolation/PHAL_DOFGradInterpolation_Def.hpp
+++ b/src/evaluators/interpolation/PHAL_DOFGradInterpolation_Def.hpp
@@ -141,6 +141,7 @@ template< typename Traits>
 KOKKOS_INLINE_FUNCTION
 void FastSolutionGradInterpolationBase<PHAL::AlbanyTraits::Jacobian, Traits, typename PHAL::AlbanyTraits::Jacobian::ScalarT>::
 operator() (const FastSolutionGradInterpolationBase_Jacobian_Tag& tag, const int& cell) const {
+  const int num_dof = this->val_node(0,0).size();
   for (size_t qp=0; qp < this->numQPs; ++qp) {
     for (size_t dim=0; dim<this->numDims; dim++) {
       this->grad_val_qp(cell,qp,dim) = ScalarT(num_dof, this->val_node(cell, 0).val() * this->GradBF(cell, 0, qp, dim));
@@ -163,7 +164,6 @@ evaluateFields(typename Traits::EvalData workset)
   // for (int i=0; i < grad_val_qp.size() ; i++) grad_val_qp[i] = 0.0;
   // Intrepid2::FunctionSpaceTools:: evaluate<ScalarT>(grad_val_qp, val_node, GradBF);
 
- num_dof = this->val_node(0,0).size();
  neq = workset.disc->getDOFManager()->getNumFields();
 
  Kokkos::parallel_for(this->getName(),FastSolutionGradInterpolationBase_Jacobian_Policy(0,workset.numCells),*this);

--- a/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
+++ b/src/evaluators/response/PHAL_ResponseSquaredL2DifferenceSide_Def.hpp
@@ -149,7 +149,7 @@ template<typename EvalT, typename Traits, typename SourceScalarT, typename Targe
 void PHAL::ResponseSquaredL2DifferenceSideBase<EvalT, Traits, SourceScalarT, TargetScalarT>::
 preEvaluate(typename Traits::PreEvalData workset)
 {
-  PHAL::set(this->global_response_eval, 0.0);
+  Kokkos::deep_copy(this->global_response_eval.get_view(), 0.0);
 
   // Do global initialization
   if(extrudedParams)

--- a/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter.hpp
@@ -118,6 +118,9 @@ private:
   typedef typename AlbanyTraits::Residual::ParamScalarT ParamScalarT;
   Teuchos::RCP< PHX::Tag<ParamScalarT> > nodal_field_tag;
   static const std::string className;
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 template<typename Traits>

--- a/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter_Def.hpp
@@ -86,14 +86,13 @@ evaluateFields(typename Traits::EvalData workset)
   if (this->memoizer.have_saved_data(workset,this->evaluatedFields()))
     return;
 
-  constexpr auto ALL = Kokkos::ALL();
   const int ws = workset.wsIndex;
 
   const auto param = workset.distParamLib->get(this->param_name);
   const auto p_data = Albany::getNonconstDeviceData(param->vector());
 
   const auto ws_elem_lids = workset.disc->getWsElementLIDs().dev();
-  const auto elem_lids = Kokkos::subview(ws_elem_lids,ws,ALL);
+  const auto elem_lids = Kokkos::subview(ws_elem_lids,ws,Kokkos::ALL());
   const auto p_elem_dof_lids = param->get_dof_mgr()->elem_dof_lids().dev();
   const int p_local_subdim = p_data.size();
 

--- a/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarNodalParameter_Def.hpp
@@ -97,7 +97,7 @@ evaluateFields(typename Traits::EvalData workset)
   const auto p_elem_dof_lids = param->get_dof_mgr()->elem_dof_lids().dev();
   const int p_local_subdim = p_data.size();
 
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     const auto elem_LID = elem_lids(cell);
     for (int node=0; node<this->numNodes; ++node) {

--- a/src/evaluators/scatter/PHAL_ScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarResponse.hpp
@@ -14,6 +14,7 @@
 #include "Teuchos_ParameterList.hpp"
 
 #include "PHAL_AlbanyTraits.hpp"
+#include "PHAL_Utilities.hpp"
 
 #include "Albany_Layouts.hpp"
 
@@ -130,6 +131,9 @@ protected:
   }
 private:
   typedef typename PHAL::AlbanyTraits::Tangent::ScalarT ScalarT;
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 // **************************************************************

--- a/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
@@ -95,12 +95,10 @@ void ScatterScalarResponse<PHAL::AlbanyTraits::Residual, Traits>::
 postEvaluate(typename Traits::PostEvalData workset)
 {
   // Here we scatter the *global* response
-  Teuchos::RCP<Thyra_Vector> g = workset.g; //Tpetra version
+  Teuchos::RCP<Thyra_Vector> g = workset.g;
   if (g != Teuchos::null) {
-    Teuchos::ArrayRCP<ST> g_nonconstView = Albany::getNonconstLocalData(g);
-    for (PHAL::MDFieldIterator<const ScalarT> gr(this->global_response); !gr.done(); ++gr) {
-      g_nonconstView[gr.idx()] = *gr;
-    }
+    Albany::ThyraVDeviceView<ST> g_nonconstView = Albany::getNonconstDeviceData(g);
+    Kokkos::deep_copy(g_nonconstView, this->global_response.get_view());
   }
 }
 

--- a/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
@@ -148,7 +148,8 @@ postEvaluate(typename Traits::PostEvalData workset)
   const auto do_gx = (gx != Teuchos::null);
   const auto do_gp = (gp != Teuchos::null);
 
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,this->global_response.size()),
+  Kokkos::parallel_for(this->getName(), 
+                       Kokkos::RangePolicy<ExecutionSpace>(0,this->global_response.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
     if (do_g){
       g_nonconstView(i) = gr[i].val();

--- a/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterScalarResponse_Def.hpp
@@ -144,21 +144,23 @@ postEvaluate(typename Traits::PostEvalData workset)
   const auto num_cols_p = workset.num_cols_p;
   const auto param_offset = workset.param_offset;
 
-  // for (PHAL::MDFieldIterator<const ScalarT> gr(this->global_response);
-  //      ! gr.done(); ++gr) {
+  const auto do_g  = (g != Teuchos::null);
+  const auto do_gx = (gx != Teuchos::null);
+  const auto do_gp = (gp != Teuchos::null);
+
   Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,this->global_response.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
-    if (g != Teuchos::null){
+    if (do_g){
       g_nonconstView(i) = gr[i].val();
     }
 
-    if (gx != Teuchos::null) {
+    if (do_gx) {
       for (int col=0; col<num_cols_x; col++) {
         gx_nonconst2dView(i,col) = gr[i].dx(col);
       }
     }
 
-    if (gp != Teuchos::null) {
+    if (do_gp) {
       for (int col=0; col<num_cols_p; col++) {
         gp_nonconst2dView(i,col) = gr[i].dx(col+param_offset);
       }

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse.hpp
@@ -163,8 +163,12 @@ protected:
   }
 protected:
   int numNodes;
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 private:
   typedef typename AlbanyTraits::Jacobian::ScalarT ScalarT;
+protected:
+  MDFieldVectorRight<const ScalarT> global_response_reader;
 };
 
 // **************************************************************

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -230,15 +230,6 @@ void SeparableScatterScalarResponse<AlbanyTraits::Jacobian, Traits>::
 postEvaluate(typename Traits::PostEvalData workset)
 {
   // Here we scatter the *global* response
-  // Teuchos::RCP<Thyra_Vector> g = workset.g;
-  // if (g != Teuchos::null) {
-  //   Teuchos::ArrayRCP<ST> g_nonconstView = Albany::getNonconstLocalData(g);
-  //   for (MDFieldIterator<const ScalarT> gr(this->global_response);
-  //        ! gr.done(); ++gr)
-  //     g_nonconstView[gr.idx()] = gr.ref().val();
-  // }
-
-  // Here we scatter the *global* response
   Teuchos::RCP<Thyra_Vector> g = workset.g;
   if (g != Teuchos::null) {
     Albany::ThyraVDeviceView<ST> g_nonconstView = Albany::getNonconstDeviceData(g);

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -123,7 +123,7 @@ evaluateFields(typename Traits::EvalData workset)
   for (int eq_dof=0; eq_dof<neq; eq_dof++) {
     auto offsets = dof_mgr->getGIDFieldOffsetsKokkos(eq_dof);
     const int num_nodes = offsets.size();
-    Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+    Kokkos::parallel_for(this->getName(),RangePolicy(0,workset.numCells),
                          KOKKOS_CLASS_LAMBDA(const int& cell) {
       const auto elem_LID = elem_lids_dev(cell);
 

--- a/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
+++ b/src/evaluators/scatter/PHAL_SeparableScatterScalarResponse_Def.hpp
@@ -235,8 +235,9 @@ postEvaluate(typename Traits::PostEvalData workset)
     Albany::ThyraVDeviceView<ST> g_nonconstView = Albany::getNonconstDeviceData(g);
     MDFieldVectorRight<const ScalarT> gr(this->global_response);
     global_response_reader = gr;
-    Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,this->global_response.size()),
-                       KOKKOS_CLASS_LAMBDA(const int i) {
+    Kokkos::parallel_for(this->getName(),
+                        Kokkos::RangePolicy<ExecutionSpace>(0,this->global_response.size()),
+                        KOKKOS_CLASS_LAMBDA(const int i) {
       g_nonconstView(i) = global_response_reader[i].val();
     });
   }

--- a/src/evaluators/state/PHAL_LoadStateField_Def.hpp
+++ b/src/evaluators/state/PHAL_LoadStateField_Def.hpp
@@ -56,7 +56,8 @@ void LoadStateFieldBase<EvalT, Traits, ScalarType>::evaluateFields(typename Trai
   MDFieldVectorRight<ScalarType> g(data);
   dataVec = g;
 
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,data.size()),
+  Kokkos::parallel_for(this->getName(),
+                       Kokkos::RangePolicy<ExecutionSpace>(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
     dataVec[i] = (i < stateToLoad_size) ? stateData(i) : 0.0;
   });
@@ -103,7 +104,8 @@ void LoadStateField<EvalT, Traits>::evaluateFields(typename Traits::EvalData wor
   MDFieldVectorRight<ParamScalarT> g(data);
   dataVec = g;
 
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,data.size()),
+  Kokkos::parallel_for(this->getName(),
+                       Kokkos::RangePolicy<ExecutionSpace>(0,data.size()),
                        KOKKOS_CLASS_LAMBDA(const int i) {
     dataVec[i] = (i < stateToLoad_size) ? stateData(i) : 0.0;
   });

--- a/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
+++ b/src/evaluators/utility/PHAL_ComputeBasisFunctionsSide_Def.hpp
@@ -114,7 +114,8 @@ postRegistrationSetup(typename Traits::SetupData d,
   intrepidBasis->getValues(grad_at_cub_points, cub_points, Intrepid2::OPERATOR_GRAD);
 
   // BF does not depend on the current element, so we fill it now
-  Kokkos::parallel_for(Kokkos::RangePolicy<ExecutionSpace>(0,BF.extent(0)),
+  Kokkos::parallel_for(this->getName(),
+                       Kokkos::RangePolicy<ExecutionSpace>(0,BF.extent(0)),
                        KOKKOS_CLASS_LAMBDA(const int cellside) { 
     for (unsigned int node=0; node<numSideNodes; ++node) {
       for (unsigned int qp=0; qp<numSideQPs; ++qp) {

--- a/src/landIce/evaluators/LandIce_EnthalpyResid_Def.hpp
+++ b/src/landIce/evaluators/LandIce_EnthalpyResid_Def.hpp
@@ -310,9 +310,10 @@ template<typename EvalT, typename Traits, typename VelocityST>
 void EnthalpyResid<EvalT,Traits,VelocityST>::
 evaluateFields(typename Traits::EvalData d)
 {
-  ScalarT hom = homotopy(0);
+  typename PHX::MDField<ScalarT>::array_type::HostMirror hom = Kokkos::create_mirror_view(homotopy.get_view());
+  Kokkos::deep_copy(hom, homotopy.get_view());
 
-  flux_reg_coeff = flux_reg_alpha*exp(flux_reg_beta*hom); // [adim]
+  flux_reg_coeff = flux_reg_alpha*exp(flux_reg_beta*hom(0)); // [adim]
 
 #ifdef OUTPUT_TO_SCREEN
   if (std::fabs(printedRegCoeff - flux_reg_coeff) > 0.0001*flux_reg_coeff)

--- a/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
+++ b/src/landIce/evaluators/LandIce_GatherVerticallyContractedSolution_Def.hpp
@@ -153,7 +153,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto l_offset = offset;
   auto ncomps = vecDim;
   auto sol = device_sol;
-  Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
     const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
@@ -209,7 +209,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto l_offset = offset;
   auto sol = device_sol;
   auto j_coeff = workset.j_coeff;
-  Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
     const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
@@ -266,7 +266,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto nlayers = numLayers;
   auto l_offset = offset;
   auto sol = device_sol;
-  Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
     const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
@@ -314,7 +314,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto nlayers = numLayers;
   auto l_offset = offset;
   auto sol = device_sol;
-  Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
     const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);
@@ -402,7 +402,7 @@ evaluateFields(typename PHALTraits::EvalData workset)
   auto l_offset = offset;
   auto sol = device_sol;
   auto j_coeff = workset.j_coeff;
-  Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_LAMBDA(const int iside) {
     const auto pos = sideSet.side_pos.d_view(iside);
     const int numSideNodes = snc(pos);

--- a/src/landIce/evaluators/LandIce_PressureCorrectedTemperature_Def.hpp
+++ b/src/landIce/evaluators/LandIce_PressureCorrectedTemperature_Def.hpp
@@ -71,7 +71,7 @@ evaluateFields(typename Traits::EvalData workset)
 {
   if (memoizer.have_saved_data(workset,this->evaluatedFields())) return;
 
-  Kokkos::parallel_for(RangePolicy(0, workset.numCells),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0, workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     if(useP0Temp) {
       correctedTemp(cell) = KU::min(temp(cell) + coeff * (sHeight(cell) - coord(cell,2)), meltingT);

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux.hpp
@@ -11,7 +11,6 @@
 #include "PHAL_SeparableScatterScalarResponse.hpp"
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_Cubature.hpp"
-#include "Albany_KokkosUtils.hpp"
 
 namespace LandIce {
 /**

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux.hpp
@@ -11,6 +11,7 @@
 #include "PHAL_SeparableScatterScalarResponse.hpp"
 #include "Intrepid2_CellTools.hpp"
 #include "Intrepid2_Cubature.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 namespace LandIce {
 /**
@@ -55,14 +56,14 @@ private:
   PHX::MDField<const ThicknessST,Side,Node>         bed;         //[km]
   PHX::MDField<const MeshScalarT,Side,Node,Dim>     coords;      //[km]
 
-  Kokkos::DynRankView<ThicknessST, PHX::Device>     gl_func,H;
-  Kokkos::DynRankView<xyST, PHX::Device>            x,y;
-  Kokkos::DynRankView<ScalarT, PHX::Device>         velx,vely;
-
   double rho_i, rho_w;  //[kg m^{-3}]
   double scaling;       //[adim]
 
   Albany::LocalSideSetInfo sideSet;
+
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 } // namespace LandIce

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -10,6 +10,7 @@
 #include "Phalanx_DataLayout.hpp"
 #include "Teuchos_CommHelpers.hpp"
 #include "PHAL_Utilities.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 #include "LandIce_ResponseGLFlux.hpp"
 

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -114,7 +114,7 @@ evaluateFields(typename Traits::EvalData workset)
     double coeff = rho_i*1e6*scaling; //to convert volume flux [km^2 m yr^{-1}] in a mass flux [kg yr^{-1}]
     sideSet = workset.sideSetViews->at(basalSideName);
 
-    Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+    Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                        KOKKOS_CLASS_LAMBDA(const int& sideSet_idx) {
       // Get the local data of cell
       const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);

--- a/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseGLFlux_Def.hpp
@@ -195,14 +195,7 @@ template<typename EvalT, typename Traits, typename ThicknessST>
 void ResponseGLFlux<EvalT, Traits, ThicknessST>::
 postEvaluate(typename Traits::PostEvalData workset)
 {
-  Kokkos::DynRankView<ScalarT,Albany::DevLayout,PHX::Device> my_global_response_eval(this->global_response_eval.get_view());
-  Kokkos::DynRankView<ScalarT,Albany::DevLayout,PHX::Device> my_global_response_eval_result(this->global_response_eval.get_view());
-
-  Kokkos::deep_copy(my_global_response_eval, this->global_response_eval.get_view());
-
-  Teuchos::reduceAll(*workset.comm, Teuchos::REDUCE_SUM, 1, my_global_response_eval.data(), my_global_response_eval_result.data());
-
-  Kokkos::deep_copy(this->global_response_eval.get_view(), my_global_response_eval_result);
+  PHAL::reduceAll<ScalarT>(*workset.comm, Teuchos::REDUCE_SUM, this->global_response_eval);
 
   // Do global scattering
   PHAL::SeparableScatterScalarResponseWithExtrudedParams<EvalT, Traits>::postEvaluate(workset);

--- a/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSMBMismatch_Def.hpp
@@ -118,7 +118,7 @@ template<typename EvalT, typename Traits, typename ThicknessScalarType>
 void ResponseSMBMismatch<EvalT, Traits, ThicknessScalarType>::
 preEvaluate(typename Traits::PreEvalData workset)
 {
-  PHAL::set(this->global_response_eval, 0.0);
+  Kokkos::deep_copy(this->global_response_eval.get_view(), 0.0);
 
   p_resp = p_reg = p_misH =0;
 

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
@@ -70,10 +70,9 @@ namespace LandIce {
     PHX::MDField<const MeshScalarT>  metric;
     PHX::MDField<const MeshScalarT>  w_measure;
 
-    using scalar_view = typename PHX::MDField<ScalarT>::array_type;
-    using scalar_view_host_mirror = typename PHX::MDField<ScalarT>::array_type::HostMirror;
+    PHX::MDField<ScalarT> p_resp, p_reg, p_reg_stiffening;
 
-    scalar_view p_resp, p_reg, p_reg_stiffening;
+    using scalar_view_host_mirror = typename PHX::MDField<ScalarT>::array_type::HostMirror;
     scalar_view_host_mirror resp, reg, reg_stiffening;
     
     double scaling, alpha, asinh_scaling, alpha_stiffening;

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
@@ -70,9 +70,14 @@ namespace LandIce {
     PHX::MDField<const MeshScalarT>  metric;
     PHX::MDField<const MeshScalarT>  w_measure;
 
-    ScalarT p_resp, p_reg, resp, reg, p_reg_stiffening,reg_stiffening;
+    Kokkos::View<ScalarT*, PHX::Device> p_resp, p_reg, p_reg_stiffening;
+    typename Kokkos::View<ScalarT*, PHX::Device>::HostMirror resp, reg, reg_stiffening;
     double scaling, alpha, asinh_scaling, alpha_stiffening;
     bool scalarRMS;
+
+  protected:
+    using ExecutionSpace = typename PHX::Device::execution_space;
+    using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 
   };
 

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch.hpp
@@ -70,8 +70,12 @@ namespace LandIce {
     PHX::MDField<const MeshScalarT>  metric;
     PHX::MDField<const MeshScalarT>  w_measure;
 
-    Kokkos::View<ScalarT*, PHX::Device> p_resp, p_reg, p_reg_stiffening;
-    typename Kokkos::View<ScalarT*, PHX::Device>::HostMirror resp, reg, reg_stiffening;
+    using scalar_view = typename PHX::MDField<ScalarT>::array_type;
+    using scalar_view_host_mirror = typename PHX::MDField<ScalarT>::array_type::HostMirror;
+
+    scalar_view p_resp, p_reg, p_reg_stiffening;
+    scalar_view_host_mirror resp, reg, reg_stiffening;
+    
     double scaling, alpha, asinh_scaling, alpha_stiffening;
     bool scalarRMS;
 

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
@@ -150,7 +150,7 @@ postRegistrationSetup(typename Traits::SetupData d, PHX::FieldManager<Traits>& f
 template<typename EvalT, typename Traits>
 void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::preEvaluate(typename Traits::PreEvalData workset)
 {
-  PHAL::set(this->global_response_eval, 0.0);
+  Kokkos::deep_copy(this->global_response_eval.get_view(), 0.0);
 
   p_resp = p_reg = p_reg_stiffening =0;
 

--- a/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
+++ b/src/landIce/evaluators/LandIce_ResponseSurfaceVelocityMismatch_Def.hpp
@@ -187,7 +187,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
   if (workset.sideSetViews->find(surfaceSideName) != workset.sideSetViews->end())
   {
     sideSet = workset.sideSetViews->at(surfaceSideName);
-    Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+    Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                          KOKKOS_CLASS_LAMBDA(const int& sideSet_idx) {
       // Get the local data of cell
       const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);
@@ -240,7 +240,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
       w_measure = w_measure_beta_vec[i];
       if (workset.sideSetViews->find(ssName) != workset.sideSetViews->end()) {
         sideSet = workset.sideSetViews->at(ssName);
-        Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+        Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                              KOKKOS_CLASS_LAMBDA(const int& sideSet_idx) {
           // Get the local data of cell
           const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);\
@@ -268,7 +268,7 @@ void LandIce::ResponseSurfaceVelocityMismatch<EvalT, Traits>::evaluateFields(typ
   if (workset.sideSetViews->find(basalSideName) != workset.sideSetViews->end() && alpha_stiffening!=0)
   {
     sideSet = workset.sideSetViews->at(basalSideName);
-    Kokkos::parallel_for(RangePolicy(0,sideSet.size),
+    Kokkos::parallel_for(this->getName(),RangePolicy(0,sideSet.size),
                          KOKKOS_CLASS_LAMBDA(const int& sideSet_idx) {
       // Get the local data of \cell
       const int cell = sideSet.ws_elem_idx.d_view(sideSet_idx);

--- a/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy.hpp
+++ b/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy.hpp
@@ -57,6 +57,10 @@ private:
   double Tm; //[K], 273.15
 
   PHAL::MDFieldMemoizer<Traits> memoizer;
+
+protected:
+  using ExecutionSpace = typename PHX::Device::execution_space;
+  using RangePolicy = Kokkos::RangePolicy<ExecutionSpace>;
 };
 
 } // Namespace LandIce

--- a/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy_Def.hpp
+++ b/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy_Def.hpp
@@ -8,6 +8,7 @@
 #include "Phalanx_DataLayout.hpp"
 #include "Phalanx_Print.hpp"
 #include "PHAL_Utilities.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 #include "LandIce_SurfaceAirEnthalpy.hpp"
 
@@ -56,9 +57,11 @@ evaluateFields(typename Traits::EvalData workset)
 
   const double powm6 = 1e-6; // [k^2], k=1000
 
-  for (std::size_t cell = 0; cell < workset.numCells; ++cell)
+  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+                       KOKKOS_CLASS_LAMBDA(const int& cell) {
     for (std::size_t node = 0; node < numNodes; ++node)
-      surfaceEnthalpy(cell,node) = rho_i * c_i * ( std::min(surfaceTemp(cell,node),Tm) - T0 ) * powm6;
+      surfaceEnthalpy(cell,node) = rho_i * c_i * ( KU::min(surfaceTemp(cell,node),Tm) - T0 ) * powm6;
+  });
 }
 
 } // namespace LandIce

--- a/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy_Def.hpp
+++ b/src/landIce/evaluators/LandIce_SurfaceAirEnthalpy_Def.hpp
@@ -57,7 +57,7 @@ evaluateFields(typename Traits::EvalData workset)
 
   const double powm6 = 1e-6; // [k^2], k=1000
 
-  Kokkos::parallel_for(RangePolicy(0,workset.numCells),
+  Kokkos::parallel_for(this->getName(),RangePolicy(0,workset.numCells),
                        KOKKOS_CLASS_LAMBDA(const int& cell) {
     for (std::size_t node = 0; node < numNodes; ++node)
       surfaceEnthalpy(cell,node) = rho_i * c_i * ( KU::min(surfaceTemp(cell,node),Tm) - T0 ) * powm6;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,10 +188,6 @@ IF(ENABLE_LANDICE AND ALBANY_SEACAS )
   add_subdirectory(landIce)
 ENDIF()
 
-IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM)
-  RETURN() # don't add any tests past this point if this is a CUDA build with uvm disabled
-ENDIF()
-
 add_subdirectory(corePDEs)
 
 IF(ENABLE_DEMO_PDES)

--- a/tests/landIce/CMakeLists.txt
+++ b/tests/landIce/CMakeLists.txt
@@ -1,11 +1,6 @@
 add_subdirectory(ExoMeshes)
 add_subdirectory(AsciiMeshes)
 add_subdirectory(FO_AIS)
-
-IF (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM)
-  RETURN() # don't add any tests past this point if this is a CUDA build with uvm disabled
-ENDIF()
-
 add_subdirectory(FO_MMS)
 add_subdirectory(FO_ISMIP)
 add_subdirectory(FO_Test)

--- a/tests/landIce/FO_AIS/CMakeLists.txt
+++ b/tests/landIce/FO_AIS/CMakeLists.txt
@@ -53,10 +53,6 @@ if(ALBANY_MUELU)
   endif()
 endif()
 
-if (Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_CUDA_UVM)
-  return() # don't add any tests past this point if this is a CUDA build with uvm disabled
-endif()
-
 if(ALBANY_MUELU)
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/inputMueLu.yaml
                  ${CMAKE_CURRENT_BINARY_DIR}/inputMueLu.yaml)


### PR DESCRIPTION
This PR updates `ResponseGLFlux` and `ResponseSurfaceVelocityMismatch` so that they can be used in uvm-off GPU builds. This includes porting a number of evaluators for scattering and communicating responses to kokkos for device-friendly access.

Additionally, this PR also fixes some existing kokkos ported evaluators to avoid some unintended host accesses that showed up in a uvm-off build. I've also added evaluator names to as many of the `parallel_for` regions as I could find to aid in performance profiling and debugging.

After this PR is merged, the following tests will now be passing in a uvm-off build:

```
landIce_FO_GIS_ForwardSensitivity
landIce_FO_GIS_Unstructured
landIce_FO_GIS_Unstructured_Restart
landIce_FO_GIS_Unstructured_Memoization
landIce_FO_GIS_Unstructured_FROSch
landIce_FO_GIS_Manifold
landIce_FO_MMS_FO_GLF_TRI_CORNER_CASE
landIce_FO_MMS_FO_GLF_QUAD
landIce_FO_MMS_FO_GLF_TRI_NONCONST_VELOCITY
landIce_FO_MMS_FO_GLF_TRI
landIce_FO_Thermo_Dry_Bed
landIce_FO_Thermo_Wet_Bed
landIce_FO_Thermo_Wet_Bed_FEA
landIce_FO_Thermo_Wet_Bed_FROSch
landIce_Enthalpy_Humboldt
landIce_Enthalpy_Kleiner_A
landIce_Enthalpy_Kleiner_B
```

The next target for the uvm-free porting process is to port `L2ProjectedBoundaryLaplacian` to kokkos which will get a large number of additional tests to start passing. (I think this will get most everything remaining in FO_GIS to pass)

Finally, I've re-enabled all of the cuda tests for the uvm-free build and I will instead start an issue to track the status of which tests and expected to pass/fail with uvm disabled.