### PR TITLE
Fix handling of side disc when saving sol in STKDiscretization

### DIFF
--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -725,8 +725,8 @@ STKDiscretization::writeSolutionToMeshDatabase(
     const double /* time */,
     const bool overlapped)
 {
-  // Put solution into STK Mesh
-  setSolutionField(soln, soln_dxdp, overlapped);
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, dof_mgr, overlapped);
 }
 
 void
@@ -738,7 +738,8 @@ STKDiscretization::writeSolutionToMeshDatabase(
     const bool overlapped)
 {
   // Put solution into STK Mesh
-  setSolutionField(soln, soln_dxdp, soln_dot, overlapped);
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, dof_mgr, overlapped);
 }
 
 void
@@ -751,7 +752,8 @@ STKDiscretization::writeSolutionToMeshDatabase(
     const bool overlapped)
 {
   // Put solution into STK Mesh
-  setSolutionField(soln, soln_dxdp, soln_dot, soln_dotdot, overlapped);
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, soln_dotdot, dof_mgr, overlapped);
 }
 
 void
@@ -762,7 +764,8 @@ STKDiscretization::writeSolutionMVToMeshDatabase(
     const bool overlapped)
 {
   // Put solution into STK Mesh
-  setSolutionFieldMV(soln, soln_dxdp, overlapped);
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnMultiVector(soln, soln_dxdp, dof_mgr, overlapped);
 }
 
 void
@@ -1021,49 +1024,6 @@ STKDiscretization::setField(
 {
   const auto dof_mgr = getDOFManager(name);
   solutionFieldContainer->saveVector(result,name,dof_mgr,overlapped);
-}
-
-void
-STKDiscretization::setSolutionField(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const bool          overlapped)
-{
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::setSolutionField(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const Thyra_Vector& soln_dot,
-    const bool          overlapped)
-{
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::setSolutionField(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const Thyra_Vector& soln_dot,
-    const Thyra_Vector& soln_dotdot,
-    const bool          overlapped)
-{
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, soln_dotdot, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::setSolutionFieldMV(
-    const Thyra_MultiVector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const bool               overlapped)
-{
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnMultiVector(soln, soln_dxdp, dof_mgr, overlapped);
 }
 
 void STKDiscretization::computeVectorSpaces()

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -346,26 +346,6 @@ public:
   void
   getSolutionField(Thyra_Vector& result, bool overlapped) const;
 
-  void
-  setSolutionField(const Thyra_Vector& soln, const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp, const bool overlapped);
-  void
-  setSolutionField(
-      const Thyra_Vector& soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& soln_dot,
-      const bool          overlapped);
-  void
-  setSolutionField(
-      const Thyra_Vector& soln,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& soln_dot,
-      const Thyra_Vector& soln_dotdot,
-      const bool          overlapped);
-  void
-  setSolutionFieldMV(const Thyra_MultiVector& solnT,
-		  const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-		  const bool overlapped);
-
   double
   monotonicTimeLabel(const double time);
 


### PR DESCRIPTION
The side discretizations were only processed in writeSolutionToFile, and not in writeSolutionToMeshDatabase (which is were the stk in-memory mesh data is updated). As a result, exo files for side discretizations had zero solution.

This PR fixes that, moving the handling of side discretizations into the main method (writeSolution), which calls the two methods mentioned above. Also, I got rid of some 2-liner methods in STKDiscretization, inlining them at the call site.