### PR TITLE
Fix for E3SM-Mali uvm-free error

### DIFF
--- a/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichletField_Def.hpp
@@ -136,19 +136,21 @@ set_row_and_col_is_dbc(typename Traits::EvalData dirichlet_workset)
   row_is_dbc_->assign(0.0);
   col_is_dbc_->assign(0.0);
 
-  auto row_is_dbc_data = Albany::getNonconstLocalData(row_is_dbc_);
+  {
+    auto row_is_dbc_data = Albany::getNonconstLocalData(row_is_dbc_);
 
-  const auto& ns_node_elem_pos = dirichlet_workset.nodeSets->at(this->nodeSetID);
+    const auto& ns_node_elem_pos = dirichlet_workset.nodeSets->at(this->nodeSetID);
 
-  const auto& sol_dof_mgr   = dirichlet_workset.disc->getDOFManager();
-  const auto& sol_elem_dof_lids = sol_dof_mgr->elem_dof_lids().host();
-  const auto& sol_offsets = sol_dof_mgr->getGIDFieldOffsets(this->offset);
-  for (const auto& ep : ns_node_elem_pos) {
-    const int ielem = ep.first;
-    const int pos   = ep.second;
-    const int x_lid = sol_elem_dof_lids(ielem,sol_offsets[pos]);
+    const auto& sol_dof_mgr   = dirichlet_workset.disc->getDOFManager();
+    const auto& sol_elem_dof_lids = sol_dof_mgr->elem_dof_lids().host();
+    const auto& sol_offsets = sol_dof_mgr->getGIDFieldOffsets(this->offset);
+    for (const auto& ep : ns_node_elem_pos) {
+      const int ielem = ep.first;
+      const int pos   = ep.second;
+      const int x_lid = sol_elem_dof_lids(ielem,sol_offsets[pos]);
 
-    row_is_dbc_data[x_lid] = 1.0;
+      row_is_dbc_data[x_lid] = 1.0;
+    }
   }
 
   auto cas_manager = Albany::createCombineAndScatterManager(domain_vs, col_vs);

--- a/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
+++ b/src/evaluators/bc/PHAL_SDirichlet_Def.hpp
@@ -137,17 +137,19 @@ set_row_and_col_is_dbc(typename Traits::EvalData dirichlet_workset)
   row_is_dbc_->assign(0.0);
   col_is_dbc_->assign(0.0);
 
-  auto row_is_dbc_data = Albany::getNonconstLocalData(row_is_dbc_);
+  {
+    auto row_is_dbc_data = Albany::getNonconstLocalData(row_is_dbc_);
 
-  const auto& ns_node_elem_pos = dirichlet_workset.nodeSets->at(this->nodeSetID);
-  const auto& sol_dof_mgr   = dirichlet_workset.disc->getDOFManager();
-  const auto& sol_elem_dof_lids = sol_dof_mgr->elem_dof_lids().host();
-  const auto& sol_offsets = sol_dof_mgr->getGIDFieldOffsets(this->offset);
-  for (const auto& ep : ns_node_elem_pos) {
-    const int ielem = ep.first;
-    const int pos   = ep.second;
-    const int x_lid = sol_elem_dof_lids(ielem,sol_offsets[pos]);
-    row_is_dbc_data[x_lid] = 1.0;
+    const auto& ns_node_elem_pos = dirichlet_workset.nodeSets->at(this->nodeSetID);
+    const auto& sol_dof_mgr   = dirichlet_workset.disc->getDOFManager();
+    const auto& sol_elem_dof_lids = sol_dof_mgr->elem_dof_lids().host();
+    const auto& sol_offsets = sol_dof_mgr->getGIDFieldOffsets(this->offset);
+    for (const auto& ep : ns_node_elem_pos) {
+      const int ielem = ep.first;
+      const int pos   = ep.second;
+      const int x_lid = sol_elem_dof_lids(ielem,sol_offsets[pos]);
+      row_is_dbc_data[x_lid] = 1.0;
+    }
   }
 
   auto cas_manager = Albany::createCombineAndScatterManager(domain_vs, col_vs);


### PR DESCRIPTION
Tpetra host views were not going out of scope before being accessed on device in `SDirichlet` and `SDirichletField` evaluators. This fixes the error that was showing up in CUDA E3SM-Mali runs when UVM is disabled.

@mperego This error didn't show up in the handful of compass tests that I'm able to run on GPU. Is there a way to know when `SDirichletField` is used based on the Albany input or timer output?