### PR TITLE
Make CreateExportAlbany less restrictive

### DIFF
--- a/cmake/CreateExportAlbany
+++ b/cmake/CreateExportAlbany
@@ -98,10 +98,11 @@ def run (bin_dir,install_lib_dir, cmake_generator):
         elif item.startswith("-L"):
             # We want to get an abs path, with symlinks resolved (if any)
             lib_dir_full = pathlib.Path(item[2:]).resolve()
+            # If path doesn't exist or it isn't a directory, don't add it to the "libs_dirs" list
             if not lib_dir_full.exists() or not lib_dir_full.is_dir():
                 print (f"could not parse token {item}")
                 print (f" -> It appears to be a lib dir entry, but the path does not exist, or is not a directory")
-                raise ValueError
+                continue
             libs_dirs.append(lib_dir_full)
         else:
             # This should be a library name, expressed by full/relative path.
@@ -109,10 +110,11 @@ def run (bin_dir,install_lib_dir, cmake_generator):
             # in the file name, to avoid an error we're seeing where libdl.so points
             # to the file libdl-2.28.so (an odd name: usually we see libdl.so.2.28)
             lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
+            # If the abs path doesn't point to an existing file, don't add the library name and path
             if not lib_file_full.exists():
                 print (f"could not locate lib: {lib_file_full}")
                 print (f"cwd: {os.getcwd()}")
-                raise ValueError
+                continue
             lib_file      = lib_file_full.name
             lib_path      = lib_file_full.parent
             # Remove all extensions (such as .so.5), and remove first 3 chars (lib)

--- a/cmake/CreateExportAlbany
+++ b/cmake/CreateExportAlbany
@@ -100,7 +100,7 @@ def run (bin_dir,install_lib_dir, cmake_generator):
             lib_dir_full = pathlib.Path(item[2:]).resolve()
             # If path doesn't exist or it isn't a directory, don't add it to the "libs_dirs" list
             if not lib_dir_full.exists() or not lib_dir_full.is_dir():
-                print (f"could not parse token {item}")
+                print (f"WARNING could not parse token {item}")
                 print (f" -> It appears to be a lib dir entry, but the path does not exist, or is not a directory")
                 continue
             libs_dirs.append(lib_dir_full)
@@ -112,7 +112,7 @@ def run (bin_dir,install_lib_dir, cmake_generator):
             lib_file_full = pathlib.Path(item).parent.resolve() / pathlib.Path(item).name
             # If the abs path doesn't point to an existing file, don't add the library name and path
             if not lib_file_full.exists():
-                print (f"could not locate lib: {lib_file_full}")
+                print (f"WARNING could not locate lib: {lib_file_full}")
                 print (f"cwd: {os.getcwd()}")
                 continue
             lib_file      = lib_file_full.name


### PR DESCRIPTION
We're currently unable to build Albany with the MPAS interface enabled on Frontier due to an overhaul of Frontier's module system. This is due to the `CreateExportAlbany` script throwing an error if a `-L` flag points to a directory that doesn't exist. (After the recent module overhaul on Frontier, `rocm/lib64` doesn't exist but Trilinos still adds it to the list of linker flags)

Is there a reason we strictly enforce that `-L` points to a valid directory? I propose that instead of throwing an error here, we just print a warning to the log and skip adding the non-existent paths to `export_albany.in`.