### PR TITLE
Add extruded discretizations that only store a basal mesh

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -232,6 +232,7 @@ list (APPEND SOURCES
   disc/Albany_MeshSpecs.cpp
   disc/Albany_DOFManager.cpp
   disc/Albany_DiscretizationUtils.cpp
+  disc/Albany_ExtrudedMesh.cpp
   )
 list (APPEND HEADERS
   disc/Albany_DiscretizationUtils.hpp
@@ -243,6 +244,7 @@ list (APPEND HEADERS
   disc/Albany_MeshSpecs.hpp
   disc/Albany_ConnManager.hpp
   disc/Albany_DOFManager.hpp
+  disc/Albany_ExtrudedMesh.hpp
   )
 
 #stk

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,6 +233,7 @@ list (APPEND SOURCES
   disc/Albany_DOFManager.cpp
   disc/Albany_DiscretizationUtils.cpp
   disc/Albany_ExtrudedMesh.cpp
+  disc/Albany_ExtrudedConnManager.cpp
   )
 list (APPEND HEADERS
   disc/Albany_DiscretizationUtils.hpp
@@ -245,6 +246,7 @@ list (APPEND HEADERS
   disc/Albany_ConnManager.hpp
   disc/Albany_DOFManager.hpp
   disc/Albany_ExtrudedMesh.hpp
+  disc/Albany_ExtrudedConnManager.hpp
   )
 
 #stk

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -234,6 +234,7 @@ list (APPEND SOURCES
   disc/Albany_DiscretizationUtils.cpp
   disc/Albany_ExtrudedMesh.cpp
   disc/Albany_ExtrudedConnManager.cpp
+  disc/Albany_ExtrudedDiscretization.cpp
   )
 list (APPEND HEADERS
   disc/Albany_DiscretizationUtils.hpp
@@ -247,6 +248,7 @@ list (APPEND HEADERS
   disc/Albany_DOFManager.hpp
   disc/Albany_ExtrudedMesh.hpp
   disc/Albany_ExtrudedConnManager.hpp
+  disc/Albany_ExtrudedDiscretization.hpp
   )
 
 #stk

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -13,6 +13,7 @@
 #include "Albany_DiscretizationUtils.hpp"
 #include "Albany_StateInfoStruct.hpp"
 #include "Albany_DOFManager.hpp"
+#include "Albany_ThyraCrsMatrixFactory.hpp"
 
 #include "Albany_ThyraTypes.hpp"
 #include "Albany_GlobalLocalIndexer.hpp"
@@ -134,8 +135,10 @@ public:
   }
 
   //! Create a Jacobian operator
-  virtual Teuchos::RCP<Thyra_LinearOp>
-  createJacobianOp() const = 0;
+  Teuchos::RCP<Thyra_LinearOp> createJacobianOp() const
+  {
+    return m_jac_factory->createOp();
+  }
 
   //! Get Node set lists
   virtual const NodeSetList&
@@ -243,8 +246,9 @@ public:
   }
 
   //! Get nodal parameters state info struct
-  virtual const StateInfoStruct&
-  getNodalParameterSIS() const = 0;
+  const StateInfoStruct& getNodalParameterSIS() const {
+    return getMeshStruct()->get_field_accessor()->getNodalParameterSIS();
+  }
 
   //! Retrieve Vector (length num worksets) of element block names
   const WorksetArray<std::string>&
@@ -387,6 +391,9 @@ public:
 
 protected:
   strmap_t<Teuchos::RCP<AbstractDiscretization>> sideSetDiscretizations;
+
+  //! Jacobian matrix operator factory
+  Teuchos::RCP<ThyraCrsMatrixFactory> m_jac_factory;
 
   // One dof mgr per dof per part
   // Notice that the dof mgr on a side is not the restriction

--- a/src/disc/Albany_AbstractMeshStruct.hpp
+++ b/src/disc/Albany_AbstractMeshStruct.hpp
@@ -44,6 +44,11 @@ struct AbstractMeshStruct {
 
     bool isBulkDataSet () const { return m_bulk_data_set; }
 
+    virtual LO get_num_local_elements () const = 0;
+    virtual LO get_num_local_nodes () const = 0;
+    virtual GO get_max_node_gid () const = 0;
+    virtual GO get_max_elem_gid () const = 0;
+
     virtual Teuchos::RCP<AbstractMeshFieldAccessor> get_field_accessor() const = 0;
 
     Teuchos::RCP<LayeredMeshNumbering<GO> > global_cell_layers_data;

--- a/src/disc/Albany_ConnManager.hpp
+++ b/src/disc/Albany_ConnManager.hpp
@@ -105,7 +105,7 @@ public:
   // Overload, not shadow
   using panzer::ConnManager::buildConnectivity;
   void buildConnectivity(const Teuchos::RCP<const panzer::FieldPattern> &fp) {
-    if (not m_fp.is_null()) {
+    if (is_connectivity_built()) {
       TEUCHOS_TEST_FOR_EXCEPTION (not m_fp->equals(*fp), std::runtime_error,
           "Error! Rebuilding conn mgr with a different field pattern!\n"
           "Old FP\n" << *m_fp << "\n"
@@ -119,6 +119,7 @@ public:
     m_fp = fp;
   }
 
+  bool is_connectivity_built () const { return not m_fp.is_null(); }
 protected:
   std::vector<std::string> m_elem_blocks_names;
 

--- a/src/disc/Albany_ConnManager.hpp
+++ b/src/disc/Albany_ConnManager.hpp
@@ -9,7 +9,8 @@
 
 #include "Albany_ScalarOrdinalTypes.hpp"
 
-#include "Panzer_ConnManager.hpp"
+#include <Panzer_ConnManager.hpp>
+#include <Panzer_FieldPattern.hpp>
 
 #include <vector>
 
@@ -100,10 +101,28 @@ public:
 
     return topologies[0];
   }
+
+  // Overload, not shadow
+  using panzer::ConnManager::buildConnectivity;
+  void buildConnectivity(const Teuchos::RCP<const panzer::FieldPattern> &fp) {
+    if (not m_fp.is_null()) {
+      TEUCHOS_TEST_FOR_EXCEPTION (not m_fp->equals(*fp), std::runtime_error,
+          "Error! Rebuilding conn mgr with a different field pattern!\n"
+          "Old FP\n" << *m_fp << "\n"
+          "New FP\n" << *fp << "\n");
+      return;
+    }
+
+    this->buildConnectivity(*fp);
+
+    // Store copy of input pattern for later checks
+    m_fp = fp;
+  }
+
 protected:
   std::vector<std::string> m_elem_blocks_names;
 
-  bool m_is_connectivity_built = false;
+  Teuchos::RCP<const panzer::FieldPattern> m_fp;
 };
 
 } // namespace Albany

--- a/src/disc/Albany_DOFManager.cpp
+++ b/src/disc/Albany_DOFManager.cpp
@@ -368,7 +368,7 @@ albanyBuildGlobalUnknowns ()
   // IMPORTANT! Do not use the GeometricAggFieldPattern, since you
   // *need* to count the same geo node multiple times if there are
   // multiple fields that need it.
-  connMngr_->buildConnectivity(*fa_fps_.back());
+  m_conn_mgr->buildConnectivity(fa_fps_.back());
 
   // We take a set as well, since std::find is on avg O(1) for unordered_set, vs O(N) in an array
   auto add_if_not_there = [](std::vector<GO>& v, std::unordered_set<GO>& s, const GO gid) {

--- a/src/disc/Albany_DOFManager.hpp
+++ b/src/disc/Albany_DOFManager.hpp
@@ -91,7 +91,7 @@ public:
     return m_conn_mgr->get_topology();
   }
 
-  Teuchos::RCP<const ConnManager> getAlbanyConnManager() const {
+  Teuchos::RCP<ConnManager> getAlbanyConnManager() const {
     return m_conn_mgr;
   }
 
@@ -146,7 +146,7 @@ private:
   // NOTE: this 
   vec4int       m_side_closure_orderd_as_side;
 
-  Teuchos::RCP<const ConnManager>           m_conn_mgr;
+  Teuchos::RCP<ConnManager>           m_conn_mgr;
 
   std::string m_part_name;
 

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -117,7 +117,7 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
     } else if (method == "Gmsh") {
         mesh = Teuchos::rcp(new GmshSTKMeshStruct(disc_params, comm, numParams));
     }
-    else if (method == "NewExtruded") {
+    else if (method == "Extruded") {
         Teuchos::RCP<AbstractMeshStruct> basalMesh;
 
         // Get basal_params
@@ -141,7 +141,7 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
         basalMesh = createMeshStruct(basal_params, comm, numParams);
         mesh = Teuchos::rcp(new ExtrudedMesh(basalMesh, disc_params, comm));
     }
-    else if (method == "Extruded") {
+    else if (method == "STKExtruded") {
         Teuchos::RCP<AbstractMeshStruct> basalMesh;
 
         // Get basal_params
@@ -180,7 +180,7 @@ DiscretizationFactory::createMeshStruct(Teuchos::RCP<Teuchos::ParameterList> dis
                   "!" << std::endl << "Supplied parameter list is " << std::endl << *disc_params <<
                   "\nValid Methods are: STK1D, STK2D, STK3D, STK3DPoint, Ioss," <<
                   " Exodus, Ascii," <<
-                  " Ascii2D, Extruded" << std::endl);
+                  " Ascii2D, STKExtruded, Extruded" << std::endl);
   }
 
   if (disc_params->isSublist ("Side Set Discretizations")) {

--- a/src/disc/Albany_DiscretizationFactory.cpp
+++ b/src/disc/Albany_DiscretizationFactory.cpp
@@ -8,6 +8,7 @@
 #include "Teuchos_TestForException.hpp"
 #include "Albany_DiscretizationFactory.hpp"
 
+#include "Albany_ExtrudedDiscretization.hpp"
 #include "Albany_STKDiscretization.hpp"
 // #include "Albany_BlockedSTKDiscretization.hpp"
 #include "Albany_TmplSTKMeshStruct.hpp"
@@ -331,7 +332,10 @@ createDiscretizationFromMeshStruct (const Teuchos::RCP<AbstractMeshStruct>& mesh
   Teuchos::RCP<AbstractDiscretization> disc;
   if (mesh->meshSpecs[0]->mesh_type==MeshType::Extruded)
   {
-    throw NotYetImplemented("ExtrudedDiscretization");
+    auto ext_mesh = Teuchos::rcp_dynamic_cast<ExtrudedMesh>(mesh);
+    auto basal_mesh = ext_mesh->basal_mesh();
+    auto basal_disc = createDiscretizationFromMeshStruct(basal_mesh,neq,{},rigidBodyModes);
+    disc = Teuchos::rcp(new ExtrudedDiscretization (discParams,neq,ext_mesh,basal_disc,comm,rigidBodyModes, sideSetEquations));
   } else if (mesh->meshLibName()=="STK") {
     auto ms = Teuchos::rcp_dynamic_cast<AbstractSTKMeshStruct>(mesh);
     disc = Teuchos::rcp(new STKDiscretization(discParams, neq, ms, comm, rigidBodyModes, sideSetEquations));

--- a/src/disc/Albany_ExtrudedConnManager.cpp
+++ b/src/disc/Albany_ExtrudedConnManager.cpp
@@ -87,7 +87,7 @@ ExtrudedConnManager::getElementBlock(const std::string& blockId) const
 const GO* ExtrudedConnManager::
 getConnectivity (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
       "Error! Cannot call getConnectivity before connectivity is build.\n");
   return m_connectivity.data() + getConnectivityStart(ielem);
 }
@@ -96,7 +96,7 @@ std::vector<int>
 ExtrudedConnManager::
 getConnectivityMask (const std::string& sub_part_name) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
       "Error! Cannot call getConnectivityMask before connectivity is build.\n");
   std::vector<int> mask(m_connectivity.size(),0);
   const auto& cell_layers_lid = m_mesh->cell_layers_lid();
@@ -189,9 +189,6 @@ buildConnectivity(const panzer::FieldPattern & fp)
   // We may remove the second assumption at some point, which means some parts
   // of the impl below will have to change.
 
-  TEUCHOS_TEST_FOR_EXCEPTION (m_is_connectivity_built, std::logic_error,
-      "[ExtrudedConnManager::buildConnectivity] Connectivity was already built.\n");
-
   using basis_type = Intrepid2::Basis<PHX::Device,RealType,RealType>;
   using tensor_basis_type = Intrepid2::Basis_TensorBasis<basis_type>;
 
@@ -265,7 +262,7 @@ buildConnectivity(const panzer::FieldPattern & fp)
 
   // Build SCALAR horiz connectivity
   // NOTE: if you generalize to fields of different patterns, fp_h will be a vector
-  m_conn_mgr_h->buildConnectivity(*fp_h);
+  m_conn_mgr_h->buildConnectivity(fp_h);
 
   // Compute basal max gid
   const auto& elems_h = m_conn_mgr_h->getElementsInBlock();
@@ -338,8 +335,6 @@ buildConnectivity(const panzer::FieldPattern & fp)
 
   m_num_vdofs_per_elem = ndofs_v;
   m_num_hdofs_per_elem = ndofs_h;
-
-  m_is_connectivity_built = true;
 }
 
 } // namespace Albany

--- a/src/disc/Albany_ExtrudedConnManager.cpp
+++ b/src/disc/Albany_ExtrudedConnManager.cpp
@@ -87,7 +87,7 @@ ExtrudedConnManager::getElementBlock(const std::string& blockId) const
 const GO* ExtrudedConnManager::
 getConnectivity (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "Error! Cannot call getConnectivity before connectivity is build.\n");
   return m_connectivity.data() + getConnectivityStart(ielem);
 }
@@ -96,7 +96,7 @@ std::vector<int>
 ExtrudedConnManager::
 getConnectivityMask (const std::string& sub_part_name) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "Error! Cannot call getConnectivityMask before connectivity is build.\n");
   std::vector<int> mask(m_connectivity.size(),0);
   const auto& cell_layers_lid = m_mesh->cell_layers_lid();

--- a/src/disc/Albany_ExtrudedConnManager.cpp
+++ b/src/disc/Albany_ExtrudedConnManager.cpp
@@ -1,0 +1,345 @@
+#include "Albany_ExtrudedConnManager.hpp"
+
+#include <Panzer_FieldAggPattern.hpp>
+#include <Panzer_GeometricAggFieldPattern.hpp>
+#include <Panzer_IntrepidFieldPattern.hpp>
+#include <Intrepid2_TensorBasis.hpp>
+
+namespace Albany {
+
+ExtrudedConnManager::
+ExtrudedConnManager(const Teuchos::RCP<ConnManager>&         conn_mgr_h,
+                    const Teuchos::RCP<const ExtrudedMesh>&  mesh)
+ : m_conn_mgr_h (conn_mgr_h)
+ , m_mesh(mesh)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (m_conn_mgr_h.is_null(), std::invalid_argument,
+      "[ExtrudedConnManager] Error! Invalid basal conn manager pointer.\n");
+  TEUCHOS_TEST_FOR_EXCEPTION (m_mesh.is_null(), std::invalid_argument,
+      "[ExtrudedConnManager] Error! Invalid extruded mesh pointer.\n");
+
+  const auto tri_topo = shards::CellTopology(shards::getCellTopologyData<shards::Triangle<3>>());
+  TEUCHOS_TEST_FOR_EXCEPTION (
+      m_conn_mgr_h->get_topology().getName()!=std::string(tri_topo.getName()), std::runtime_error,
+      "[ExtrudedConnManager::getElementBlockTopologies] Unsupported basal topology.\n"
+      "  Basal topology: " << m_conn_mgr_h->get_topology().getName() << "\n"
+      "  Supported basal topologies: " << tri_topo.getName() << "\n");
+
+  auto layers_data = mesh->cell_layers_lid();
+  m_num_elems = layers_data->numHorizEntities*layers_data->numLayers;
+
+  m_elem_blocks_names.resize(1, mesh->meshSpecs[0]->ebName);
+}
+
+Teuchos::RCP<panzer::ConnManager>
+ExtrudedConnManager::noConnectivityClone() const
+{
+  auto panzer_conn_mgr_h = m_conn_mgr_h->noConnectivityClone();
+  auto conn_mgr_h = Teuchos::rcp_dynamic_cast<ConnManager>(panzer_conn_mgr_h);
+  return Teuchos::rcp(new ExtrudedConnManager(conn_mgr_h,m_mesh));
+}
+
+std::vector<GO>
+ExtrudedConnManager::
+getElementsInBlock (const std::string& blockId) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (blockId!=m_elem_blocks_names[0],std::logic_error,
+      "[ExtrudedConnManager::getElementBlock] Error! Invalid elem block name: " + blockId + ".\n");
+
+  const auto& elems_basal = m_conn_mgr_h->getElementBlock();
+
+  std::vector<GO> elems;
+  auto layers_data = m_mesh->cell_layers_gid();
+  elems.reserve(m_num_elems);
+  for (auto bgid : elems_basal) {
+    for (int ilayer=0; ilayer<layers_data->numLayers; ++ilayer) {
+      elems.push_back (layers_data->getId(bgid,ilayer));
+    }
+  }
+  return elems;
+}
+
+std::string ExtrudedConnManager::
+getBlockId(LO localElmtId) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (localElmtId<0 or localElmtId>m_num_elems, std::runtime_error,
+      "[ExtrudedConnManager::getBlockId] Element LID (" << localElmtId << ") out of bounds [0," << m_num_elems << ")\n");
+
+  return elem_block_name();
+}
+
+void ExtrudedConnManager::
+getElementBlockTopologies(std::vector<shards::CellTopology>& elementBlockTopologies) const
+{
+  const auto& topo = shards::CellTopology(&m_mesh->meshSpecs[0]->ctd);
+  elementBlockTopologies.resize(numElementBlocks(),topo);
+}
+
+const std::vector<LO>&
+ExtrudedConnManager::getElementBlock(const std::string& blockId) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (blockId!=elem_block_name(),std::logic_error,
+      "[ExtrudedConnManager::getElementBlock] Error! Invalid elem block name: " + blockId + ".\n");
+
+  return m_elem_lids;
+}
+
+const GO* ExtrudedConnManager::
+getConnectivity (const LO ielem) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+      "Error! Cannot call getConnectivity before connectivity is build.\n");
+  return m_connectivity.data() + getConnectivityStart(ielem);
+}
+
+std::vector<int>
+ExtrudedConnManager::
+getConnectivityMask (const std::string& sub_part_name) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+      "Error! Cannot call getConnectivityMask before connectivity is build.\n");
+  std::vector<int> mask(m_connectivity.size(),0);
+  const auto& cell_layers_lid = m_mesh->cell_layers_lid();
+  const int num_basal_elems = m_mesh->basal_mesh()->get_num_local_elements();
+  const int num_layers = cell_layers_lid->numLayers;
+  if (sub_part_name=="basalside" or sub_part_name=="upperside" or
+      sub_part_name=="bottom" or sub_part_name=="top") {
+    const int ilay = sub_part_name=="basalside" or sub_part_name=="bottom" ? 0 : num_layers-1;
+    int num_side_dofs = m_num_dofs_per_elem / m_num_vdofs_per_elem;
+
+    const int lid_offset = ilay==0 ? 0 : num_side_dofs*(m_num_vdofs_per_elem-1);
+    for (int ie=0; ie<num_basal_elems; ++ie) {
+      const int ielem3d = cell_layers_lid->getId(ie,ilay);
+      auto m = &mask[getConnectivityStart(ielem3d)];
+      for (int idof=0; idof<num_side_dofs; ++idof) {
+        m[lid_offset+idof] = 1;
+      }
+    }
+  } else if (sub_part_name=="lateral" or sub_part_name=="lateralside" or
+             sub_part_name.substr(0,9)=="extruded_") {
+    std::vector<std::string> basal_ss_names;
+    if (sub_part_name=="lateral" or sub_part_name=="lateralside") {
+      basal_ss_names = m_mesh->basal_mesh()->meshSpecs[0]->ssNames;
+    } else {
+      basal_ss_names.push_back(m_mesh->get_basal_part_name(sub_part_name));
+    }
+    LayeredMeshNumbering<LO> dofs_layers(m_num_hdofs_per_elem*m_num_fields,m_num_vdofs_per_elem,LayeredMeshOrdering::LAYER);
+    for (const auto& basal_ssn : basal_ss_names) {
+      const auto& basal_mask = m_conn_mgr_h->getConnectivityMask(basal_ssn);
+      for (int ie=0; ie<num_basal_elems; ++ie) {
+        const int start_h = m_conn_mgr_h->getConnectivityStart(ie);
+        const int size_h  = m_conn_mgr_h->getConnectivitySize(ie);
+        const auto basal_conn = m_conn_mgr_h->getConnectivity(ie);
+        for (int idof=0; idof<size_h; ++idof) {
+          if (basal_mask[start_h+idof]==1) {
+            for (int ilay=0; ilay<num_layers; ++ilay) {
+              const int ielem3d = cell_layers_lid->getId(ie,ilay);
+              const int start3d = getConnectivityStart(ielem3d);
+              auto m = &mask[start3d];
+              for (int ilev=0; ilev<m_num_vdofs_per_elem; ++ilev) {
+                const int lid = dofs_layers.getId(idof,ilev);
+                m[lid] = 1;
+              }
+            }
+          }
+        }
+      }
+    }
+  } else if (sub_part_name.substr(0,5)=="basal") {
+    std::cout << "basal NS not yet implemented, but not erroring out for now...\n";
+  } else {
+    throw NotYetImplemented("ExtrudedConnManager::getConnectivityMask for generic sub-part");
+  }
+  return mask;
+}
+
+int ExtrudedConnManager::
+part_dim (const std::string& part_name) const
+{
+  const auto& ms = m_mesh->meshSpecs[0];
+  const auto& ss_names = ms->ssNames;
+  if (part_name==elem_block_name()) {
+    return ms->numDim;
+  } else if (std::find(ss_names.begin(),ss_names.end(),part_name)!=ss_names.end()) {
+    return ms->numDim - 1;
+  } else {
+    try {
+      return m_conn_mgr_h->part_dim(m_mesh->get_basal_part_name(part_name));
+    } catch (...) {
+      TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
+          "[ExtrudedConnManager::part_dim] Invalid part name: " + part_name + "\n");
+    }
+  }
+}
+  
+const Ownership*
+ExtrudedConnManager::getOwnership(LO localElmtId) const
+{
+  return m_ownership.data() + getConnectivityStart(localElmtId);
+}
+
+void ExtrudedConnManager::
+buildConnectivity(const panzer::FieldPattern & fp)
+{
+  // To build the 3d connectivity we make a few assumptions:
+  //   - the input pattern is a FieldAggPattern
+  //   - all patterns in the aggregate pattern are the same
+  //   - all patterns in the aggregate pattern are Intrepid2FieldPattern
+  //   - the basis in the Intrepid2FieldPattern is a tensor basis
+  // We may remove the second assumption at some point, which means some parts
+  // of the impl below will have to change.
+
+  TEUCHOS_TEST_FOR_EXCEPTION (m_is_connectivity_built, std::logic_error,
+      "[ExtrudedConnManager::buildConnectivity] Connectivity was already built.\n");
+
+  using basis_type = Intrepid2::Basis<PHX::Device,RealType,RealType>;
+  using tensor_basis_type = Intrepid2::Basis_TensorBasis<basis_type>;
+
+  auto fp_rcp = Teuchos::rcpFromRef(fp);
+  auto fp_agg = Teuchos::rcp_dynamic_cast<const panzer::FieldAggPattern>(fp_rcp,true);
+
+  // Unfortunately, FieldAggPattern does not expose how many fields are in it,
+  // so use try/catch block with one of the getters;
+  m_num_fields = 0;
+  while (true) {
+    try {
+      fp_agg->getFieldType(m_num_fields);
+      ++m_num_fields;
+    } catch(...) {
+      break;
+    }
+  };
+
+  using IFP = panzer::Intrepid2FieldPattern;
+  const auto line = shards::CellTopology(shards::getCellTopologyData<shards::Line<2>>());
+  auto basis2fp = [](const Teuchos::RCP<basis_type>& basis) {
+    return Teuchos::rcp(new panzer::Intrepid2FieldPattern(basis));
+  };
+
+  // Check that all fields have the same pattern
+  Teuchos::RCP<const IFP> intrepid_fp;
+  for (int ifield=0; ifield<m_num_fields; ++ifield) {
+    auto fpi = fp_agg->getFieldPattern(ifield);
+    auto this_fp = Teuchos::rcp_dynamic_cast<const IFP>(fpi,true);
+
+    // TODO: allowing fields with different patterns would be nice, but much more complicated.
+    //       For now, require same pattern, and move on. Later, we may generalize.
+    TEUCHOS_TEST_FOR_EXCEPTION (
+        intrepid_fp!=Teuchos::null and this_fp!=intrepid_fp and not this_fp->equals(*intrepid_fp),
+        std::runtime_error,
+        "ExtrudedConnManager expects a FieldPattern consisting of N copies of the same Intrepid2FieldPattern.\n");
+    intrepid_fp = this_fp;
+  }
+
+  // Now build the horiz/vert patterns
+  auto basis = intrepid_fp->getIntrepidBasis();
+  auto tbasis = Teuchos::rcp_dynamic_cast<tensor_basis_type>(basis,true);
+  auto comps = tbasis->getTensorBasisComponents();
+
+  TEUCHOS_TEST_FOR_EXCEPTION (comps.size()!=2, std::runtime_error,
+      "ExtrudedConnManager can only handle a tensor basis with 2 tensor components.\n"
+      "  - tensor basis name  : " << tbasis->getName() << "\n"
+      "  - num tensorial comps: " << comps.size() << "\n");
+
+  auto basis_h = comps[0];
+  auto basis_v = comps[1];
+  TEUCHOS_TEST_FOR_EXCEPTION (basis_v->getBaseCellTopology()!=line, std::runtime_error,
+      "ExtrudedConnManager expects a tensor product of the form BasisBasal X Line.\n"
+      "  - vert basis name: " << basis_v->getName() << "\n"
+      "  - vert basis base cell topo: " << basis_v->getBaseCellTopology().getName() << "\n");
+
+  const auto& basalShape = basis_h->getBaseCellTopology();
+  TEUCHOS_TEST_FOR_EXCEPTION (basalShape.getKey()!=m_conn_mgr_h->get_topology().getKey(), std::invalid_argument,
+      "[ExtrudedConnManager] Intrepid field pattern is incompatible with basal conn manager:\n"
+      "  - basal conn manager cell topo : " << m_conn_mgr_h->get_topology().getName() << "\n"
+      "  - field pattern basal cell topo: " << basalShape.getName() << "\n");
+
+  auto cell_layers_gid = m_mesh->cell_layers_gid();
+  auto cell_layers_lid = m_mesh->cell_layers_lid();
+
+  // Build horiz and vertical intrepid patterns.
+  // TODO: if you generalize to fields of different patterns,
+  //       you'll need a vector of patterns (one per field)
+  auto fp_v = Teuchos::rcp(new IFP (basis_v));
+  auto fp_h = Teuchos::rcp(new IFP (basis_h));
+
+  // Build SCALAR horiz connectivity
+  // NOTE: if you generalize to fields of different patterns, fp_h will be a vector
+  m_conn_mgr_h->buildConnectivity(*fp_h);
+
+  // Compute basal max gid
+  const auto& elems_h = m_conn_mgr_h->getElementsInBlock();
+  const int nelems_h = elems_h.size();
+  GO my_max_gid = 0;
+  for (int ie=0; ie<nelems_h; ++ie) {
+    const int ndofs = m_conn_mgr_h->getConnectivitySize(ie);
+    const GO* dofs  = m_conn_mgr_h->getConnectivity(ie);
+    for (int idof=0; idof<ndofs; ++idof) {
+      my_max_gid = std::max(my_max_gid,dofs[idof]);
+    }
+  }
+  GO max_gid_h;
+  auto comm = m_mesh->comm();
+  Teuchos::reduceAll(*comm,Teuchos::REDUCE_MAX,1,&my_max_gid,&max_gid_h);
+
+  // These are either 0 or 1, since fp_v is a scalar FP
+  // NOTE: if you generalize to fields with different vert pattern, you will
+  //       have to turn these into vectors
+  const LO nodeIdCnt_v = fp_v->getSubcellIndices(0,0).size();
+  const LO cellIdCnt_v = fp_v->getSubcellIndices(1,0).size();
+
+  // Total number of dofs in "vertical grid" (for a scalar field)
+  GO numDofLayers = (cell_layers_gid->numLayers+1) * nodeIdCnt_v
+                  +  cell_layers_gid->numLayers    * cellIdCnt_v;
+  m_num_dofs_layers = numDofLayers;
+
+  m_num_dofs_per_elem = fp.numberIds();
+
+  // The strategy to number dofs is the following:
+  //  1. loop over num belems and num levs, compute ielem3d with layered data
+  //  2. compute horiz conn for that ibelem
+  //  3. add dofs for 3d elem on a per-layer basis (local ordering), but honoring
+  //     the user requests when it comes to global ids.
+  LayeredMeshNumbering<GO> dofs_layers_data(m_num_fields*(max_gid_h+1),numDofLayers,cell_layers_gid->ordering);
+
+  const int ndofs_v = fp_v->numberIds();
+  const int ndofs_h = fp_h->numberIds();
+  m_ownership.resize(m_num_elems*m_num_dofs_per_elem);
+  m_connectivity.resize(m_num_elems*m_num_dofs_per_elem);
+  for (int ibelem=0; ibelem<m_mesh->basal_mesh()->get_num_local_elements(); ++ibelem) {
+    auto conn_h = m_conn_mgr_h->getConnectivity(ibelem);
+    auto ownership_h = m_conn_mgr_h->getOwnership(ibelem);
+
+    auto add_layer_conn = [&](const int dof_layer, int elem_offset,
+                              Ownership* ownership, GO* connectivity) {
+      for (int idof_h=0; idof_h<ndofs_h; ++idof_h) {
+        for (int ifield=0; ifield<m_num_fields; ++ifield) {
+          auto dof2d = conn_h[idof_h]*m_num_fields+ifield;
+          connectivity[elem_offset+idof_h*m_num_fields+ifield] = dofs_layers_data.getId(dof2d,dof_layer);
+          ownership[elem_offset+idof_h*m_num_fields+ifield] = ownership_h[idof_h*m_num_fields+ifield];
+        }
+      }
+    };
+
+    for (int ilay=0; ilay<cell_layers_lid->numLayers; ++ilay) {
+      int ielem = cell_layers_lid->getId(ibelem,ilay);
+
+      const GO ielem_offset = ielem*m_num_dofs_per_elem;
+      auto conn3d = &m_connectivity[ielem_offset];
+      for (int ilev_dof=0; ilev_dof<ndofs_v; ++ilev_dof) {
+        int dof_lev = ilay*cellIdCnt_v+ilay*nodeIdCnt_v + ilev_dof;
+        int elem_offset = ilev_dof*ndofs_h*m_num_fields;
+        add_layer_conn(dof_lev, elem_offset,
+                       &m_ownership[ielem_offset],
+                       &m_connectivity[ielem_offset]);
+      }
+    }
+  }
+
+  m_num_vdofs_per_elem = ndofs_v;
+  m_num_hdofs_per_elem = ndofs_h;
+
+  m_is_connectivity_built = true;
+}
+
+} // namespace Albany

--- a/src/disc/Albany_ExtrudedConnManager.cpp
+++ b/src/disc/Albany_ExtrudedConnManager.cpp
@@ -125,11 +125,10 @@ getConnectivityMask (const std::string& sub_part_name) const
     }
     LayeredMeshNumbering<LO> dofs_layers(m_num_hdofs_per_elem*m_num_fields,m_num_vdofs_per_elem,LayeredMeshOrdering::LAYER);
     for (const auto& basal_ssn : basal_ss_names) {
-      const auto& basal_mask = m_conn_mgr_h->getConnectivityMask(basal_ssn);
+      const auto basal_mask = m_conn_mgr_h->getConnectivityMask(basal_ssn);
       for (int ie=0; ie<num_basal_elems; ++ie) {
         const int start_h = m_conn_mgr_h->getConnectivityStart(ie);
         const int size_h  = m_conn_mgr_h->getConnectivitySize(ie);
-        const auto basal_conn = m_conn_mgr_h->getConnectivity(ie);
         for (int idof=0; idof<size_h; ++idof) {
           if (basal_mask[start_h+idof]==1) {
             for (int ilay=0; ilay<num_layers; ++ilay) {

--- a/src/disc/Albany_ExtrudedConnManager.hpp
+++ b/src/disc/Albany_ExtrudedConnManager.hpp
@@ -1,0 +1,89 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_EXTRUDED_CONN_MANAGER_HPP
+#define ALBANY_EXTRUDED_CONN_MANAGER_HPP
+
+#include "Albany_ConnManager.hpp"
+#include "Albany_ExtrudedMesh.hpp"
+
+namespace Albany {
+
+/*
+ * A class providing the connectivity manager interfaces for
+ * an underlying extruded mesh, without having access
+ * to the full extruded mesh.
+ */
+
+class ExtrudedConnManager : public ConnManager {
+public:
+  ExtrudedConnManager (const Teuchos::RCP<ConnManager>&         conn_mgr_h,
+                       const Teuchos::RCP<const ExtrudedMesh>&  mesh);
+  ~ExtrudedConnManager() = default;
+
+  // Element blocks information
+  std::vector<GO> getElementsInBlock (const std::string& blockId) const override;
+  std::string getBlockId(LO localElmtId) const override;
+  std::size_t numElementBlocks() const override { return 1; } // For now, assum basal mesh has one block
+  void getElementBlockTopologies(std::vector<shards::CellTopology> & elementBlockTopologies) const override;
+  const std::vector<LO>& getElementBlock(const std::string& blockId) const override;
+
+  // Connectivity info
+  int getConnectivityStart (const LO ielem) const override;
+  const GO * getConnectivity(LO localElmtId) const override;
+  LO getConnectivitySize (LO localElmtId) const override;
+  std::vector<int> getConnectivityMask (const std::string& sub_part_name) const override;
+  const Ownership* getOwnership(LO localElmtId) const override;
+
+  // Methods called by panzer
+  Teuchos::RCP<panzer::ConnManager> noConnectivityClone() const override;
+  void buildConnectivity(const panzer::FieldPattern & fp) override;
+
+  int part_dim (const std::string& part_name) const override;
+
+protected:
+  Teuchos::RCP<ConnManager>           m_conn_mgr_h;
+  Teuchos::RCP<const ExtrudedMesh>    m_mesh;
+
+  int m_num_elems;
+
+  int m_num_vdofs_per_elem; // For each field
+  int m_num_hdofs_per_elem; // For each field
+  int m_num_fields;
+
+  // Equal to the product of the 3 above
+  int m_num_dofs_per_elem;
+
+  // Equals to 2*num_vdofs_per_node + num_vdofs_per_elem
+  int m_num_dofs_layers;
+
+  std::vector<LO>                     m_elem_lids;
+  std::vector<GO>                     m_connectivity;
+  std::vector<Ownership>              m_ownership;
+};
+
+// ================ INLINED METHODS ================= //
+
+inline int ExtrudedConnManager::
+getConnectivityStart (const LO ielem) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+      "Error! Cannot call getConnectivityStart before connectivity is build.\n");
+
+  return ielem * m_num_dofs_per_elem;
+}
+
+inline int ExtrudedConnManager::
+getConnectivitySize (const LO ielem) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+      "Error! Cannot call getConnectivitySize before connectivity is build.\n");
+  return m_num_dofs_per_elem;
+}
+
+} // namespace Albany
+
+#endif // ALBANY_EXTRUDED_CONN_MANAGER_HPP

--- a/src/disc/Albany_ExtrudedConnManager.hpp
+++ b/src/disc/Albany_ExtrudedConnManager.hpp
@@ -70,7 +70,7 @@ protected:
 inline int ExtrudedConnManager::
 getConnectivityStart (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
       "Error! Cannot call getConnectivityStart before connectivity is build.\n");
 
   return ielem * m_num_dofs_per_elem;
@@ -79,7 +79,7 @@ getConnectivityStart (const LO ielem) const
 inline int ExtrudedConnManager::
 getConnectivitySize (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
       "Error! Cannot call getConnectivitySize before connectivity is build.\n");
   return m_num_dofs_per_elem;
 }

--- a/src/disc/Albany_ExtrudedConnManager.hpp
+++ b/src/disc/Albany_ExtrudedConnManager.hpp
@@ -70,7 +70,7 @@ protected:
 inline int ExtrudedConnManager::
 getConnectivityStart (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "Error! Cannot call getConnectivityStart before connectivity is build.\n");
 
   return ielem * m_num_dofs_per_elem;
@@ -79,7 +79,7 @@ getConnectivityStart (const LO ielem) const
 inline int ExtrudedConnManager::
 getConnectivitySize (const LO ielem) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_fp.is_null(), std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "Error! Cannot call getConnectivitySize before connectivity is build.\n");
   return m_num_dofs_per_elem;
 }

--- a/src/disc/Albany_ExtrudedDiscretization.cpp
+++ b/src/disc/Albany_ExtrudedDiscretization.cpp
@@ -1,0 +1,1337 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include <Albany_ExtrudedDiscretization.hpp>
+
+#include <Albany_ExtrudedConnManager.hpp>
+#include <Albany_CommUtils.hpp>
+#include <Albany_ThyraUtils.hpp>
+#include "Albany_Macros.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+#include "Albany_GlobalLocalIndexer.hpp"
+#include "Albany_ProblemUtils.hpp"
+
+#include <PHAL_Dimension.hpp>
+
+#include <Panzer_IntrepidFieldPattern.hpp>
+#include <Panzer_ElemFieldPattern.hpp>
+
+#include <iostream>
+#include <string>
+
+// Uncomment the following line if you want debug output to be printed to screen
+#define OUTPUT_TO_SCREEN
+
+namespace Albany {
+
+ExtrudedDiscretization::
+ExtrudedDiscretization (const Teuchos::RCP<Teuchos::ParameterList>&     discParams,
+                        const int                                       neq,
+                        const Teuchos::RCP<ExtrudedMesh>&               extruded_mesh,
+                        const Teuchos::RCP<AbstractDiscretization>&     basal_disc,
+                        const Teuchos::RCP<const Teuchos_Comm>&         comm,
+                        const Teuchos::RCP<RigidBodyModes>&             rigidBodyModes,
+                        const std::map<int, std::vector<std::string>>&  sideSetEquations)
+ : m_comm(comm)
+ , m_basal_disc (basal_disc)
+ , m_neq (neq)
+ , m_sideSetEquations(sideSetEquations)
+ , m_rigid_body_modes(rigidBodyModes)
+ , m_extruded_mesh(extruded_mesh)
+ , m_disc_params (discParams)
+{
+  sideSetDiscretizations["basalside"] = basal_disc;
+}
+
+void
+ExtrudedDiscretization::setupMLCoords()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: setupMLCoords");
+  if (m_rigid_body_modes.is_null()) { return; }
+  if (!m_rigid_body_modes->isMueLuUsed() && !m_rigid_body_modes->isFROSchUsed()) { return; }
+
+  const int numDim = getNumDim();
+  auto coordMV = Thyra::createMembers(getNodeVectorSpace(), numDim);
+  auto coordMV_data = getNonconstLocalData(coordMV);
+
+  // NOTE: you cannot use DOFManager dof gids as entity ID in stk, and viceversa.
+  // All you can do is loop over dofs/nodes in an element, since you have the following guarantees:
+  //  - elem GIDs are the same in DOFManager and stk mesh
+  //  - nodes ordering is the same in DOFManager and stk mesh
+  // We'll loop over certain nodes more than once, but this is a setup method, so it's fine
+  const auto& node_dof_mgr = getNodeDOFManager();
+  const auto& elems = node_dof_mgr->getAlbanyConnManager()->getElementsInBlock();
+  const int   num_elems = elems.size();
+  for (int ielem=0; ielem<num_elems; ++ielem) {
+    const auto& node_dofs = node_dof_mgr->getElementGIDs(ielem);
+    const int num_nodes = node_dofs.size();
+    for (int i=0; i<num_nodes; ++i) {
+      LO node_lid = node_dof_mgr->indexer()->getLocalElement(node_dofs[i]);
+      if (node_lid>=0) {
+        double* X = &m_nodes_coordinates[numDim*node_lid];
+        for (int j=0; j<numDim; ++j) {
+          coordMV_data[j][node_lid] = X[j];
+        }
+      }
+    }
+  }
+
+  m_rigid_body_modes->setCoordinatesAndComputeNullspace(
+      coordMV,
+      getVectorSpace(),
+      getOverlapVectorSpace());
+}
+
+void
+ExtrudedDiscretization::writeSolution(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const double        time,
+    const bool          overlapped,
+    const bool          force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+}
+
+void
+ExtrudedDiscretization::writeSolution(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const double        time,
+    const bool          overlapped,
+    const bool          force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+}
+
+void
+ExtrudedDiscretization::writeSolution(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const Thyra_Vector& soln_dotdot,
+    const double        time,
+    const bool          overlapped,
+    const bool          force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+}
+
+void
+ExtrudedDiscretization::writeSolutionMV(
+    const Thyra_MultiVector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const double             time,
+    const bool               overlapped,
+    const bool               force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionMV");
+}
+
+void
+ExtrudedDiscretization::writeSolutionToMeshDatabase(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const double /* time */,
+    const bool overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
+}
+
+void
+ExtrudedDiscretization::writeSolutionToMeshDatabase(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const double /* time */,
+    const bool overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
+}
+
+void
+ExtrudedDiscretization::writeSolutionToMeshDatabase(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const Thyra_Vector& soln_dotdot,
+    const double /* time */,
+    const bool overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
+}
+
+void
+ExtrudedDiscretization::writeSolutionMVToMeshDatabase(
+    const Thyra_MultiVector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const double /* time */,
+    const bool overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
+}
+
+void
+ExtrudedDiscretization::writeSolutionToFile(
+    const Thyra_Vector& soln,
+    const double        time,
+    const bool          overlapped,
+    const bool          force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToFile");
+}
+
+void
+ExtrudedDiscretization::writeSolutionMVToFile(
+    const Thyra_MultiVector& soln,
+    const double             time,
+    const bool               overlapped,
+    const bool               force_write_solution)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionMVToFile");
+}
+
+Teuchos::RCP<Thyra_Vector>
+ExtrudedDiscretization::getSolutionField(bool overlapped) const
+{
+  throw NotYetImplemented("ExtrudedDiscretization::getSolutionField");
+  // // Copy soln vector into solution field, one node at a time
+  // Teuchos::RCP<Thyra_Vector> soln = Thyra::createMember(getVectorSpace());
+  // this->getSolutionField(*soln, overlapped);
+  // return soln;
+}
+
+void
+ExtrudedDiscretization::getField(Thyra_Vector& result, const std::string& name) const
+{
+  throw NotYetImplemented("ExtrudedDiscretization::getField");
+  // auto dof_mgr = getDOFManager(name);
+  // solutionFieldContainer->fillVector(result, name, dof_mgr, false);
+}
+
+void
+ExtrudedDiscretization::getSolutionField(Thyra_Vector& result, const bool overlapped) const
+{
+  throw NotYetImplemented("ExtrudedDiscretization::getSolutionField");
+  // TEUCHOS_TEST_FOR_EXCEPTION(overlapped, std::logic_error, "Not implemented.");
+
+  // solutionFieldContainer->fillSolnVector(result, getDOFManager(), overlapped);
+}
+
+void
+ExtrudedDiscretization::getSolutionMV(
+    Thyra_MultiVector& result,
+    const bool         overlapped) const
+{
+  throw NotYetImplemented("ExtrudedDiscretization::getSolutionMV");
+  // TEUCHOS_TEST_FOR_EXCEPTION(overlapped, std::logic_error, "Not implemented.");
+
+  // solutionFieldContainer->fillSolnMultiVector(result, getDOFManager(), overlapped);
+}
+
+/*****************************************************************/
+/*** Private functions follow. These are just used in above code */
+/*****************************************************************/
+
+void
+ExtrudedDiscretization::setField(
+    const Thyra_Vector& result,
+    const std::string&  name,
+    bool                overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::setField");
+  // const auto dof_mgr = getDOFManager(name);
+  // solutionFieldContainer->saveVector(result,name,dof_mgr,overlapped);
+}
+
+void
+ExtrudedDiscretization::setSolutionField(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const bool          overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::setSolutionField");
+  // const auto& dof_mgr = getDOFManager();
+  // solutionFieldContainer->saveSolnVector(soln, soln_dxdp, dof_mgr, overlapped);
+}
+
+void
+ExtrudedDiscretization::setSolutionField(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const bool          overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::setSolutionField");
+  // const auto& dof_mgr = getDOFManager();
+  // solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, dof_mgr, overlapped);
+}
+
+void
+ExtrudedDiscretization::setSolutionField(
+    const Thyra_Vector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const Thyra_Vector& soln_dot,
+    const Thyra_Vector& soln_dotdot,
+    const bool          overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::setSolutionField");
+  // const auto& dof_mgr = getDOFManager();
+  // solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, soln_dotdot, dof_mgr, overlapped);
+}
+
+void
+ExtrudedDiscretization::setSolutionFieldMV(
+    const Thyra_MultiVector& soln,
+    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+    const bool               overlapped)
+{
+  throw NotYetImplemented("ExtrudedDiscretization::setSolutionFieldMV");
+  // const auto& dof_mgr = getDOFManager();
+  // solutionFieldContainer->saveSolnMultiVector(soln, soln_dxdp, dof_mgr, overlapped);
+}
+
+void ExtrudedDiscretization::computeCoordinates ()
+{
+  m_nodes_coordinates.resize(getNumDim() * getLocalSubdim(getOverlapNodeVectorSpace()));
+
+  const auto& node_layers_lid = m_extruded_mesh->node_layers_lid();
+  const auto& node_layers_gid = m_extruded_mesh->node_layers_gid();
+
+  const int num_layers = m_extruded_mesh->cell_layers_gid()->numLayers;
+
+  std::vector<double> levelsNormalizedThickness(num_layers+1);
+  bool useGlimmerSpacing = m_disc_params->get("Use Glimmer Spacing", false);
+  if(useGlimmerSpacing)
+    for (int i = 0; i <= num_layers; ++i)
+      levelsNormalizedThickness[num_layers-i] = 1.0- (1.0 - std::pow(double(i) / num_layers + 1.0, -2))/(1.0 - std::pow(2.0, -2));
+  else  //uniform layers
+    for (int i = 0; i <= num_layers; i++)
+      levelsNormalizedThickness[i] = double(i) / num_layers;
+
+  const auto& basal_node_dof_mgr = m_basal_disc->getNodeDOFManager();
+  const auto& basal_elem_lids = basal_node_dof_mgr->elem_dof_lids().host();
+  const auto& basal_elems = basal_node_dof_mgr->getAlbanyConnManager()->getElementsInBlock();
+  const auto& basal_coords = sideSetDiscretizations["basalside"]->getCoordinates();
+  const auto& basal_mesh = m_extruded_mesh->basal_mesh();
+  
+  std::string thickness_name = m_disc_params->get<std::string>("Thickness Field Name","thickness");
+  std::string surface_height_name = m_disc_params->get<std::string>("Surface Height Field Name","surface_height");
+
+  auto surf_height = Thyra::createMember(basal_node_dof_mgr->ov_vs());
+  auto thickness   = Thyra::createMember(basal_node_dof_mgr->ov_vs());
+  basal_mesh->get_field_accessor()->fillVector(*surf_height,surface_height_name,basal_node_dof_mgr, true);
+  basal_mesh->get_field_accessor()->fillVector(*thickness,thickness_name,basal_node_dof_mgr, true);
+  auto s_h = getLocalData(surf_height.getConst());
+  auto H = getLocalData(thickness.getConst());
+
+  const auto node_indexer = getNodeDOFManager()->ov_indexer();
+  const int num_basal_elems = basal_elems.size();
+  const int npe_basal = basal_elem_lids.extent(1); // nodes-per-element
+  const int basal_dim = m_basal_disc->getNumDim();
+  const int mesh_dim = getNumDim();
+  auto ni_vs = node_indexer->getVectorSpace();
+  auto my_gids = getGlobalElements(ni_vs);
+  for (int ielem=0; ielem<num_basal_elems; ++ielem) {
+    const auto& basal_node_gids = basal_node_dof_mgr->getElementGIDs(ielem);
+    for (int node=0; node<npe_basal; ++node) {
+      const int basal_node_lid = basal_elem_lids(ielem,node);
+      const GO basal_node_gid  = basal_node_gids[node];
+      double* bcoords = &basal_coords[basal_dim*basal_node_lid];
+
+      for (int ilev=0; ilev<=num_layers; ++ilev) {
+        // if (ilev!=num_layers)V
+        // int elem3d = cell_layers_lid->getId(ielem,min(ilev
+        // const auto& node_gids = node_dof_mgr->getElementGIDs(ielem);
+        const GO node_gid = node_layers_gid->getId(basal_node_gid, ilev);
+        const int node_lid = node_indexer->getLocalElement(node_gid);
+        double* coords = &m_nodes_coordinates[mesh_dim*node_lid];
+
+        for (int idim=0; idim<basal_dim; ++idim) {
+          coords[idim] = bcoords[idim];
+        }
+        coords[basal_dim] = s_h[basal_node_lid] - H[basal_node_lid] * (1. - levelsNormalizedThickness[ilev]);
+      }
+    }
+  }
+
+#ifdef OUTPUT_TO_SCREEN
+  printCoords();
+#endif
+}
+
+void ExtrudedDiscretization::createDOFManagers()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization:createDOFManagers");
+  // NOTE: in Albany we use the mesh part name "" to refer to the whole mesh.
+  //       That's not the name that stk uses for the whole mesh. So if the
+  //       dof part name is "", we get the part stored in the stk mesh struct
+  //       for the element block, where we REQUIRE that there is only ONE element block.
+
+  strmap_t<std::pair<std::string,int>> name_to_partAndDim;
+  name_to_partAndDim[solution_dof_name()] = std::make_pair("",m_neq);
+  name_to_partAndDim[nodes_dof_name()] = std::make_pair("",1);
+  for (const auto& sis : m_extruded_mesh->get_field_accessor()->getNodalParameterSIS()) {
+    const auto& dims = sis->dim;
+    int dof_dim = -1;
+    switch (dims.size()) {
+      case 2: dof_dim = 1;               break;
+      case 3: dof_dim = dims[2];         break;
+      case 4: dof_dim = dims[2]*dims[3]; break;
+      default:
+        TEUCHOS_TEST_FOR_EXCEPTION (true, std::runtime_error,
+            "Error! Unsupported layout for nodal parameter '" + sis->name + ".\n");
+    }
+
+    name_to_partAndDim[sis->name] = std::make_pair(sis->meshPart,dof_dim);
+  }
+
+  for (const auto& it : name_to_partAndDim) {
+    const auto& field_name = it.first;
+    const auto& part_name  = it.second.first;
+    const auto& dof_dim    = it.second.second;
+
+    // NOTE: for now we hard code P1. In the future, we must be able to
+    //       store this info somewhere and retrieve it here.
+    auto dof_mgr = create_dof_mgr(part_name,field_name,FE_Type::HGRAD,1,dof_dim);
+    m_dof_managers[field_name][part_name] = dof_mgr;
+    m_node_dof_managers[part_name] = Teuchos::null;
+  }
+
+  // For each part, also make a Node dof manager
+  for (auto& it : m_node_dof_managers) {
+    const auto& part_name = it.first;
+    it.second = create_dof_mgr(part_name, nodes_dof_name(), FE_Type::HGRAD,1,1);
+  }
+}
+
+void
+ExtrudedDiscretization::computeGraphs()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: computeGraphs");
+  const auto vs = getVectorSpace();
+  const auto ov_vs = getOverlapVectorSpace();
+  m_jac_factory = Teuchos::rcp(new ThyraCrsMatrixFactory(vs, vs, ov_vs, ov_vs));
+
+  // Determine which equations are defined on the whole domain,
+  // as well as what eqn are on each sideset
+  std::vector<int> volumeEqns;
+  std::map<std::string,std::vector<int>> ss_to_eqns;
+  for (int k=0; k < m_neq; ++k) {
+    if (m_sideSetEquations.find(k) == m_sideSetEquations.end()) {
+      volumeEqns.push_back(k);
+    }
+  }
+  const int numVolumeEqns = volumeEqns.size();
+
+  // The global solution dof manager
+  const auto sol_dof_mgr = getDOFManager();
+  const int num_elems = sol_dof_mgr->cell_indexer()->getNumLocalElements();
+
+  // Handle the simple case, and return immediately
+  if (numVolumeEqns==m_neq) {
+    // This is the easy case: couple everything with everything
+    for (int icell=0; icell<num_elems; ++icell) {
+      const auto& elem_gids = sol_dof_mgr->getElementGIDs(icell);
+      m_jac_factory->insertGlobalIndices(elem_gids,elem_gids,true);
+    }
+    m_jac_factory->fillComplete();
+    return;
+  }
+
+  // Ok, if we're here there is at least 1 side equation
+  Teuchos::Array<GO> rows,cols;
+
+  // First, couple global eqn (row) with global eqn (col)
+  for (int icell=0; icell<num_elems; ++icell) {
+    const auto& elem_gids = sol_dof_mgr->getElementGIDs(icell);
+
+    for (int ieq=0; ieq<numVolumeEqns; ++ieq) {
+
+      // Couple eqn=ieq with itself
+      const auto& row_gids_offsets = sol_dof_mgr->getGIDFieldOffsets(volumeEqns[ieq]);
+      const int num_row_gids = row_gids_offsets.size();
+      rows.resize(num_row_gids);
+      for (int idof=0; idof<num_row_gids; ++idof) {
+        rows[idof] = elem_gids[row_gids_offsets[idof]];
+      }
+      m_jac_factory->insertGlobalIndices(rows(),rows(),false);
+
+      // Couple eqn=ieq with eqn=jeq!=ieq
+      for (int jeq=0; jeq<numVolumeEqns; ++jeq) {
+        const auto& col_gids_offsets = sol_dof_mgr->getGIDFieldOffsets(jeq);
+        const int num_col_gids = col_gids_offsets.size();
+        cols.resize(num_col_gids);
+        for (int jdof=0; jdof<num_col_gids; ++jdof) {
+          cols[jdof] = elem_gids[col_gids_offsets[jdof]];
+        }
+        m_jac_factory->insertGlobalIndices(rows(),cols(),true);
+      }
+    }
+
+    // While at it, for side set equations, set the diag entry, so that jac pattern
+    // is for sure non-singular in the volume.
+    for (const auto& it : m_sideSetEquations) {
+      int eq = it.first;
+      const auto& eq_offsets = sol_dof_mgr->getGIDFieldOffsets(eq);
+      for (auto o : eq_offsets) {
+        GO row = elem_gids[o];
+        m_jac_factory->insertGlobalIndices(row,row,false);
+      }
+    }
+  }
+
+  // Now, process rows/cols corresponding to ss equations
+  const auto& cell_layers_data_lid = m_extruded_mesh->cell_layers_lid();
+  const auto& cell_layers_data_gid = m_extruded_mesh->cell_layers_gid();
+  for (const auto& it : m_sideSetEquations) {
+    const int side_eq = it.first;
+
+    // If the side eqn is column-coupled, it needs special treatment.
+    // A side eqn can be coupled to the whole column if
+    //   1) the mesh is layered, AND
+    //   2) all sidesets where it's defined are on the top or bottom
+    int allowColumnCoupling = 1;
+    for (const auto& ss_name : it.second) {
+      SideStruct* side = nullptr;
+      for (int ws=0; ws<getNumWorksets(); ++ws) {
+        if (m_sideSets[ws].at(ss_name).size()>0) {
+          side = &m_sideSets[ws].at(ss_name)[0];
+        }
+      }
+      if (side==nullptr) {
+        // This rank owns 0 sides on this sideset
+        continue;
+      }
+
+      // Given any side of this sideSet, check layerId and pos within element,
+      // to determine if we are on the top/bot of the mesh
+      const auto pos = side->side_pos;
+      const auto layer = cell_layers_data_gid->getLayerId(side->elem_GID);
+
+      if (layer==(cell_layers_data_lid->numLayers-1)) {
+        allowColumnCoupling = pos==cell_layers_data_lid->top_side_pos;
+      } else if (layer==0) {
+        allowColumnCoupling = pos==cell_layers_data_lid->bot_side_pos;
+      } else {
+        // This sideset is niether top nor bottom
+        allowColumnCoupling = 0;
+      }
+    }
+    // NOTE: Teuchos::reduceAll does not accept bool Packet, despite offerint REDUCE_AND as reduction op, so use int
+    int globalAllowColumnCoupling = allowColumnCoupling;
+    Teuchos::reduceAll(*m_comm,Teuchos::REDUCE_AND,1,&allowColumnCoupling,&globalAllowColumnCoupling);
+
+    // Loop over all side sets where this eqn is defined
+    for (const auto& ss_name : it.second) {
+      for (int ws=0; ws<getNumWorksets(); ++ws) {
+        const auto& elem_lids = getElementLIDs_host(ws);
+        const auto& ss = m_sideSets[ws].at(ss_name);
+
+        // Loop over all sides in this side set
+        for (const auto& side : ss) {
+          const LO ws_elem_idx = side.ws_elem_idx;
+          const LO elem_LID = elem_lids(ws_elem_idx);
+          const auto& side_elem_gids = sol_dof_mgr->getElementGIDs(elem_LID);
+          const int side_pos = side.side_pos;
+          const auto& side_eq_offsets = sol_dof_mgr->getGIDFieldOffsetsSide(side_eq,side_pos);
+
+          // Compute row GIDs
+          const int num_row_gids = side_eq_offsets.size();
+          rows.resize(num_row_gids);
+          for (int idof=0; idof<num_row_gids; ++idof) {
+            rows[idof] = side_elem_gids[side_eq_offsets[idof]];
+          }
+
+          if (globalAllowColumnCoupling) {
+            // Assume the worst, and couple with all eqns over the whole column
+            const int numLayers = cell_layers_data_lid->numLayers;
+            const LO basal_elem_LID = cell_layers_data_lid->getColumnId(elem_LID);
+            for (int eq=0; eq<m_neq; ++eq) {
+              const auto& eq_offsets = sol_dof_mgr->getGIDFieldOffsets(eq);
+              const int num_col_gids = eq_offsets.size();
+              cols.resize(num_col_gids);
+              for (int il=0; il<numLayers; ++il) {
+                const LO layer_elem_lid = cell_layers_data_lid->getId(basal_elem_LID,il);
+                const auto& elem_gids = sol_dof_mgr->getElementGIDs(layer_elem_lid);
+
+                for (int jdof=0; jdof<num_col_gids; ++jdof) {
+                  cols[jdof] = elem_gids[eq_offsets[jdof]];
+                }
+                m_jac_factory->insertGlobalIndices(rows(),cols(),true);
+              }
+            }
+          } else {
+
+            // Add local coupling (on this side) with all eqns
+            // NOTE: we could be fancier, and couple only with volume eqn or side eqn that are defined
+            //       on this side set. However, if a sideset is a subset of another, we might miss the
+            //       coupling since the side sets have different names. We'd have to inspect if a ss is
+            //       contained in the other, but that starts to get too involved. Given that it's not
+            //       a common scenario (need 2+ ss eqn defined on 2 different sidesets), and that we
+            //       might have to redo this when we assemble by blocks, we just don't bother.
+            for (int col_eq=0; col_eq<m_neq; ++col_eq) {
+              const auto& col_eq_offsets = sol_dof_mgr->getGIDFieldOffsetsSide(col_eq,side_pos);
+              const int num_col_gids = col_eq_offsets.size();
+              cols.resize(num_col_gids);
+              for (int jdof=0; jdof<num_col_gids; ++jdof) {
+                cols[jdof] = side_elem_gids[col_eq_offsets[jdof]];
+              }
+
+              m_jac_factory->insertGlobalIndices(rows(),cols(),true);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  m_jac_factory->fillComplete();
+}
+
+void
+ExtrudedDiscretization::computeWorksetInfo()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: computeWorksetInfo");
+
+  const int num_elems = m_extruded_mesh->get_num_local_elements();
+  const int ws_size = m_extruded_mesh->meshSpecs[0]->worksetSize;
+  const int num_ws  = (num_elems + ws_size - 1) / ws_size;
+
+  m_workset_sizes.resize(num_ws);
+  m_workset_elements = DualView<int**>("ws_elem",num_ws,ws_size);
+  for (int ws=0,lid=0; ws<num_ws; ++ws) {
+    // For the last ws, we may have less elems.
+    int this_ws_size = ws==(num_ws-1) ? num_elems-ws*ws_size : ws_size;
+    m_workset_sizes[ws] = this_ws_size;
+    for (int ie=0; ie<this_ws_size; ++ie, ++lid) {
+      m_workset_elements.host()(ws,ie) = lid;
+    }
+    // Fill the remainder (if any) with very invalid numbers
+    for (int ie=this_ws_size; ie<ws_size; ++ie) {
+      m_workset_elements.host()(ws,ie) = -1;
+    }
+  }
+  m_workset_elements.sync_to_dev();
+
+  // For now, everything has the same element block name, and same phys index
+  m_wsEBNames.resize(num_ws,m_extruded_mesh->meshSpecs[0]->ebName);
+  m_wsPhysIndex.resize(num_ws,0);
+
+  m_stateArrays.elemStateArrays.resize(num_ws);
+  const auto& field_container = m_extruded_mesh->get_field_accessor();
+  for (auto& state : field_container->getNodalSIS()) {
+    const std::string&            name = state->name;
+    const StateStruct::FieldDims& dim  = state->dim;
+
+    const auto& dof_mgr = getDOFManager(name);
+    auto thyra_vec = Thyra::createMember(dof_mgr->ov_vs());
+
+    field_container->fillVector(*thyra_vec,name,dof_mgr,true);
+
+    auto data = getLocalData(thyra_vec.getConst());
+    for (int ws = 0; ws < num_ws; ws++) {
+      auto& state_arr = m_stateArrays.elemStateArrays[ws][name];
+      const int dim0 = m_workset_sizes[ws];
+      switch (dim.size()) {
+        case 2:  // scalar
+        {
+          auto dofs_lids = dof_mgr->elem_dof_lids().host();
+          state_arr.resize(name,dim0,dim[1]);
+          auto state_h = state_arr.host();
+          for (int i=0; i<dim0; ++i) {
+            const int elem_lid = m_workset_elements.host()(ws,i);
+            for (int j=0; j<static_cast<int>(dim[1]); ++j) {
+              const int dof_lid = dofs_lids(elem_lid,j);
+              state_h(i,j) = data[dof_lid];
+            }
+          }
+          break;
+        }
+        case 3:  // vector
+        {
+          auto dofs_lids = dof_mgr->elem_dof_lids().host();
+          state_arr.resize(name,dim0,dim[1],dim[2]);
+          auto state_h = state_arr.host();
+          for (int i=0; i<dim0; ++i) {
+            const int elem_lid = m_workset_elements.host()(ws,i);
+            for (int j=0; j<static_cast<int>(dim[1]); ++j) {
+              for (int k=0; k<static_cast<int>(dim[2]); ++k) {
+                const int dof_lid = dofs_lids(elem_lid,j*dim[2]+k);
+                state_h(i,j,k) = data[dof_lid];
+              }
+            }
+          }
+          break;
+        }
+        case 4:  // tensor
+        {
+          auto dofs_lids = dof_mgr->elem_dof_lids().host();
+          state_arr.resize(name,dim0,dim[1],dim[2],dim[3]);
+          auto state_h = state_arr.host();
+          for (int i=0; i<dim0; ++i) {
+            const int elem_lid = m_workset_elements.host()(ws,i);
+            for (int j=0; j<static_cast<int>(dim[1]); ++j) {
+              for (int k=0; k<static_cast<int>(dim[2]); ++k) {
+                for (int l=0; l<static_cast<int>(dim[3]); ++l) {
+                  const int dof_lid = dofs_lids(elem_lid,j*dim[2]*dim[3]+k*dim[3]+l);
+                  state_h(i,j,k,l) = data[dof_lid];
+                }
+              }
+            }
+          }
+          break;
+        }
+        default:
+          throw std::runtime_error ("Invalid/unsupported rank for nodal state: " + std::to_string(dim.size()) + "\n");
+      }
+      state_arr.sync_to_dev();
+    }
+  }
+
+
+  // Clear map (in case we're remeshing)
+  m_elemGIDws.clear();
+  m_ws_elem_coords.resize(num_ws);
+  const auto& elem_gids = getDOFManager()->getAlbanyConnManager()->getElementsInBlock();
+  const auto node_dof_mgr = getNodeDOFManager();
+  const auto elem_node_lids = node_dof_mgr->elem_dof_lids().host();
+  const int num_nodes = elem_node_lids.extent(1);
+  const int num_dim = getNumDim();
+  for (int ws = 0; ws < num_ws; ws++) {
+    m_ws_elem_coords[ws].resize(m_workset_sizes[ws]);
+
+    for (int ie=0; ie<m_workset_sizes[ws]; ++ie) {
+      const int elem_lid = m_workset_elements.host()(ws,ie);
+      auto& gid_ws = m_elemGIDws[elem_gids[elem_lid]];
+      gid_ws.ws = ws;
+      gid_ws.LID = elem_lid;
+
+      m_ws_elem_coords[ws][ie].resize(num_nodes);
+      for (int in=0; in<num_nodes; ++in) {
+        const int node_lid = elem_node_lids(elem_lid,in);
+        m_ws_elem_coords[ws][ie][in] = &m_nodes_coordinates[num_dim*node_lid];
+      }
+    }
+  }
+}
+
+void
+ExtrudedDiscretization::computeSideSets()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: computeSideSets");
+
+  // NOTE: the convention for ordering the mesh sides GIDs is
+  // - basal side
+  // - upper side
+  // - lateral side
+
+  // Clean up existing sideset structure (in case we are remeshing)
+  m_sideSets.clear();
+
+  int num_ws = getNumWorksets();
+  m_sideSets.resize(num_ws);  // Need a sideset list per workset
+
+  const auto& basal_node_dof_mgr = m_basal_disc->getNodeDOFManager();
+  const auto& basal_cell_indexer = m_basal_disc->getDOFManager()->cell_indexer();
+  const auto& node_dof_mgr = getNodeDOFManager();
+  const auto& cell_indexer = node_dof_mgr->cell_indexer();
+  const int num_glb_basal_elems = basal_cell_indexer->getNumGlobalElements();
+  const auto& cell_layers_gid = m_extruded_mesh->cell_layers_gid();
+  const auto& extr_conn_mgr = Teuchos::rcp_dynamic_cast<ExtrudedConnManager>(getNodeDOFManager()->getAlbanyConnManager(),true);
+  for (const auto& ss : m_extruded_mesh->meshSpecs[0]->ssNames) {
+    // Make sure the sideset exist even if no sides are owned on this process
+    for (int i=0; i<num_ws; ++i) {
+      m_sideSets[i][ss].resize(0);
+    }
+
+    if (ss=="basalside" or ss=="upperside") {
+      // Side sets are just the basal mesh elems
+      const int num_sides = basal_cell_indexer->getNumLocalElements();
+      for (int iside=0; iside<num_sides; ++iside) {
+        SideStruct sStruct;
+
+        const GO basal_gid = basal_cell_indexer->getGlobalElement(iside);
+        const int ilayer = ss=="basalside" ? 0 : cell_layers_gid->numLayers-1;
+
+        sStruct.elem_GID = cell_layers_gid->getId(basal_gid,ilayer);
+        sStruct.side_GID = basal_gid + (ss=="upperside" ? num_glb_basal_elems : 0);
+
+        sStruct.ws_elem_idx = m_elemGIDws[sStruct.elem_GID].LID;
+
+        // Get the ws that this element lives in
+        int workset = m_elemGIDws[sStruct.elem_GID].ws;
+
+        // Save the position of the side within element (0-based).
+        sStruct.side_pos = ss=="basalside" ? cell_layers_gid->bot_side_pos : cell_layers_gid->top_side_pos;
+
+        // Save the index of the element block that this elem lives in
+        sStruct.elem_ebIndex = m_extruded_mesh->meshSpecs[0]->ebNameToIndex[m_wsEBNames[workset]];
+
+        // Get or create the vector of side structs for this side set on this workset
+        auto& ss_vec = m_sideSets[workset][ss];
+        ss_vec.push_back(sStruct);
+      }
+    } else {
+      std::vector<std::string> basal_ss_names;
+      if (ss=="lateralside") {
+        // Extrude all sideSets from the basal mesh
+        basal_ss_names = m_extruded_mesh->basal_mesh()->meshSpecs[0]->ssNames;
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION (ss.substr(0,9)!="extruded_", std::runtime_error,
+            "Error! Unexpected value for side set name.\n"
+            "  - ss name: " + ss + "\n"
+            "  - supported values: basalside, upperside, lateralside, extruded_*\n");
+        basal_ss_names.push_back(m_extruded_mesh->get_basal_part_name(ss));
+      }
+
+      // First, figure out the largest basal side GID (so we can build a proper LayeredMeshNumbering)
+      GO max_basal_side_GID = -1;
+      for (int ws=0; ws<m_basal_disc->getNumWorksets(); ++ws) {
+        for (const auto& basal_ssn : basal_ss_names) {
+          auto basal_ss = m_basal_disc->getSideSets(ws).at(basal_ssn);
+          for (const auto& side : basal_ss) {
+            max_basal_side_GID = std::max(max_basal_side_GID,side.side_GID);
+          }
+        }
+      }
+
+      LayeredMeshNumbering<GO> side_layers_gid (max_basal_side_GID,cell_layers_gid->numLayers,cell_layers_gid->ordering);
+      auto get_basal_side_nodes = [&](const SideStruct& side) {
+        std::vector<GO> nodes;
+        const int elem_LID = basal_cell_indexer->getLocalElement(side.elem_GID);
+        const auto& elem_nodes = basal_node_dof_mgr->getElementGIDs(elem_LID);
+        const auto& offsets = basal_node_dof_mgr->getGIDFieldOffsetsSide(0,side.side_pos);
+        for (auto o : offsets) {
+          nodes.push_back(elem_nodes[o]);
+        }
+        return nodes;
+      };
+
+      auto determine_side_pos = [&] (const GO elem_GID, std::vector<GO> basal_side_nodes) {
+        const int num_sides = node_dof_mgr->get_topology().getSideCount();
+        const int elem_LID = cell_indexer->getLocalElement(elem_GID);
+        const auto& elem_nodes = node_dof_mgr->getElementGIDs(elem_LID);
+        int pos = -1;
+        std::vector<GO> side_nodes;
+        GO ilay = cell_layers_gid->getLayerId(elem_GID);
+        const auto& node_layers_gid = m_extruded_mesh->node_layers_gid();
+        for (auto bn : basal_side_nodes) {
+          side_nodes.push_back(node_layers_gid->getId(bn,ilay));
+        }
+        for (auto bn : basal_side_nodes) {
+          side_nodes.push_back(node_layers_gid->getId(bn,ilay+1));
+        }
+        for (int iside=0; iside<num_sides and pos==-1; ++iside) {
+          const auto& offsets = node_dof_mgr->getGIDFieldOffsetsSide(0,iside);
+          pos = iside;
+          for (auto o : offsets) {
+            if (std::find(side_nodes.begin(),side_nodes.end(),elem_nodes[o])==side_nodes.end()) {
+              pos = -1; break;
+            }
+          }
+        }
+        TEUCHOS_TEST_FOR_EXCEPTION (pos==-1, std::runtime_error,
+            "Error! Could not locate side inside an element.\n"
+            " - side nodes gids: " + util::join(side_nodes,",") + "\n"
+            " - elem nodes gids: " + util::join(elem_nodes,",") + "\n");
+        return pos;
+      };
+      for (int ws=0; ws<m_basal_disc->getNumWorksets(); ++ws) {
+        for (const auto& basal_ssn : basal_ss_names) {
+          auto basal_ss = m_basal_disc->getSideSets(ws).at(basal_ssn);
+          for (const auto& basal_side : basal_ss) {
+            const auto basal_elem_gid = basal_side.elem_GID;
+            const auto basal_side_nodes_gids = get_basal_side_nodes(basal_side);
+            for (int ilev=0; ilev<cell_layers_gid->numLayers; ++ilev) {
+              SideStruct sStruct;
+              sStruct.elem_GID = cell_layers_gid->getId(basal_elem_gid,ilev);
+              sStruct.side_GID = 2*num_glb_basal_elems + side_layers_gid.getId(basal_side.side_GID,ilev);
+              sStruct.ws_elem_idx = m_elemGIDws[sStruct.elem_GID].LID;
+
+              // Get the ws that this element lives in
+              int workset = m_elemGIDws[sStruct.elem_GID].ws;
+
+              // Save the position of the side within element (0-based).
+              sStruct.side_pos = determine_side_pos(sStruct.elem_GID,basal_side_nodes_gids);
+
+              // Save the index of the element block that this elem lives in
+              sStruct.elem_ebIndex = m_extruded_mesh->meshSpecs[0]->ebNameToIndex[m_wsEBNames[workset]];
+
+              // Get or create the vector of side structs for this side set on this workset
+              auto& ss_vec = m_sideSets[workset][ss];
+              ss_vec.push_back(sStruct);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // =============================================================
+  // (Kokkos Refactor) Convert sideSets to sideSetViews
+
+  // 1) Compute view extents (num_local_worksets, max_sideset_length, max_sides) and local workset counter (current_local_index)
+  std::map<std::string, int> num_local_worksets;
+  std::map<std::string, int> max_sideset_length;
+  std::map<std::string, int> max_sides;
+  std::map<std::string, int> current_local_index;
+  for (size_t i = 0; i < m_sideSets.size(); ++i) {
+    for (const auto& ss_it : m_sideSets[i]) {
+      std::string             ss_key = ss_it.first;
+      std::vector<SideStruct> ss_val = ss_it.second;
+
+      // Initialize values if this is the first time seeing a sideset key
+      if (num_local_worksets.find(ss_key) == num_local_worksets.end())
+        num_local_worksets[ss_key] = 0;
+      if (max_sideset_length.find(ss_key) == max_sideset_length.end())
+        max_sideset_length[ss_key] = 0;
+      if (max_sides.find(ss_key) == max_sides.end())
+        max_sides[ss_key] = 0;
+      if (current_local_index.find(ss_key) == current_local_index.end())
+        current_local_index[ss_key] = 0;
+
+      // Update extents for given workset/sideset
+      num_local_worksets[ss_key]++;
+      max_sideset_length[ss_key] = std::max(max_sideset_length[ss_key], (int) ss_val.size());
+      for (size_t j = 0; j < ss_val.size(); ++j)
+        max_sides[ss_key] = std::max(max_sides[ss_key], (int) ss_val[j].side_pos);
+    }
+  }
+
+  // 2) Construct GlobalSideSetList (map of GlobalSideSetInfo)
+  for (const auto& ss_it : num_local_worksets) {
+    std::string             ss_key = ss_it.first;
+
+    max_sides[ss_key]++; // max sides is the largest local ID + 1 and needs to be incremented once for each key here
+
+    globalSideSetViews[ss_key].num_local_worksets = num_local_worksets[ss_key];
+    globalSideSetViews[ss_key].max_sideset_length = max_sideset_length[ss_key];
+    globalSideSetViews[ss_key].side_GID         = Kokkos::DualView<GO**,   Kokkos::LayoutRight, PHX::Device>("side_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].elem_GID         = Kokkos::DualView<GO**,   Kokkos::LayoutRight, PHX::Device>("elem_GID", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].ws_elem_idx      = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("ws_elem_idx", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].elem_ebIndex     = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("elem_ebIndex", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].side_pos         = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("side_pos", num_local_worksets[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].max_sides        = max_sides[ss_key];
+    globalSideSetViews[ss_key].numCellsOnSide   = Kokkos::DualView<int**,  Kokkos::LayoutRight, PHX::Device>("numCellsOnSide", num_local_worksets[ss_key], max_sides[ss_key]);
+    globalSideSetViews[ss_key].cellsOnSide      = Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>("cellsOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
+    globalSideSetViews[ss_key].sideSetIdxOnSide = Kokkos::DualView<int***, Kokkos::LayoutRight, PHX::Device>("sideSetIdxOnSide", num_local_worksets[ss_key], max_sides[ss_key], max_sideset_length[ss_key]);
+  }
+
+  // 3) Populate global views
+  for (size_t i = 0; i < m_sideSets.size(); ++i) {
+    for (const auto& ss_it : m_sideSets[i]) {
+      std::string             ss_key = ss_it.first;
+      std::vector<SideStruct> ss_val = ss_it.second;
+
+      int current_index = current_local_index[ss_key];
+      int numSides = max_sides[ss_key];
+
+      int max_cells_on_side = 0;
+      std::vector<int> numCellsOnSide(numSides);
+      std::vector<std::vector<int>> cellsOnSide(numSides);
+      std::vector<std::vector<int>> sideSetIdxOnSide(numSides);
+      for (size_t j = 0; j < ss_val.size(); ++j) {
+        int cell = ss_val[j].ws_elem_idx;
+        int side = ss_val[j].side_pos;
+
+        cellsOnSide[side].push_back(cell);
+        sideSetIdxOnSide[side].push_back(j);
+      }
+      for (int side = 0; side < numSides; ++side) {
+        numCellsOnSide[side] = cellsOnSide[side].size();
+        max_cells_on_side = std::max(max_cells_on_side, numCellsOnSide[side]);
+      }
+
+      for (int side = 0; side < numSides; ++side) {
+        globalSideSetViews[ss_key].numCellsOnSide.h_view(current_index, side) = numCellsOnSide[side];
+        for (int j = 0; j < numCellsOnSide[side]; ++j) {
+          globalSideSetViews[ss_key].cellsOnSide.h_view(current_index, side, j) = cellsOnSide[side][j];
+          globalSideSetViews[ss_key].sideSetIdxOnSide.h_view(current_index, side, j) = sideSetIdxOnSide[side][j];
+        }
+        for (int j = numCellsOnSide[side]; j < max_sideset_length[ss_key]; ++j) {
+          globalSideSetViews[ss_key].cellsOnSide.h_view(current_index, side, j) = -1;
+          globalSideSetViews[ss_key].sideSetIdxOnSide.h_view(current_index, side, j) = -1;
+        }
+      }
+
+      for (size_t j = 0; j < ss_val.size(); ++j) {
+        globalSideSetViews[ss_key].side_GID.h_view(current_index, j)      = ss_val[j].side_GID;
+        globalSideSetViews[ss_key].elem_GID.h_view(current_index, j)      = ss_val[j].elem_GID;
+        globalSideSetViews[ss_key].ws_elem_idx.h_view(current_index, j)   = ss_val[j].ws_elem_idx;
+        globalSideSetViews[ss_key].elem_ebIndex.h_view(current_index, j)  = ss_val[j].elem_ebIndex;
+        globalSideSetViews[ss_key].side_pos.h_view(current_index, j) = ss_val[j].side_pos;
+      }
+
+      globalSideSetViews[ss_key].side_GID.modify_host();
+      globalSideSetViews[ss_key].elem_GID.modify_host();
+      globalSideSetViews[ss_key].ws_elem_idx.modify_host();
+      globalSideSetViews[ss_key].elem_ebIndex.modify_host();
+      globalSideSetViews[ss_key].side_pos.modify_host();
+      globalSideSetViews[ss_key].numCellsOnSide.modify_host();
+      globalSideSetViews[ss_key].cellsOnSide.modify_host();
+      globalSideSetViews[ss_key].sideSetIdxOnSide.modify_host();
+
+      globalSideSetViews[ss_key].side_GID.sync_device();
+      globalSideSetViews[ss_key].elem_GID.sync_device();
+      globalSideSetViews[ss_key].ws_elem_idx.sync_device();
+      globalSideSetViews[ss_key].elem_ebIndex.sync_device();
+      globalSideSetViews[ss_key].side_pos.sync_device();
+      globalSideSetViews[ss_key].numCellsOnSide.sync_device();
+      globalSideSetViews[ss_key].cellsOnSide.sync_device();
+      globalSideSetViews[ss_key].sideSetIdxOnSide.sync_device();
+
+      current_local_index[ss_key]++;
+    }
+  }
+
+  // 4) Reset current_local_index
+  std::map<std::string, int>::iterator counter_it = current_local_index.begin();
+  while (counter_it != current_local_index.end()) {
+    std::string counter_key = counter_it->first;
+    current_local_index[counter_key] = 0;
+    counter_it++;
+  }
+
+  // 5) Populate map of LocalSideSetInfos
+  for (size_t i = 0; i < m_sideSets.size(); ++i) {
+    LocalSideSetInfoList& lssList = sideSetViews[i];
+
+    for (const auto& ss_it : m_sideSets[i]) {
+      std::string             ss_key = ss_it.first;
+      std::vector<SideStruct> ss_val = ss_it.second;
+
+      int current_index = current_local_index[ss_key];
+      std::pair<int,int> range(0, ss_val.size());
+
+      lssList[ss_key].size           = ss_val.size();
+      lssList[ss_key].side_GID       = Kokkos::subview(globalSideSetViews[ss_key].side_GID, current_index, range );
+      lssList[ss_key].elem_GID       = Kokkos::subview(globalSideSetViews[ss_key].elem_GID, current_index, range );
+      lssList[ss_key].ws_elem_idx    = Kokkos::subview(globalSideSetViews[ss_key].ws_elem_idx, current_index, range );
+      lssList[ss_key].elem_ebIndex   = Kokkos::subview(globalSideSetViews[ss_key].elem_ebIndex,  current_index, range );
+      lssList[ss_key].side_pos  = Kokkos::subview(globalSideSetViews[ss_key].side_pos, current_index, range );
+      lssList[ss_key].numSides       = globalSideSetViews[ss_key].max_sides;
+      lssList[ss_key].numCellsOnSide = Kokkos::subview(globalSideSetViews[ss_key].numCellsOnSide, current_index, Kokkos::ALL() );
+      lssList[ss_key].cellsOnSide    = Kokkos::subview(globalSideSetViews[ss_key].cellsOnSide,    current_index, Kokkos::ALL(), Kokkos::ALL() );
+      lssList[ss_key].sideSetIdxOnSide    = Kokkos::subview(globalSideSetViews[ss_key].sideSetIdxOnSide,    current_index, Kokkos::ALL(), Kokkos::ALL() );
+
+      current_local_index[ss_key]++;
+    }
+  }
+
+  // 6) Determine size of global DOFView structure and allocate
+  std::map<std::string, int> total_sideset_idx;
+  std::map<std::string, int> sideset_idx_offset;
+  unsigned int maxSideNodes = 0;
+  const auto& cell_layers_data = m_extruded_mesh->cell_layers_lid();
+  if (!cell_layers_data.is_null()) {
+    const Teuchos::RCP<const CellTopologyData> cell_topo = Teuchos::rcp(new CellTopologyData(m_extruded_mesh->meshSpecs[0]->ctd));
+    const int numLayers = cell_layers_data->numLayers;
+    const int numComps = getDOFManager()->getNumFields();
+
+    // Determine maximum number of side nodes
+    for (unsigned int elem_side = 0; elem_side < cell_topo->side_count; ++elem_side) {
+      const CellTopologyData_Subcell& side =  cell_topo->side[elem_side];
+      const unsigned int numSideNodes = side.topology->node_count;
+      maxSideNodes = std::max(maxSideNodes, numSideNodes);
+    }
+
+    // Determine total number of sideset indices per each sideset name
+    for (auto& ssList : m_sideSets) {
+      for (auto& ss_it : ssList) {
+        std::string             ss_key = ss_it.first;
+        std::vector<SideStruct> ss_val = ss_it.second;
+
+        if (sideset_idx_offset.find(ss_key) == sideset_idx_offset.end())
+          sideset_idx_offset[ss_key] = 0;
+        if (total_sideset_idx.find(ss_key) == total_sideset_idx.end())
+          total_sideset_idx[ss_key] = 0;
+
+        total_sideset_idx[ss_key] += ss_val.size();
+      }
+    }
+
+    // Allocate total localDOFView for each sideset name
+    for (auto& ss_it : num_local_worksets) {
+      std::string ss_key = ss_it.first;
+      allLocalDOFViews[ss_key] = Kokkos::DualView<LO****, PHX::Device>(ss_key + " localDOFView", total_sideset_idx[ss_key], maxSideNodes, numLayers+1, numComps);
+    }
+  }
+
+  // Get topo data
+  auto ctd = m_extruded_mesh->meshSpecs[0]->ctd;
+
+  // Ensure we have ONE cell per layer.
+  const auto topo_hexa  = shards::getCellTopologyData<shards::Hexahedron<8>>();
+  const auto topo_wedge = shards::getCellTopologyData<shards::Wedge<6>>();
+  TEUCHOS_TEST_FOR_EXCEPTION (
+      ctd.name!=topo_hexa->name &&
+      ctd.name!=topo_wedge->name, std::runtime_error,
+      "Extruded meshses only allowed if there is one element per layer (hexa or wedges).\n"
+      "  - current topology name: " << ctd.name << "\n");
+
+  const auto& sol_dof_mgr = getDOFManager();
+  const auto& elem_dof_lids = sol_dof_mgr->elem_dof_lids().host();
+
+  // Build a LayeredMeshNumbering for cells, so we can get the LIDs of elems over the column
+  const auto numLayers = cell_layers_data->numLayers;
+  const int top = cell_layers_data->top_side_pos;
+  const int bot = cell_layers_data->bot_side_pos;
+
+  // 7) Populate localDOFViews for GatherVerticallyContractedSolution
+  for (int ws=0; ws<getNumWorksets(); ++ws) {
+
+    // Need to look at localDOFViews for each i so that there is a view available for each workset even if it is empty
+    std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>& wsldofViews = wsLocalDOFViews[ws];
+
+    const auto& elem_lids = getElementLIDs_host(ws);
+
+    // Loop over the sides that form the boundary condition
+    // const Teuchos::ArrayRCP<Teuchos::ArrayRCP<GO> >& wsElNodeID_i = wsElNodeID[i];
+    for (auto& ss_it : m_sideSets[ws]) {
+      std::string             ss_key = ss_it.first;
+      std::vector<SideStruct> ss_val = ss_it.second;
+
+      Kokkos::DualView<LO****, PHX::Device>& globalDOFView = allLocalDOFViews[ss_key];
+
+      for (unsigned int sideSet_idx = 0; sideSet_idx < ss_val.size(); ++sideSet_idx) {
+        const auto& side = ss_val[sideSet_idx];
+
+        // Get the data that corresponds to the side
+        const int ws_elem_idx = side.ws_elem_idx;
+        const int side_pos    = side.side_pos;
+
+        // Check if this sideset is the top or bot of the mesh. If not, the data structure
+        // for coupling vertical dofs is not needed.
+        if (side_pos!=top && side_pos!=bot)
+          break;
+
+        const int elem_LID = elem_lids(ws_elem_idx);
+        const int basal_elem_LID = cell_layers_data->getColumnId(elem_LID);
+
+        for (int eq=0; eq<m_neq; ++eq) {
+          const auto& sol_top_offsets = sol_dof_mgr->getGIDFieldOffsetsSide(eq,top,side_pos);
+          const auto& sol_bot_offsets = sol_dof_mgr->getGIDFieldOffsetsSide(eq,bot,side_pos);
+          const int numSideNodes = sol_top_offsets.size();
+
+          for (int j=0; j<numSideNodes; ++j) {
+            for (int il=0; il<numLayers; ++il) {
+              const LO layer_elem_LID = cell_layers_data->getId(basal_elem_LID,il);
+              globalDOFView.h_view(sideSet_idx + sideset_idx_offset[ss_key], j, il, eq) =
+                elem_dof_lids(layer_elem_LID,sol_bot_offsets[j]);
+            }
+
+            // Add top side in last layer
+            const int il = numLayers-1;
+            const LO layer_elem_LID = cell_layers_data->getId(basal_elem_LID,il);
+            globalDOFView.h_view(sideSet_idx + sideset_idx_offset[ss_key], j, il+1, eq) =
+              elem_dof_lids(layer_elem_LID,sol_top_offsets[j]);
+          }
+        }
+      }
+
+      globalDOFView.modify_host();
+      globalDOFView.sync_device();
+
+      // Set workset-local sub-view
+      std::pair<int,int> range(sideset_idx_offset[ss_key], sideset_idx_offset[ss_key]+ss_val.size());
+      wsldofViews[ss_key] = Kokkos::subview(globalDOFView, range, Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL());
+
+      sideset_idx_offset[ss_key] += ss_val.size();
+    }
+  }
+}
+
+void
+ExtrudedDiscretization::computeNodeSets()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: computeNodeSets");
+
+  const auto& node_dof_mgr = getNodeDOFManager();
+  const auto& node_conn_mgr = node_dof_mgr->getAlbanyConnManager();
+  const auto& node_dof_lids = node_dof_mgr->elem_dof_lids().host();
+  const int num_elems = m_extruded_mesh->get_num_local_elements();
+  const int mesh_dim = getNumDim();
+
+  // Loop over all node sets
+  for (const auto& ns : m_extruded_mesh->meshSpecs[0]->nsNames) {
+    auto& ns_gids     = m_nodeSetGIDs[ns];
+    auto& ns_elem_pos = m_nodeSets[ns];
+    auto& ns_coords   = m_nodeSetCoords[ns];
+
+    // Get the mask for this nodeset from the conn mgr, and count how many nodes are in it
+    auto mask = node_conn_mgr->getConnectivityMask(ns);
+
+    std::set<GO> gids_found;
+    for (int ie=0; ie<num_elems; ++ie) {
+      const auto& node_gids = node_dof_mgr->getElementGIDs(ie);
+      const int conn_start = node_conn_mgr->getConnectivityStart(ie);
+      const int conn_size  = node_conn_mgr->getConnectivitySize(ie);
+      for (int in=0; in<conn_size; ++in) {
+        if (mask[conn_start+in]==1) {
+          auto it_bool = gids_found.insert(node_gids[in]);
+          if (it_bool.second) {
+            // Newly processed node
+            ns_gids.push_back(node_gids[in]);
+            ns_elem_pos.push_back(std::make_pair(ie,in));
+            const int node_lid = node_dof_lids(ie,in);
+            ns_coords.push_back(&m_nodes_coordinates[mesh_dim*node_lid]);
+          }
+        }
+      }
+    }
+  }
+}
+
+void
+ExtrudedDiscretization::buildSideSetProjectors()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: buildSideSetProjectors");
+  std::cout << "WARNING! ExtrudedDiscretization::buildSideSetProjectors not yet implemented!\n";
+  return;
+}
+
+void ExtrudedDiscretization::printCoords() const 
+{
+  const int nnodes = m_extruded_mesh->get_num_local_nodes();
+  const int ndim   = getNumDim();
+  std::cout << "coordinates on processor " << m_comm->getRank() << "/" << m_comm->getSize() << "\n";
+  for (int inode=0; inode<nnodes; ++inode) {
+    GO node_gid = getNodeDOFManager()->ov_indexer()->getGlobalElement(inode);
+    std::cout << "  node_GID=" << node_gid << ", coords=";
+    for (int idim=0; idim<ndim; ++idim) {
+      std::cout << " " << m_nodes_coordinates[inode*3+idim];
+    }
+    std::cout << "\n";
+  }
+}
+
+void
+ExtrudedDiscretization::updateMesh()
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: updateMesh");
+
+  // First, make sure the basal disc is updated
+  m_basal_disc->updateMesh();
+
+  createDOFManagers();
+
+  computeCoordinates();
+
+  setupMLCoords();
+
+  computeWorksetInfo();
+
+  computeNodeSets();
+
+  computeSideSets();
+
+  computeGraphs();
+
+  buildCellSideNodeNumerationMaps();
+
+  if (sideSetDiscretizations.size()>0) {
+    buildSideSetProjectors();
+  }
+}
+
+void ExtrudedDiscretization::
+buildCellSideNodeNumerationMaps()
+{
+  // The numeration is simple, since we decided the side gids
+  const auto& node_dof_mgr = getNodeDOFManager();
+
+  const auto& basal_node_dof_mgr = m_basal_disc->getNodeDOFManager();
+  const auto& basal_cell_indexer = basal_node_dof_mgr->cell_indexer();
+  const auto& basal_elem_gids = m_basal_disc->getNodeDOFManager()->getAlbanyConnManager()->getElementsInBlock();
+  const int num_basal_elems = m_extruded_mesh->basal_mesh()->get_num_local_elements();
+  const int num_glb_basal_elems = basal_cell_indexer->getNumGlobalElements();
+
+  const auto& cell_layers_gid = m_extruded_mesh->cell_layers_gid();
+  const auto& node_layers_gid = m_extruded_mesh->node_layers_gid();
+
+  std::vector<GO> side_nodes;
+
+  // ONLY for basalside and upperside, since that's where we are likely to load data from mesh
+  for (int ws=0; ws<getNumWorksets(); ++ws) {
+    const auto& sideSets = m_sideSets[ws];
+    for (std::string ssn : {"basalside","upperside"}) {
+      auto& s2ssc = sideToSideSetCellMap[ssn];
+      auto& s2nn = sideNodeNumerationMap[ssn];
+
+      for (const auto& s : m_sideSets[ws][ssn]) {
+        const GO basal_elem_GID = s2ssc[s.side_GID] = cell_layers_gid->getColumnId(s.elem_GID);
+        const auto elem_LID = node_dof_mgr->cell_indexer()->getLocalElement(s.elem_GID);
+        const auto& elem_nodes = node_dof_mgr->getElementGIDs(elem_LID);
+        const auto& basal_nodes = basal_node_dof_mgr->getElementGIDs(basal_elem_GID);
+        const auto& offsets = node_dof_mgr->getGIDFieldOffsetsSide(0,s.side_pos);
+
+        // Retrieve the gids of the basal mesh nodes that generated the gids of this side
+        // NOTE: if ordering==LAYER, they are the same
+        side_nodes.resize(offsets.size());
+        for (size_t i=0; i<offsets.size(); ++i) {
+          auto gid3d = elem_nodes[offsets[i]];
+          side_nodes[i] = node_layers_gid->getColumnId(gid3d);
+        }
+        s2nn[s.side_GID].resize(offsets.size());
+        for (size_t i=0; i<offsets.size(); ++i) {
+          auto it = std::find(side_nodes.begin(),side_nodes.end(),basal_nodes[i]);
+          TEUCHOS_TEST_FOR_EXCEPTION (it==side_nodes.end(), std::runtime_error,
+              "Error! Could not locate node in the basal mesh.\n");
+
+          s2nn[s.side_GID][i] = std::distance(side_nodes.begin(),it);
+        }
+      }
+    }
+  }
+}
+
+void ExtrudedDiscretization::
+setFieldData(const Teuchos::RCP<StateInfoStruct>& sis)
+{
+  TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: setFieldData");
+}
+
+Teuchos::RCP<DOFManager>
+ExtrudedDiscretization::
+create_dof_mgr (const std::string& part_name,
+                const std::string& field_name,
+                const FE_Type fe_type,
+                const int order,
+                const int dof_dim) const
+{
+  const auto& ebn = m_extruded_mesh->meshSpecs()[0]->ebName;;
+  std::vector<std::string> elem_blocks =  {ebn};
+
+  // Create conn and dof managers
+  auto conn_mgr_h = m_basal_disc->getDOFManager(field_name)->getAlbanyConnManager();
+  auto conn_mgr = Teuchos::rcp(new ExtrudedConnManager(conn_mgr_h,m_extruded_mesh));
+  auto dof_mgr  = Teuchos::rcp(new DOFManager(conn_mgr,m_comm,part_name));
+
+  const auto& topo = conn_mgr->get_topology();
+  Teuchos::RCP<panzer::FieldPattern> fp;
+  if (topo.getName()==std::string("Particle")) {
+    // ODE equations are defined on a Particle geometry, where Intrepid2 doesn't work.
+    fp = Teuchos::rcp(new panzer::ElemFieldPattern(shards::CellTopology(topo)));
+  } else {
+    // For space-dependent equations, we rely on Intrepid2 for patterns
+    const auto basis = getIntrepid2TensorBasis(*conn_mgr_h->get_topology().getCellTopologyData(),1);
+    fp = Teuchos::rcp(new panzer::Intrepid2FieldPattern(basis));
+  }
+  // NOTE: we add $dof_dim copies of the field pattern to the dof mgr,
+  //       and call the fields ${field_name}_n, n=0,..,$dof_dim-1
+  for (int i=0; i<dof_dim; ++i) {
+    dof_mgr->addField(field_name + "_" + std::to_string(i),fp);
+  }
+
+  dof_mgr->build();
+
+  return dof_mgr;
+}
+
+}  // namespace Albany

--- a/src/disc/Albany_ExtrudedDiscretization.cpp
+++ b/src/disc/Albany_ExtrudedDiscretization.cpp
@@ -94,7 +94,8 @@ ExtrudedDiscretization::writeSolution(
     const bool          overlapped,
     const bool          force_write_solution)
 {
-  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
+  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
 }
 
 void
@@ -106,7 +107,8 @@ ExtrudedDiscretization::writeSolution(
     const bool          overlapped,
     const bool          force_write_solution)
 {
-  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
+  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
 }
 
 void
@@ -119,7 +121,8 @@ ExtrudedDiscretization::writeSolution(
     const bool          overlapped,
     const bool          force_write_solution)
 {
-  throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
+  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
+  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
 }
 
 void

--- a/src/disc/Albany_ExtrudedDiscretization.cpp
+++ b/src/disc/Albany_ExtrudedDiscretization.cpp
@@ -1075,7 +1075,7 @@ ExtrudedDiscretization::computeSideSets()
   TEUCHOS_TEST_FOR_EXCEPTION (
       ctd.name!=topo_hexa->name &&
       ctd.name!=topo_wedge->name, std::runtime_error,
-      "Extruded meshses only allowed if there is one element per layer (hexa or wedges).\n"
+      "Extruded meshes only allowed if there is one element per layer (hexa or wedges).\n"
       "  - current topology name: " << ctd.name << "\n");
 
   const auto& sol_dof_mgr = getDOFManager();

--- a/src/disc/Albany_ExtrudedDiscretization.hpp
+++ b/src/disc/Albany_ExtrudedDiscretization.hpp
@@ -1,0 +1,275 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_EXTRUDED_DISCRETIZATION_HPP
+#define ALBANY_EXTRUDED_DISCRETIZATION_HPP
+
+#include "Albany_AbstractDiscretization.hpp"
+#include "Albany_ExtrudedMesh.hpp"
+#include "Albany_DataTypes.hpp"
+#include "Albany_ThyraCrsMatrixFactory.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_NullSpaceUtils.hpp"
+
+#include <utility>
+#include <vector>
+
+namespace Albany {
+
+// ====================== STK Discretization ===================== //
+
+class ExtrudedDiscretization : public AbstractDiscretization
+{
+public:
+  //! Constructor
+  ExtrudedDiscretization (const Teuchos::RCP<Teuchos::ParameterList>& discParams,
+                          const int neq,
+                          const Teuchos::RCP<ExtrudedMesh>&        extruded_mesh,
+                          const Teuchos::RCP<AbstractDiscretization>& basal_disc,
+                          const Teuchos::RCP<const Teuchos_Comm>&     comm,
+                          const Teuchos::RCP<RigidBodyModes>& rigidBodyModes = Teuchos::null,
+                          const std::map<int, std::vector<std::string>>& sideSetEquations = {});
+
+  //! Destructor
+  virtual ~ExtrudedDiscretization() = default;
+
+  //! Get Node set lists (typedef in Albany_DiscretizationUtils.hpp)
+  const NodeSetList&      getNodeSets()      const override { return m_nodeSets;      }
+  const NodeSetGIDsList&  getNodeSetGIDs()   const override { return m_nodeSetGIDs;   }
+  const NodeSetCoordList& getNodeSetCoords() const override { return m_nodeSetCoords; }
+
+  //! Get Side set lists (typedef in Albany_AbstractDiscretization.hpp)
+  const SideSetList& getSideSets(const int workset) const override
+  {
+    return m_sideSets[workset];
+  }
+
+  //! Get Side set lists (typedef in Albany_AbstractDiscretization.hpp)
+  const LocalSideSetInfoList& getSideSetViews(const int workset) const override
+  {
+    return sideSetViews.at(workset);
+  }
+
+  //! Get local DOF views for GatherVerticallyContractedSolution
+  const std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>&
+  getLocalDOFViews(const int workset) const override
+  {
+    return wsLocalDOFViews.at(workset);
+  }
+
+  //! Get connectivity map from elementGID to workset
+        WsLIDList& getElemGIDws()       override { return m_elemGIDws; }
+  const WsLIDList& getElemGIDws() const override { return m_elemGIDws; }
+
+  //! Retrieve coordinate vector (num_used_nodes * 3)
+  const Teuchos::ArrayRCP<double>& getCoordinates() const override { return m_nodes_coordinates; }
+
+  //! Print the coordinates for debugging
+  void printCoords() const override;
+
+  Teuchos::RCP<AbstractMeshStruct> getMeshStruct() const override { return m_extruded_mesh; }
+
+  const std::map<std::string, std::map<GO, GO>>& getSideToSideSetCellMap() const override
+  {
+    throw NotYetImplemented("ExtrudedDiscretization::getSideToSideSetCellMap");
+  }
+
+  const std::map<std::string, std::map<GO, std::vector<int>>>&
+  getSideNodeNumerationMap() const override
+  {
+    throw NotYetImplemented("ExtrudedDiscretization::getSideNodeNumerationMap");
+  }
+
+  //! Flag if solution has a restart values -- used in Init Cond
+  bool hasRestartSolution() const override { return false; }
+
+  //! If restarting, convenience function to return restart data time
+  double restartDataTime() const override { return -1.0; }
+
+  //! After mesh modification, need to update the element connectivity and nodal
+  //! coordinates
+  void updateMesh() override;
+
+  //! Function that transforms an STK mesh of a unit cube (for LandIce problems)
+  void transformMesh();
+
+  //! Get number of spatial dimensions
+  int getNumDim() const override { return m_extruded_mesh->meshSpecs[0]->numDim; }
+
+  //! Get number of total DOFs per node
+  int getNumEq() const override { return m_neq; }
+
+  // --- Get/set solution/residual/field vectors to/from mesh --- //
+
+  Teuchos::RCP<Thyra_Vector> getSolutionField (const bool overlapped = false) const override;
+
+  void getSolutionMV (Thyra_MultiVector& result, bool overlapped) const override;
+
+  void getField (Thyra_Vector& field_vector, const std::string& field_name) const override;
+  void setField (const Thyra_Vector& field_vector,
+                 const std::string&  field_name,
+                 const bool          overlapped = false) override;
+
+  // --- Methods to write solution in the output file --- //
+
+  void writeSolution (const Thyra_Vector& solution,
+                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                      const double        time,
+                      const bool          overlapped = false,
+                      const bool          force_write_solution = false) override; 
+  void writeSolution (const Thyra_Vector& solution,
+                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                      const Thyra_Vector& solution_dot,
+                      const double        time,
+                      const bool          overlapped = false,
+                      const bool          force_write_solution = false) override; 
+  void writeSolution (const Thyra_Vector& solution,
+                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                      const Thyra_Vector& solution_dot,
+                      const Thyra_Vector& solution_dotdot,
+                      const double        time,
+                      const bool          overlapped = false,
+                      const bool          force_write_solution = false) override; 
+  void writeSolutionMV (const Thyra_MultiVector& solution,
+                        const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                        const double             time,
+                        const bool               overlapped = false,
+                        const bool               force_write_solution = false) override; 
+
+  //! Write the solution to the mesh database.
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const double /* time */,
+                                    const bool overlapped = false) override;
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const Thyra_Vector& solution_dot,
+                                    const double /* time */,
+                                    const bool overlapped = false) override;
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const Thyra_Vector& solution_dot,
+                                    const Thyra_Vector& solution_dotdot,
+                                    const double /* time */,
+                                    const bool overlapped = false) override;
+  void writeSolutionMVToMeshDatabase (const Thyra_MultiVector& solution,
+                                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                      const double /* time */,
+                                      const bool overlapped = false) override;
+
+  //! Write the solution to file. Must call writeSolution first.
+  void writeSolutionToFile (const Thyra_Vector& solution,
+                            const double        time,
+                            const bool          overlapped = false,
+                            const bool          force_write_solution = false) override; 
+
+  void writeSolutionMVToFile (const Thyra_MultiVector& solution,
+                              const double             time,
+                              const bool               overlapped = false,
+                              const bool               force_write_solution = false) override; 
+
+  void setFieldData(const Teuchos::RCP<StateInfoStruct>& sis) override;
+
+ protected:
+
+  void getSolutionField(Thyra_Vector& result, bool overlapped) const;
+
+  void setSolutionField (const Thyra_Vector& soln, const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp, const bool overlapped);
+  void setSolutionField (const Thyra_Vector& soln,
+                         const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                         const Thyra_Vector& soln_dot,
+                         const bool          overlapped);
+  void setSolutionField (const Thyra_Vector& soln,
+                         const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                         const Thyra_Vector& soln_dot,
+                         const Thyra_Vector& soln_dotdot,
+                         const bool          overlapped);
+  void setSolutionFieldMV (const Thyra_MultiVector& solnT,
+                           const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                           const bool overlapped);
+
+  void computeCoordinates();
+  void createDOFManagers();
+
+  //! Compute jacobian graph
+  virtual void computeGraphs();
+
+  //! Process coords for ML
+  void setupMLCoords();
+
+  //! Precompute some data divided by workset
+  void computeWorksetInfo();
+
+  //! Compute nodesets information
+  void computeNodeSets();
+
+  //! Compute sidesets information
+  void computeSideSets();
+
+  void buildCellSideNodeNumerationMaps();
+
+  // Create projectors to restrict solution to sidesets
+  void buildSideSetProjectors();
+
+  Teuchos::RCP<DOFManager>
+  create_dof_mgr (const std::string& part_name,
+                  const std::string& field_name,
+                  const FE_Type fe_type,
+                  const int order,
+                  const int dof_dim) const;
+
+  // ==================== Members =================== //
+
+  //! Teuchos communicator
+  Teuchos::RCP<const Teuchos_Comm> m_comm;
+
+  Teuchos::RCP<AbstractDiscretization> m_basal_disc;
+
+  //! Number of equations (and unknowns) per node
+  const int m_neq;
+
+  //! Equations that are defined only on some side sets of the mesh
+  std::map<int, std::vector<std::string>> m_sideSetEquations;
+
+  //! node sets stored as std::map(string ID, int vector of GIDs)
+  NodeSetList      m_nodeSets;
+  NodeSetGIDsList  m_nodeSetGIDs;
+  NodeSetCoordList m_nodeSetCoords;
+
+  //! side sets stored as std::map(string ID, SideArray classes) per workset
+  std::vector<SideSetList> m_sideSets;
+  GlobalSideSetList globalSideSetViews;
+  std::map<int, LocalSideSetInfoList> sideSetViews;
+
+  //! GatherVerticallyContractedSolution connectivity
+  std::map<std::string, Kokkos::DualView<LO****, PHX::Device>> allLocalDOFViews;
+  std::map<int, std::map<std::string, Kokkos::DualView<LO****, PHX::Device>>> wsLocalDOFViews;
+
+  // Coordinates spliced together, as [x0,y0,z0,x1,y1,z1,...]
+  Teuchos::ArrayRCP<double>   m_nodes_coordinates;
+
+  //! Connectivity map from elementGID to workset and LID in workset
+  WsLIDList m_elemGIDws;
+
+  // Needed to pass coordinates to ML.
+  Teuchos::RCP<RigidBodyModes> m_rigid_body_modes;
+
+  // The underlying extruded mesh
+  Teuchos::RCP<ExtrudedMesh> m_extruded_mesh;
+
+  // Keep params around, since we may need them after construction
+  Teuchos::RCP<Teuchos::ParameterList> m_disc_params;
+
+  // Sideset discretizations
+  strmap_t<std::map<GO, GO>>                sideToSideSetCellMap;
+  strmap_t<std::map<GO, std::vector<int>>>  sideNodeNumerationMap;
+  strmap_t<Teuchos::RCP<Thyra_LinearOp>>    projectors;
+  strmap_t<Teuchos::RCP<Thyra_LinearOp>>    ov_projectors;
+};
+
+}  // namespace Albany
+
+#endif  // ALBANY_EXTRUDED_DISCRETIZATION_HPP

--- a/src/disc/Albany_ExtrudedMesh.cpp
+++ b/src/disc/Albany_ExtrudedMesh.cpp
@@ -1,0 +1,150 @@
+#include "Albany_ExtrudedMesh.hpp"
+
+#include "Albany_DiscretizationUtils.hpp"
+
+namespace Albany {
+
+ExtrudedMesh::
+ExtrudedMesh (const Teuchos::RCP<AbstractMeshStruct>& basal_mesh,
+              const Teuchos::RCP<Teuchos::ParameterList>& params,
+              const Teuchos::RCP<const Teuchos_Comm>& comm)
+ : m_comm (comm)
+ , m_params (params)
+ , m_basal_mesh (basal_mesh)
+{
+  // Sanity checks
+  TEUCHOS_TEST_FOR_EXCEPTION (basal_mesh.is_null(), std::invalid_argument,
+      "[ExtrudedMesh] Error! Invalid basal mesh pointer.\n");
+
+  const auto basal_mesh_specs = m_basal_mesh->meshSpecs[0];
+  const int basalNumDim = basal_mesh_specs->numDim;
+
+  TEUCHOS_TEST_FOR_EXCEPTION (basalNumDim!=2, std::logic_error,
+      "[ExtrudedMesh] Error! ExtrudedMesh only available in 3D.\n"
+      "  - basal mesh dim: " << basalNumDim << "\n");
+  TEUCHOS_TEST_FOR_EXCEPTION (m_params.is_null(), std::runtime_error,
+      "[ExtrudedMesh] Error! Invalid parameter list pointer.\n");
+
+  // Create elem layers data
+  auto num_layers = m_params->get<int>("NumLayers");
+  TEUCHOS_TEST_FOR_EXCEPTION (num_layers<=0, Teuchos::Exceptions::InvalidParameterValue,
+      "[ExtrudedMesh] Error! Number of layers must be strictly positive.\n"
+      "  - NumLayers: " << num_layers << "\n");
+
+  // Create extruded sideSets/nodeSets/elemBlocks names
+  std::vector<std::string> nsNames = {"lateral", "bottom", "top"};
+  std::vector<std::string> ssNames = {"lateralside", "basalside", "upperside"};
+  std::vector<std::string> lateralParts = {"lateralside"};
+
+  for (const auto& ns : basal_mesh_specs->nsNames) {
+    nsNames.push_back ("extruded_" + ns);
+    nsNames.push_back ("basal_" + ns);
+  }
+  for (const auto& ss : basal_mesh_specs->ssNames) {
+    auto pname = "extruded_" + ss;
+    ssNames.push_back (pname);
+    lateralParts.push_back(pname);
+  }
+  std::string ebName = "extruded_" + basal_mesh_specs->ebName;
+  std::map<std::string,int> ebNameToIndex =
+  {
+    { ebName, 0}
+  };
+
+  // Determine topology
+  std::string elem2d_name(basal_mesh_specs->ctd.base->name);
+  std::string tria = shards::getCellTopologyData<shards::Triangle<3> >()->name;
+  auto wedge_topo = shards::CellTopology(shards::getCellTopologyData<shards::Wedge<6>>());
+  shards::CellTopology elem_topo;
+  if (elem2d_name==tria) {
+    elem_topo = wedge_topo;
+  } else {
+    throw Teuchos::Exceptions::InvalidParameterValue(
+      "[ExtrudedSTKMeshStruct] Invalid/unsupported basal mesh element type.\n"
+      "  - valid element types: " + tria + "\n"
+      "  - basal alement type : " + elem2d_name + "\n");
+  }
+  const CellTopologyData& ctd = *elem_topo.getCellTopologyData();
+
+  // Compute workset size
+  int basalWorksetSize = basal_mesh_specs->worksetSize;
+  int worksetSizeMax = m_params->get<int>("Workset Size");
+  int ebSizeMaxEstimate = basalWorksetSize * num_layers; // This is ebSizeMax when basalWorksetSize is max
+  int worksetSize = computeWorksetSize(worksetSizeMax, ebSizeMaxEstimate);
+
+  // Finally, we can create the mesh specs
+  this->meshSpecs.resize(1,Teuchos::rcp(
+        new MeshSpecsStruct(MeshType::Extruded, ctd, basalNumDim+1, nsNames, ssNames,
+                            worksetSize, ebName, ebNameToIndex)));
+
+  meshSpecs[0]->sideSetMeshSpecs["basalside"] = m_basal_mesh->meshSpecs;
+  sideSetMeshStructs["basalside"] = m_basal_mesh;
+}
+
+std::string ExtrudedMesh::
+get_basal_part_name (const std::string& extruded_part_name) const
+{
+  const std::string prefix = "extruded_";
+  TEUCHOS_TEST_FOR_EXCEPTION (extruded_part_name.substr(0,prefix.length())!=prefix, std::logic_error,
+      "Error! Extruded part name does not start with 'extruded_'.\n"
+      " - part name: " + extruded_part_name + "\n");
+
+  return extruded_part_name.substr(prefix.length());
+}
+
+void ExtrudedMesh::
+setFieldData (const Teuchos::RCP<const Teuchos_Comm>& comm,
+              const Teuchos::RCP<StateInfoStruct>& sis)
+{
+  // Register surface height and mesh thickness in the 2d mesh
+  std::string thickness_name = m_params->get<std::string>("Thickness Field Name","thickness");
+  std::string surface_height_name = m_params->get<std::string>("Surface Height Field Name","surface_height");
+  auto mesh_sis = Teuchos::rcp(new StateInfoStruct());
+  auto NDTEN = StateStruct::MeshFieldEntity::NodalDataToElemNode;
+
+  std::vector<size_t> dims = {
+    static_cast<size_t>(m_basal_mesh->meshSpecs[0]->worksetSize),
+    m_basal_mesh->meshSpecs[0]->ctd.node_count
+  };
+  mesh_sis->emplace_back(Teuchos::rcp(new StateStruct(surface_height_name,NDTEN,dims,"")));
+  mesh_sis->emplace_back(Teuchos::rcp(new StateStruct(thickness_name,NDTEN,dims,"")));
+  m_basal_mesh->setFieldData(comm,mesh_sis);
+}
+
+void ExtrudedMesh::
+setBulkData(const Teuchos::RCP<const Teuchos_Comm>& comm)
+{
+  if (not m_basal_mesh->isBulkDataSet()) {
+    m_basal_mesh->setBulkData(comm);
+  }
+
+  // Create layer data structures
+  const auto max_basal_node_gid = m_basal_mesh->get_max_node_gid();
+  const auto num_basal_nodes    = m_basal_mesh->get_num_local_nodes();
+  const auto max_basal_elem_gid = m_basal_mesh->get_max_elem_gid();
+  const auto num_basal_elems    = m_basal_mesh->get_num_local_elements();
+
+  const auto num_layers = m_params->get<int>("NumLayers");
+  const auto ordering = m_params->get("Columnwise Ordering", false)
+                      ? LayeredMeshOrdering::COLUMN
+                      : LayeredMeshOrdering::LAYER;
+
+  m_elem_layers_data_gid = Teuchos::rcp(new LayeredMeshNumbering<GO>(max_basal_elem_gid+1,num_layers,ordering));
+  m_elem_layers_data_lid = Teuchos::rcp(new LayeredMeshNumbering<LO>(num_basal_elems,num_layers,ordering));
+  m_node_layers_data_gid = Teuchos::rcp(new LayeredMeshNumbering<GO>(max_basal_node_gid+1,num_layers+1,ordering));
+  m_node_layers_data_lid = Teuchos::rcp(new LayeredMeshNumbering<LO>(num_basal_nodes,num_layers+1,ordering));
+
+  auto set_pos = [&](auto data) {
+    const auto& ctd = meshSpecs[0]->ctd;
+    data->top_side_pos = ctd.side_count-1;
+    data->bot_side_pos = ctd.side_count-2;
+  };
+  set_pos(m_elem_layers_data_gid);
+  set_pos(m_elem_layers_data_lid);
+  set_pos(m_node_layers_data_gid);
+  set_pos(m_node_layers_data_lid);
+
+  m_bulk_data_set = true;
+}
+
+} // namespace Albany

--- a/src/disc/Albany_ExtrudedMesh.hpp
+++ b/src/disc/Albany_ExtrudedMesh.hpp
@@ -1,0 +1,86 @@
+#ifndef ALBANY_EXTRUDED_MESH_HPP
+#define ALBANY_EXTRUDED_MESH_HPP
+
+#include "Albany_AbstractMeshStruct.hpp"
+#include "Albany_LayeredMeshNumbering.hpp"
+#include "Albany_DiscretizationUtils.hpp"
+
+#include <Teuchos_RCP.hpp>
+
+namespace Albany {
+
+class ExtrudedMesh : public AbstractMeshStruct {
+public:
+  ExtrudedMesh (const Teuchos::RCP<AbstractMeshStruct>& basal_mesh,
+                const Teuchos::RCP<Teuchos::ParameterList>& params,
+                const Teuchos::RCP<const Teuchos_Comm>& comm);
+
+  virtual ~ExtrudedMesh () = default;
+
+  std::string meshLibName () const override {
+    return "Albany";
+  }
+
+  // Checks that the extruded part name is "extruded_XYZ", and return XYZ
+  std::string get_basal_part_name (const std::string& extruded_part_name) const;
+
+  const Teuchos::RCP<LayeredMeshNumbering<GO>>&
+  cell_layers_gid () const { return m_elem_layers_data_gid; }
+  const Teuchos::RCP<LayeredMeshNumbering<LO>>&
+  cell_layers_lid () const { return m_elem_layers_data_lid; }
+
+  const Teuchos::RCP<LayeredMeshNumbering<GO>>&
+  node_layers_gid () const { return m_node_layers_data_gid; }
+  const Teuchos::RCP<LayeredMeshNumbering<LO>>&
+  node_layers_lid () const { return m_node_layers_data_lid; }
+
+  const Teuchos::RCP<AbstractMeshStruct>& basal_mesh () const { return m_basal_mesh; }
+
+  const Teuchos::RCP<const Teuchos_Comm>& comm() const { return m_comm; }
+
+  LO get_num_local_nodes () const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (not isBulkDataSet(), std::logic_error,
+        "Error! Bulk data must be set before you can call get_num_local_nodes.\n");
+    return m_basal_mesh->get_num_local_nodes()*m_node_layers_data_gid->numLayers;
+  }
+  LO get_num_local_elements () const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (not isBulkDataSet(), std::logic_error,
+        "Error! Bulk data must be set before you can call get_num_local_elements.\n");
+    return m_basal_mesh->get_num_local_elements()*m_elem_layers_data_gid->numLayers;
+  }
+  GO get_max_node_gid () const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (not isBulkDataSet(), std::logic_error,
+        "Error! Bulk data must be set before you can call get_max_node_gid.\n");
+    return m_node_layers_data_gid->numHorizEntities*m_node_layers_data_gid->numLayers;
+  }
+  GO get_max_elem_gid () const override {
+    TEUCHOS_TEST_FOR_EXCEPTION (not isBulkDataSet(), std::logic_error,
+        "Error! Bulk data must be set before you can call get_max_elem_gid.\n");
+    return m_elem_layers_data_gid->numHorizEntities*m_elem_layers_data_gid->numLayers;
+  }
+
+  Teuchos::RCP<AbstractMeshFieldAccessor> get_field_accessor () const override {
+    return m_basal_mesh->get_field_accessor();
+  }
+
+  void setFieldData (const Teuchos::RCP<const Teuchos_Comm>& comm,
+                     const Teuchos::RCP<StateInfoStruct>& sis) override;
+
+  void setBulkData(const Teuchos::RCP<const Teuchos_Comm>& comm) override;
+
+protected:
+
+  Teuchos::RCP<const Teuchos_Comm>          m_comm;
+  Teuchos::RCP<Teuchos::ParameterList>      m_params;
+
+  Teuchos::RCP<AbstractMeshStruct>          m_basal_mesh;
+
+  Teuchos::RCP<LayeredMeshNumbering<GO>>    m_elem_layers_data_gid;
+  Teuchos::RCP<LayeredMeshNumbering<LO>>    m_elem_layers_data_lid;
+  Teuchos::RCP<LayeredMeshNumbering<GO>>    m_node_layers_data_gid;
+  Teuchos::RCP<LayeredMeshNumbering<LO>>    m_node_layers_data_lid;
+};
+
+} // namespace Albany
+
+#endif // ALBANY_EXTRUDED_MESH_HPP

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -1,6 +1,7 @@
 #include "Albany_OmegahDiscretization.hpp"
 #include "Albany_OmegahUtils.hpp"
 #include "Albany_StringUtils.hpp"
+#include "Albany_ThyraUtils.hpp"
 
 #include "OmegahConnManager.hpp"
 
@@ -38,6 +39,7 @@ updateMesh ()
 {
   printf ("TODO: change name to the method?\n");
 
+  // Create DOF managers
   auto sol_dof_mgr  = create_dof_mgr(solution_dof_name(),"",FE_Type::HGRAD,1,m_neq);
   auto node_dof_mgr = create_dof_mgr(nodes_dof_name(),"",FE_Type::HGRAD,1,1);
 
@@ -89,6 +91,7 @@ updateMesh ()
   const auto& node_elem_dof_lids = node_dof_mgr->elem_dof_lids().host();
 
   const int mdim = mesh.dim();
+  m_nodes_coordinates.resize(3 * getLocalSubdim(getOverlapNodeVectorSpace()));
   for (int ws=0; ws<num_ws; ++ws) {
     m_ws_elem_coords[ws].resize(m_workset_sizes[ws]);
     for (int ielem=0; ielem<m_workset_sizes[ws]; ++ielem) {
@@ -97,6 +100,10 @@ updateMesh ()
         LO node_lid = node_elem_dof_lids(ielem,inode);
         int omh_pos = m_node_lid_to_omegah_pos[node_lid];
         m_ws_elem_coords[ws][ielem][inode] = &coords_h[omh_pos*mdim];
+        auto coords = &m_nodes_coordinates[node_lid*mdim];
+        for (int idim=0; idim<mdim; ++idim) {
+          coords[idim] = m_ws_elem_coords[ws][ielem][inode][idim];
+        }
       }
     }
   }

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -11,7 +11,6 @@
 
 #include "Albany_OmegahGenericMesh.hpp"
 
-#include "Albany_ThyraCrsMatrixFactory.hpp"
 #include "Albany_NullSpaceUtils.hpp"
 
 namespace Albany {
@@ -32,11 +31,6 @@ public:
   virtual ~OmegahDiscretization() = default;
 
   void updateMesh () override;
-
-  Teuchos::RCP<Thyra_LinearOp>
-  createJacobianOp() const override {
-    return m_jac_factory->createOp();
-  }
 
   //! Get Node set lists
   const NodeSetList&
@@ -98,12 +92,6 @@ public:
   Teuchos::RCP<AbstractMeshStruct>
   getMeshStruct() const override {
     return m_mesh_struct;
-  }
-
-  //! Get nodal parameters state info struct
-  const StateInfoStruct&
-  getNodalParameterSIS() const override {
-    return m_mesh_struct->get_field_accessor()->getNodalParameterSIS();
   }
 
   //! Retrieve connectivity map from elementGID to workset
@@ -289,9 +277,6 @@ protected:
 
   //! Equations that are defined only on some side sets of the mesh
   std::map<int, std::vector<std::string>> m_side_set_equations;
-
-  //! Jacobian matrix operator factory
-  Teuchos::RCP<ThyraCrsMatrixFactory> m_jac_factory;
 
   // Number of equations (and unknowns) per node
   // TODO: this should soon be removed, in favor of more granular description of each dof/unknown

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -65,10 +65,7 @@ public:
   }
 
   //! Get coordinates (overlap map).
-  const Teuchos::ArrayRCP<double>&
-  getCoordinates() const override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::getCoordinates");
-  }
+  const Teuchos::ArrayRCP<double>& getCoordinates() const override { return m_nodes_coordinates; }
 
   //! Print the coords for mesh debugging
   void
@@ -274,6 +271,9 @@ protected:
 
   NodeSetList       m_node_sets;
   NodeSetCoordList  m_node_set_coords;
+
+  // Coordinates spliced together, as [x0,y0,z0,x1,y1,z1,...]
+  Teuchos::ArrayRCP<double>   m_nodes_coordinates;
 
   //! Equations that are defined only on some side sets of the mesh
   std::map<int, std::vector<std::string>> m_side_set_equations;

--- a/src/disc/omegah/Albany_OmegahGenericMesh.hpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.hpp
@@ -21,6 +21,11 @@ public:
   void setFieldData (const Teuchos::RCP<const Teuchos_Comm>& comm,
                      const Teuchos::RCP<Albany::StateInfoStruct>& sis) override;
 
+  LO get_num_local_nodes () const override;
+  LO get_num_local_elements  () const override;
+  GO get_max_node_gid () const override;
+  GO get_max_elem_gid () const override;
+
   Teuchos::RCP<AbstractMeshFieldAccessor> get_field_accessor () const override { return m_field_accessor; }
 
   // ------------- Omegah specific methods -------------- //
@@ -58,6 +63,9 @@ protected:
 
   DeviceView1d<const double>                m_coords_d;
   DeviceView1d<      double>::HostMirror    m_coords_h;
+
+  mutable GO m_max_node_gid = -1;
+  mutable GO m_max_elem_gid = -1;
 
   bool m_has_restart_solution = false;
 };

--- a/src/disc/omegah/OmegahConnManager.cpp
+++ b/src/disc/omegah/OmegahConnManager.cpp
@@ -531,7 +531,7 @@ int OmegahConnManager::part_dim (const std::string& name) const
 
 const Ownership* OmegahConnManager::getOwnership(LO localElmtId) const
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (owners.size()==0, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "Error! Cannot call getOwnership before connectivity is built.\n");
   return &owners.at(localElmtId*m_dofsPerElm);
 }

--- a/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_ExtrudedSTKMeshStruct.cpp
@@ -174,9 +174,8 @@ ExtrudedSTKMeshStruct(const Teuchos::RCP<Teuchos::ParameterList>& params,
   const CellTopologyData& ctd = *shards_ctd.getCellTopologyData();
 
   // NOTE: I am marking the mesh as Unstructured rather than Extruded, since
-  //       I am planning to develop a generic interface for Extruded meshes,
-  //       which does not store 3d data (only basal). In order to not confuse
-  //       the two, I keep this mesh as Unstructured.
+  //       I am reserving Extruded for disc/Albany_ExtrudedMesh.*pp, which does
+  //       not store the full 3d mesh.
   this->meshSpecs[0] = Teuchos::rcp(
       new MeshSpecsStruct(MeshType::Unstructured, ctd, numDim,
                           nsNames, ssNames, worksetSize,

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
@@ -352,9 +352,6 @@ fillVectorImpl(Thyra_Vector&                         field_vector,
                const Teuchos::RCP<const DOFManager>& field_dof_mgr,
                const bool                            overlapped)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (!this->solutionFieldContainer, std::logic_error,
-    "Error OrdinarySTKFieldContainer::fillVectorImpl not called from a solution field container.\n");
-
   // Figure out if it's a nodal or elem field
   const auto& fp = field_dof_mgr->getGeometricFieldPattern();
   const auto& ftopo = field_dof_mgr->get_topology();

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1849,7 +1849,7 @@ STKDiscretization::computeSideSets()
     TEUCHOS_TEST_FOR_EXCEPTION (
         ctd.name!=topo_hexa->name &&
         ctd.name!=topo_wedge->name, std::runtime_error,
-        "Extruded meshses only allowed if there is one element per layer (hexa or wedges).\n"
+        "Extruded meshes only allowed if there is one element per layer (hexa or wedges).\n"
         "  - current topology name: " << ctd.name << "\n");
 
     const auto& sol_dof_mgr = getDOFManager();

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -13,7 +13,6 @@
 #include "Albany_AbstractDiscretization.hpp"
 #include "Albany_AbstractSTKMeshStruct.hpp"
 #include "Albany_DataTypes.hpp"
-#include "Albany_ThyraCrsMatrixFactory.hpp"
 #include "Albany_ThyraUtils.hpp"
 #include "Albany_GlobalLocalIndexer.hpp"
 
@@ -53,13 +52,6 @@ public:
 
   void
   printConnectivity() const;
-
-  //! Create a Jacobian operator (owned and overlapped)
-  Teuchos::RCP<Thyra_LinearOp>
-  createJacobianOp() const
-  {
-    return m_jac_factory->createOp();
-  }
 
   //! Get Node set lists (typedef in Albany_AbstractDiscretization.hpp)
   const NodeSetList&
@@ -118,13 +110,6 @@ public:
   //! Print the coordinates for debugging
   void
   printCoords() const;
-
-  //! Get nodal parameters state info struct
-  const StateInfoStruct&
-  getNodalParameterSIS() const
-  {
-    return stkMeshStruct->getFieldContainer()->getNodalParameterSIS();
-  }
 
   // Retrieve mesh struct
   Teuchos::RCP<AbstractSTKMeshStruct>
@@ -373,9 +358,6 @@ public:
 
   //! Teuchos communicator
   Teuchos::RCP<const Teuchos_Comm> comm;
-
-  //! Jacobian matrix operator factory
-  Teuchos::RCP<ThyraCrsMatrixFactory> m_jac_factory;
 
   //! Number of equations (and unknowns) per node
   const int neq;

--- a/src/problems/Albany_ProblemUtils.cpp
+++ b/src/problems/Albany_ProblemUtils.cpp
@@ -13,6 +13,7 @@
 #include "Intrepid2_HGRAD_TET_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_HEX_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_WEDGE_C1_FEM.hpp"
+#include <Intrepid2_HierarchicalBasisFamily.hpp>
 
 #include "Kokkos_DynRankView.hpp"
 
@@ -132,6 +133,32 @@ getIntrepid2Basis(const CellTopologyData& ctd)
        "Albany::ProblemUtils::getIntrepid2Basis did not recognize element name: " << ctd.name);
 
    return intrepidBasis;
+}
+
+Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> >
+getIntrepid2TensorBasis(const CellTopologyData& basal_ctd, const int vert_degree)
+{
+  std::string name = basal_ctd.name;
+  name = name.substr(0,name.find("_"));
+  const int & numNodes = basal_ctd.node_count;
+  Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> > intrepidBasis;
+  using basis_family_type = Intrepid2::HierarchicalBasisFamily<PHX::Device>;
+  if (name == "Triangle") {
+    using wedge_basis_type = typename basis_family_type::HGRAD_WEDGE;
+    if (numNodes == 3)
+      intrepidBasis = Teuchos::rcp(new wedge_basis_type(1,vert_degree));
+    else if (numNodes==6)
+      intrepidBasis = Teuchos::rcp(new wedge_basis_type(2,vert_degree));
+    else
+      throw Teuchos::Exceptions::InvalidParameter(
+          "Albany::ProblemUtils::getIntrepid2TensorBasis: basal triangle element with " + std::to_string(numNodes) + " nodes is not supported\n");
+  } else {
+    // Unrecognized element type
+    throw Teuchos::Exceptions::InvalidParameter(
+        "Albany::ProblemUtils::getIntrepid2Basis did not recognize element name: " + std::string(basal_ctd.name) + "\n");
+  }
+
+  return intrepidBasis;
 }
 
 bool mesh_depends_on_parameters () {

--- a/src/problems/Albany_ProblemUtils.hpp
+++ b/src/problems/Albany_ProblemUtils.hpp
@@ -20,6 +20,9 @@ namespace Albany {
 Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> >
 getIntrepid2Basis(const CellTopologyData& ctd);
 
+Teuchos::RCP<Intrepid2::Basis<PHX::Device, RealType, RealType> >
+getIntrepid2TensorBasis(const CellTopologyData& basal_ctd, const int vert_degree);
+
 bool mesh_depends_on_parameters ();
 
 } // namespace Albany

--- a/tests/corePDEs/CMakeLists.txt
+++ b/tests/corePDEs/CMakeLists.txt
@@ -5,6 +5,7 @@
 ##*****************************************************************//
 
 # Heat Transfer Problems ###############
+add_subdirectory(ExtrudedMesh)
 add_subdirectory(SteadyHeat2D)
 add_subdirectory(SteadyHeatConstrainedOpt2D)
 add_subdirectory(SteadyHeat3D)

--- a/tests/corePDEs/ExtrudedMesh/CMakeLists.txt
+++ b/tests/corePDEs/ExtrudedMesh/CMakeLists.txt
@@ -6,8 +6,14 @@ if (ALBANY_IFPACK2 AND ALBANY_OMEGAH)
   set (testNameRoot ${parentDirName}_${dirName})
 
   # Create the test with this name and standard executable
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
-                 ${CMAKE_CURRENT_BINARY_DIR}/input.yaml COPYONLY)
-  add_test(${testNameRoot} ${Albany.exe} input.yaml)
+  # Note: only extruded.yaml is used, but we ship also monolithic,
+  #       which uses a STK3D mesh, so you can easily debug by
+  #       running both the yamls.
+  #       PLEASE, keep them in sync!
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/extruded.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/extruded.yaml COPYONLY)
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/monolithic.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/monolithic.yaml COPYONLY)
+  add_test(${testNameRoot} ${Albany.exe} extruded.yaml)
   set_tests_properties(${testNameRoot} PROPERTIES LABELS "Basic;Forward")
 endif ()

--- a/tests/corePDEs/ExtrudedMesh/CMakeLists.txt
+++ b/tests/corePDEs/ExtrudedMesh/CMakeLists.txt
@@ -1,0 +1,13 @@
+if (ALBANY_IFPACK2 AND ALBANY_OMEGAH)
+  # Name the test with the directory name
+  get_filename_component(parentPath ${CMAKE_CURRENT_SOURCE_DIR} PATH)
+  get_filename_component(parentDirName ${parentPath} NAME)
+  get_filename_component(dirName ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+  set (testNameRoot ${parentDirName}_${dirName})
+
+  # Create the test with this name and standard executable
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input.yaml COPYONLY)
+  add_test(${testNameRoot} ${Albany.exe} input.yaml)
+  set_tests_properties(${testNameRoot} PROPERTIES LABELS "Basic;Forward")
+endif ()

--- a/tests/corePDEs/ExtrudedMesh/extruded.yaml
+++ b/tests/corePDEs/ExtrudedMesh/extruded.yaml
@@ -43,7 +43,7 @@ ANONYMOUS:
       Response 3:
         Name: Solution Min Value
   Discretization:
-    Method: NewExtruded
+    Method: Extruded
     NumLayers: 5
     Columnwise Ordering: true
     Side Set Discretizations:

--- a/tests/corePDEs/ExtrudedMesh/extruded.yaml
+++ b/tests/corePDEs/ExtrudedMesh/extruded.yaml
@@ -1,18 +1,26 @@
 %YAML 1.1
 ---
 ANONYMOUS:
+  Debug Output:
+    Report Timers: false
   Problem:
     Name: Heat 3D
-    Compute Sensitivities: true
+    Compute Sensitivities: false
+    Phalanx Graph Visualization Detail: 1
     Dirichlet BCs:
-      DBC on NS bottom for DOF T: 2.0
+      DBC on NS bottom for DOF T: 1.0
       DBC on NS top for DOF T: 2.0
-      DBC on NS lateral for DOF T: 1.0
+    Initial Condition:
+      Function: Constant
+      Function Data: [1.5]
+    ThermalConductivity:
+      ThermalConductivity Type: Constant
+      Value: 3.0
     Source Functions:
       Quadratic:
         Nonlinear Factor: 3.0
     Parameters:
-      Number Of Parameters: 1
+      Number Of Parameters: 0
       Parameter 0:
         Type: Vector
         Dimension: 4
@@ -21,15 +29,19 @@ ANONYMOUS:
         Scalar 1:
           Name: DBC on NS top for DOF T
         Scalar 2:
-          Name: DBC on NS lateral for DOF T
-        Scalar 3:
           Name: Quadratic Nonlinear Factor
+        Scalar 3:
+          Name: ThermalConductivity
     Response Functions:
-      Number Of Responses: 2
+      Number Of Responses: 4
       Response 0:
-        Name: Solution Average
-      Response 1:
         Name: Solution Two Norm
+      Response 1:
+        Name: Solution Average
+      Response 2:
+        Name: Solution Max Value
+      Response 3:
+        Name: Solution Min Value
   Discretization:
     Method: NewExtruded
     NumLayers: 5
@@ -38,8 +50,8 @@ ANONYMOUS:
       Side Sets: [basalside]
       basalside:
         Method: STK2D
-        1D Elements: 1
-        2D Elements: 1
+        1D Elements: 5
+        2D Elements: 5
         Cell Topology: Triangle
         Required Fields Info:
           Number Of Fields: 2
@@ -47,12 +59,12 @@ ANONYMOUS:
             Field Name: surface_height
             Field Type: Node Scalar
             Field Origin: File
-            Field Expression: ['1.001-x/1000']  # 1km+1m at x=0km, 1m at x=1000km
+            Field Value: 1.0
           Field 1:
             Field Name: thickness
             Field Type: Node Scalar
             Field Origin: File
-            Field Expression: ['1.001-x/1000']  # 1km+1m at x=0km, 1m at x=1000km
+            Field Value: 1.0
   # Regression For Response 0:
   #   Test Value: 1.630433
   #   Relative Tolerance: 1.0e-03

--- a/tests/corePDEs/ExtrudedMesh/input.yaml
+++ b/tests/corePDEs/ExtrudedMesh/input.yaml
@@ -1,0 +1,106 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Problem:
+    Name: Heat 3D
+    Compute Sensitivities: true
+    Dirichlet BCs:
+      DBC on NS bottom for DOF T: 2.0
+      DBC on NS top for DOF T: 2.0
+      DBC on NS lateral for DOF T: 1.0
+    Source Functions:
+      Quadratic:
+        Nonlinear Factor: 3.0
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Type: Vector
+        Dimension: 4
+        Scalar 0:
+          Name: DBC on NS bottom for DOF T
+        Scalar 1:
+          Name: DBC on NS top for DOF T
+        Scalar 2:
+          Name: DBC on NS lateral for DOF T
+        Scalar 3:
+          Name: Quadratic Nonlinear Factor
+    Response Functions:
+      Number Of Responses: 2
+      Response 0:
+        Name: Solution Average
+      Response 1:
+        Name: Solution Two Norm
+  Discretization:
+    Method: NewExtruded
+    NumLayers: 5
+    Columnwise Ordering: true
+    Side Set Discretizations:
+      Side Sets: [basalside]
+      basalside:
+        Method: STK2D
+        1D Elements: 1
+        2D Elements: 1
+        Cell Topology: Triangle
+        Required Fields Info:
+          Number Of Fields: 2
+          Field 0:
+            Field Name: surface_height
+            Field Type: Node Scalar
+            Field Origin: File
+            Field Expression: ['1.001-x/1000']  # 1km+1m at x=0km, 1m at x=1000km
+          Field 1:
+            Field Name: thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            Field Expression: ['1.001-x/1000']  # 1km+1m at x=0km, 1m at x=1000km
+  # Regression For Response 0:
+  #   Test Value: 1.630433
+  #   Relative Tolerance: 1.0e-03
+  #   Sensitivity For Parameter 0:
+  #     Test Values: [1.906416e-01, 1.906395e-01, 2.057308e-01, 2.057247e-01, 2.30337e-01, 2.30337e-01, 7.82e-02]
+  Piro:
+    NOX:
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Rescue Bad Newton Solve: true
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: { }
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Convergence Tolerance: 1.0e-05
+                      Output Frequency: 10
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 100
+                      Block Size: 1
+                      Num Blocks: 50
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: Ifpack2
+              Preconditioner Types:
+                Ifpack2:
+                  Overlap: 1
+                  Prec Type: ILUT
+                  Ifpack2 Settings:
+                    'fact: drop tolerance': 0.0
+                    'fact: ilut level-of-fill': 1.0
+                    'fact: level-of-fill': 1
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Information: 103
+        Output Precision: 3
+      Solver Options:
+        Status Test Check Type: Minimal
+...

--- a/tests/corePDEs/ExtrudedMesh/monolithic.yaml
+++ b/tests/corePDEs/ExtrudedMesh/monolithic.yaml
@@ -1,0 +1,113 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Debug Output:
+    Report Timers: false
+  Problem:
+    Name: Heat 3D
+    Compute Sensitivities: false
+    Dirichlet BCs:
+      DBC on NS NodeSet4 for DOF T: 1.0
+      DBC on NS NodeSet5 for DOF T: 2.0
+    Initial Condition:
+      Function: Constant
+      Function Data: [1.5]
+    ThermalConductivity:
+      ThermalConductivity Type: Constant
+      Value: 3.0
+    Source Functions:
+      Quadratic:
+        Nonlinear Factor: 3.0
+    Parameters:
+      Number Of Parameters: 0
+      Parameter 0:
+        Type: Vector
+        Dimension: 4
+        Scalar 0:
+            Name: DBC on NS NodeSet4 for DOF T
+        Scalar 1:
+            Name: DBC on NS NodeSet5 for DOF T
+        Scalar 2:
+            Name: Quadratic Nonlinear Factor
+        Scalar 3:
+            Name: ThermalConductivity
+    Response Functions:
+      Number Of Responses: 4
+      Response 0:
+        Name: Solution Two Norm
+      Response 1:
+        Name: Solution Average
+      Response 2:
+        Name: Solution Max Value
+      Response 3:
+        Name: Solution Min Value
+    Cubature Degree: 3
+  Discretization:
+    1D Elements: 5
+    2D Elements: 5
+    3D Elements: 5
+    Workset Size: 100
+    Method: STK3D
+  # Regression For Response 0:
+  #   Test Value: 6.68057e+01
+  #   Relative Tolerance: 1.0e-03
+  #   Sensitivity For Parameter 0:
+  #     Test Values: [8.14701e+00, 8.14701e+00, 6.2797, 6.27977, 7.8437, 7.84374, 6.2431e-01, -6.2431e-01]
+  Piro:
+    LOCA:
+      Bifurcation: { }
+      Constraints: { }
+      Predictor:
+        First Step Predictor: { }
+        Last Step Predictor: { }
+      Step Size: { }
+      Stepper:
+        Eigensolver: { }
+    NOX:
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Rescue Bad Newton Solve: true
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-04
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: { }
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Convergence Tolerance: 1.0e-05
+                      Output Frequency: 10
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 100
+                      Block Size: 1
+                      Num Blocks: 50
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: Ifpack2
+              Preconditioner Types:
+                Ifpack2:
+                  Overlap: 1
+                  Prec Type: ILUT
+                  Ifpack2 Settings:
+                    'fact: drop tolerance': 0.0
+                    'fact: ilut level-of-fill': 1.0
+                    'fact: level-of-fill': 1
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Information: 103
+        Output Precision: 3
+      Solver Options:
+        Status Test Check Type: Minimal
+...

--- a/tests/landIce/CismAlbany/inputFiles/input_standalone-albany.yaml
+++ b/tests/landIce/CismAlbany/inputFiles/input_standalone-albany.yaml
@@ -44,7 +44,7 @@ ANONYMOUS:
   Discretization:
     Columnwise Ordering: true
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: greenland_standalone-albanyT.exo
     NumLayers: 10
     Extrude Basal Node Fields: [basal_friction, thickness, surface_height]

--- a/tests/landIce/CismAlbany/inputFiles/input_standalone-albany_withFlowRate.yaml
+++ b/tests/landIce/CismAlbany/inputFiles/input_standalone-albany_withFlowRate.yaml
@@ -44,7 +44,7 @@ ANONYMOUS:
   Discretization:
     Columnwise Ordering: true
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: gis_unstruct.exo
     NumLayers: 10
     Extrude Basal Node Fields: [basal_friction, thickness, surface_height]

--- a/tests/landIce/Enthalpy/input_enthalpy_humboldt.yaml
+++ b/tests/landIce/Enthalpy/input_enthalpy_humboldt.yaml
@@ -68,7 +68,7 @@ ANONYMOUS:
         Name: Solution Average
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_enthalpy.exo

--- a/tests/landIce/Enthalpy/input_kleiner_A.yaml
+++ b/tests/landIce/Enthalpy/input_kleiner_A.yaml
@@ -61,7 +61,7 @@ ANONYMOUS:
         Type: Scalar Response
         Name: Solution Average
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: kleiner_A.exo
     Use Serial Mesh: true

--- a/tests/landIce/Enthalpy/input_kleiner_B.yaml
+++ b/tests/landIce/Enthalpy/input_kleiner_B.yaml
@@ -61,7 +61,7 @@ ANONYMOUS:
         Type: Scalar Response
         Name: Solution Average
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: kleiner_B.exo
     Use Serial Mesh: true

--- a/tests/landIce/FO_AIS/inputMueLu.yaml
+++ b/tests/landIce/FO_AIS/inputMueLu.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: antarctica_muelu_out.exo
     NumLayers: 3

--- a/tests/landIce/FO_AIS/inputMueLuKokkos.yaml
+++ b/tests/landIce/FO_AIS/inputMueLuKokkos.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: antarctica_muelu_out.exo
     NumLayers: 3

--- a/tests/landIce/FO_AIS/inputMueLuShort.yaml
+++ b/tests/landIce/FO_AIS/inputMueLuShort.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: antarctica_muelu_short_out.exo
     NumLayers: 3

--- a/tests/landIce/FO_AIS/input_FROSch.yaml
+++ b/tests/landIce/FO_AIS/input_FROSch.yaml
@@ -52,7 +52,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: antarctica_muelu_out.exo
     NumLayers: 3

--- a/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity.yaml
@@ -55,7 +55,7 @@ ANONYMOUS:
     Body Force: 
       Type: FO INTERP SURF GRAD
   Discretization: 
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_adjoint_sensitivity.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_bed_and_top.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_bed_and_top.yaml
@@ -114,7 +114,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_adjoint_sensitivity_bed_and_top.exo

--- a/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness.yaml
@@ -95,7 +95,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_adjoint_sensitivity_thickness.exo

--- a/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeight.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_adjoint_sensitivity_thickness_adjustSurfHeight.yaml
@@ -62,7 +62,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_adjoint_sensitivity_thickness.exo

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta.yaml
@@ -80,7 +80,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_beta.exo
     Columnwise Ordering: false

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian.yaml
@@ -118,7 +118,7 @@ ANONYMOUS:
                   Amesos2: {}
                   Amesos2 solver name: klu
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_beta.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian_matfree.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_hessian_matfree.yaml
@@ -114,7 +114,7 @@ ANONYMOUS:
                 Overlap: 0
                 Prec Type: RILUK
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_beta.exo
     Columnwise Ordering: false

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_mem.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_beta_mem.yaml
@@ -75,7 +75,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_beta_mem.exo
     Columnwise Ordering: false

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening.yaml
@@ -146,7 +146,7 @@ ANONYMOUS:
                   Amesos2: {}
                   Amesos2 solver name: klu
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_stiffening.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening_mem.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_stiffening_mem.yaml
@@ -73,7 +73,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_analysis_stiffening_mem.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_analysis_two_params.yaml
@@ -81,7 +81,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_analysis_two_params.exo

--- a/tests/landIce/FO_GIS/input_fo_gis_beta_smb.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_beta_smb.yaml
@@ -68,7 +68,7 @@ ANONYMOUS:
   Discretization:
     Columnwise Ordering: true
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: gis_beta_smb.exo
     Workset Size: 2500
     NumLayers: 5

--- a/tests/landIce/FO_GIS/input_fo_gis_coupled.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_coupled.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_coupled.exo
     Workset Size: 2000

--- a/tests/landIce/FO_GIS/input_fo_gis_forward_sensitivity.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_forward_sensitivity.yaml
@@ -53,7 +53,7 @@ ANONYMOUS:
     Body Force:
       Type: FO INTERP SURF GRAD
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_unstruct_adjoint_sensitivity.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_GIS/input_fo_gis_manifold.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_manifold.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
       Y_0: 0.0
   Discretization:
     Columnwise Ordering: true
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: gis_manifold.exo
     NumLayers: 5

--- a/tests/landIce/FO_GIS/input_fo_gis_populate_meshes.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_populate_meshes.yaml
@@ -8,7 +8,7 @@ ANONYMOUS:
     Name: Populate Mesh
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Columnwise Ordering: true
     NumLayers: 5
     Thickness Field Name: ice_thickness

--- a/tests/landIce/FO_GIS/input_fo_gis_unstruct.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_unstruct.yaml
@@ -54,7 +54,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: gis_unstruct.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_GIS/input_fo_gis_unstruct_FROSch.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_unstruct_FROSch.yaml
@@ -56,7 +56,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: gis_unstruct_frosh.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_GIS/input_fo_gis_unstruct_mem.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_unstruct_mem.yaml
@@ -54,7 +54,7 @@ ANONYMOUS:
       Type: FO INTERP SURF GRAD
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: gis_unstruct_mem.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_GIS/input_fo_humboldt_analysis.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_analysis.yaml
@@ -175,7 +175,7 @@ ANONYMOUS:
   # What mesh, elements to used, what/how to import fields.
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_analysis_mat_free_reg.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_analysis_mat_free_reg.yaml
@@ -198,7 +198,7 @@ ANONYMOUS:
   # What mesh, elements to used, what/how to import fields.
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_analysis_three_params.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_analysis_three_params.yaml
@@ -356,7 +356,7 @@ ANONYMOUS:
   # What mesh, elements to used, what/how to import fields.
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: observed_surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_depthInt_muelu.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_depthInt_muelu.yaml
@@ -91,7 +91,7 @@ ANONYMOUS:
           Regularization Coefficient: 1.0e+00
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_frosch_effect_press.yaml
@@ -86,7 +86,7 @@ ANONYMOUS:
           Regularization Coefficient: 1.0e+00
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt_eff_press.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_frosch_fluxdiv.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_frosch_fluxdiv.yaml
@@ -130,7 +130,7 @@ ANONYMOUS:
                 Prec Type: RILUK
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt_fluxdiv.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_frosch_power_law.yaml
@@ -86,7 +86,7 @@ ANONYMOUS:
           Regularization Coefficient: 1.0e+00
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt_power_law.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_frosch_pressurized_bed.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_frosch_pressurized_bed.yaml
@@ -88,7 +88,7 @@ ANONYMOUS:
           Regularization Coefficient: 1.0e+00
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt_press_bed.exo

--- a/tests/landIce/FO_GIS/input_fo_humboldt_muelu.yaml
+++ b/tests/landIce/FO_GIS/input_fo_humboldt_muelu.yaml
@@ -89,7 +89,7 @@ ANONYMOUS:
           Regularization Coefficient: 1.0e+00
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: output/humboldt.exo

--- a/tests/landIce/FO_GIS/input_humboldt_sampling_3D.yaml
+++ b/tests/landIce/FO_GIS/input_humboldt_sampling_3D.yaml
@@ -26,7 +26,7 @@ ANONYMOUS:
     Cubature Degree: 3
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: humboldt_laplacian_3d_sampling.exo

--- a/tests/landIce/FO_Hydrology/input_dome_steady_bwd.yaml
+++ b/tests/landIce/FO_Hydrology/input_dome_steady_bwd.yaml
@@ -199,7 +199,7 @@ ANONYMOUS:
         Type: Given Field
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Columnwise Ordering: true
     NumLayers: 5
     Thickness Field Name: ice_thickness

--- a/tests/landIce/FO_Hydrology/input_dome_steady_fwd.yaml
+++ b/tests/landIce/FO_Hydrology/input_dome_steady_fwd.yaml
@@ -105,7 +105,7 @@ ANONYMOUS:
         Type: Given Field
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: results-fwd/dome.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_glf_quad.yaml
+++ b/tests/landIce/FO_MMS/input_glf_quad.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
       Function Expression for DOF Y: 'value = 0'
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_hex_glf.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_glf_tri.yaml
+++ b/tests/landIce/FO_MMS/input_glf_tri.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
       Function Expression for DOF Y: 'value = 0'
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_glf.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_glf_tri_edge_on_gl.yaml
+++ b/tests/landIce/FO_MMS/input_glf_tri_edge_on_gl.yaml
@@ -58,7 +58,7 @@ ANONYMOUS:
       Function Expression for DOF Y: 'value = 0'
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_flg_edge_on_gl.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_glf_tri_nonconst_vel.yaml
+++ b/tests/landIce/FO_MMS/input_glf_tri_nonconst_vel.yaml
@@ -60,7 +60,7 @@ ANONYMOUS:
       Function Expression for DOF Y: 'value = 1'
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_glf_nonconst_vel.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_smb_quad.yaml
+++ b/tests/landIce/FO_MMS/input_smb_quad.yaml
@@ -68,7 +68,7 @@ ANONYMOUS:
       Function Data: [1.0, 2.0]
   Discretization: 
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_hex_smb.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_MMS/input_smb_tri.yaml
+++ b/tests/landIce/FO_MMS/input_smb_tri.yaml
@@ -69,7 +69,7 @@ ANONYMOUS:
       Function Expression for DOF Y: 'value = x'
   Discretization:
     Number Of Time Derivatives: 0
-    Method: Extruded
+    Method: STKExtruded
     Exodus Output File Name: slab_smb.exo
     Columnwise Ordering: true
     NumLayers: 5

--- a/tests/landIce/FO_Thermo/humboldt_analysis.yaml
+++ b/tests/landIce/FO_Thermo/humboldt_analysis.yaml
@@ -137,7 +137,7 @@ ANONYMOUS:
         Scaling Coefficient: 4.540693e-06
   Discretization: 
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_full.exo

--- a/tests/landIce/FO_Thermo/humboldt_analysis_contiguous.yaml
+++ b/tests/landIce/FO_Thermo/humboldt_analysis_contiguous.yaml
@@ -137,7 +137,7 @@ ANONYMOUS:
         Scaling Coefficient: 4.540693e-06
   Discretization: 
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_full.exo

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_depthInt_fluxDiv.yaml
@@ -134,7 +134,7 @@ ANONYMOUS:
         Field Name: L2 Projected Boundary Laplacian_basalside 
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_full.exo

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_fluxDiv.yaml
@@ -133,7 +133,7 @@ ANONYMOUS:
         Field Name: L2 Projected Boundary Laplacian_basalside 
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_full.

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_lubricated.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_Humboldt_lubricated.yaml
@@ -113,7 +113,7 @@ ANONYMOUS:
         Target Field Name: observed_surface_velocity_upperside
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Surface Height Field Name: surface_height
     Number Of Time Derivatives: 0
     Exodus Output File Name: ./humboldt_full.exo

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_dry_bed_test.yaml
@@ -74,7 +74,7 @@ ANONYMOUS:
         Name: Solution Average
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: enth_coupled.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test.yaml
@@ -78,7 +78,7 @@ ANONYMOUS:
         Name: Solution Average
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: enth_coupled.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_FROSch.yaml
@@ -76,7 +76,7 @@ ANONYMOUS:
         Name: Solution Average
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: enth_coupled.exo
     Columnwise Ordering: true

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_fea.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_fea.yaml
@@ -76,7 +76,7 @@ ANONYMOUS:
         Name: Solution Average
   Discretization:
     Workset Size: -1
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: enth_coupled.exo
     Columnwise Ordering: true

--- a/tests/landIce/unit/input_column_coupling.yaml
+++ b/tests/landIce/unit/input_column_coupling.yaml
@@ -25,7 +25,7 @@ ANONYMOUS:
     Cubature Degree: 4
     
   Discretization:
-    Method: Extruded
+    Method: STKExtruded
     Number Of Time Derivatives: 0
     Exodus Output File Name: column_coupling_test.exo
     Columnwise Ordering: true

--- a/tests/unit/Albany_UnitTestMain.cpp
+++ b/tests/unit/Albany_UnitTestMain.cpp
@@ -8,11 +8,15 @@
 #include "Teuchos_GlobalMPISession.hpp"
 #include "Phalanx_KokkosDeviceTypes.hpp"
 
+#include "Albany_UnitTestSession.hpp"
+
 #include "Albany_config.h"
 #ifdef ALBANY_OMEGAH
 #include "Albany_CommUtils.hpp"
 #include "Albany_Omegah.hpp"
 #endif
+
+#include <random>
 
 int main( int argc, char* argv[] )
 {
@@ -30,6 +34,17 @@ int main( int argc, char* argv[] )
     PHX::exec_space exec_space; 
     exec_space.print_configuration(out);
   }
+
+  auto& clp = Teuchos::UnitTestRepository::getCLP();
+  auto& ts = Albany::UnitTestSession::instance();
+
+  std::random_device rdev;
+  ts.rng_seed = rdev();
+  clp.setOption("rng-seed",
+                &ts.rng_seed,
+                "Allow to set a seed that can be used by unit tests in random numbers generators.\n"
+                "Using this value in tests allows to reproduce the exact same results of a previous run.");
+
   Teuchos::UnitTestRepository::setGloballyReduceTestResult(true);
   auto success = Teuchos::UnitTestRepository::runUnitTestsFromMain(argc, argv);
 

--- a/tests/unit/Albany_UnitTestSession.hpp
+++ b/tests/unit/Albany_UnitTestSession.hpp
@@ -1,0 +1,21 @@
+#ifndef ALBANY_UNIT_TESTS_SESSION_HPP
+#define ALBANY_UNIT_TESTS_SESSION_HPP
+
+namespace Albany
+{
+
+struct UnitTestSession {
+  static UnitTestSession& instance () {
+    static UnitTestSession ts;
+    return ts;
+  }
+
+  int rng_seed;
+
+private:
+  UnitTestSession() = default;
+};
+
+}
+
+#endif // ALBANY_UNIT_TESTS_SESSION_HPP

--- a/tests/unit/disc/CMakeLists.txt
+++ b/tests/unit/disc/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(generic)
 add_subdirectory(stk)
 if (ENABLE_OMEGAH)
   add_subdirectory(omegah)

--- a/tests/unit/disc/generic/CMakeLists.txt
+++ b/tests/unit/disc/generic/CMakeLists.txt
@@ -1,0 +1,18 @@
+#*****************************************************************//
+#    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+#    This Software is released under the BSD license detailed     //
+#    in the file "license.txt" in the top-level Albany directory  //
+#*****************************************************************//
+
+get_filename_component(parentPath ${CMAKE_CURRENT_SOURCE_DIR} PATH)
+get_filename_component(parentDirName ${parentPath} NAME)
+get_filename_component(dirName ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+set (testNameRoot ${parentDirName}_${dirName})
+
+#################################################
+#          Omega_h Discretization tests         #
+#################################################
+
+create_unit_test (NAME    ExtrudedMesh
+                  PREFIX  ${testNameRoot}
+                  SOURCES ExtrudedMesh.cpp)

--- a/tests/unit/disc/generic/CMakeLists.txt
+++ b/tests/unit/disc/generic/CMakeLists.txt
@@ -16,3 +16,8 @@ set (testNameRoot ${parentDirName}_${dirName})
 create_unit_test (NAME    ExtrudedMesh
                   PREFIX  ${testNameRoot}
                   SOURCES ExtrudedMesh.cpp)
+
+create_unit_test (NAME    ExtrudedConnManager
+                  PREFIX  ${testNameRoot}
+                  SOURCES ExtrudedConnManager.cpp
+                          DummyConnManager.cpp)

--- a/tests/unit/disc/generic/DummyConnManager.cpp
+++ b/tests/unit/disc/generic/DummyConnManager.cpp
@@ -1,0 +1,139 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "DummyConnManager.hpp"
+
+#include <Panzer_FieldPattern.hpp>
+
+#include <numeric>
+
+namespace Albany {
+
+DummyConnManager::
+DummyConnManager (const Teuchos::RCP<const DummyMesh>& mesh)
+ : m_mesh(mesh)
+{
+  // Init members of base class
+  const auto& ms = m_mesh->meshSpecs[0];
+  m_elem_blocks_names.resize(1,ms->ebName);
+
+  int ne = m_mesh->get_num_local_elements();
+  m_elem_lids.resize(ne);
+  std::iota(m_elem_lids.begin(),m_elem_lids.end(),0);
+}
+
+Teuchos::RCP<panzer::ConnManager>
+DummyConnManager::noConnectivityClone() const
+{
+  return Teuchos::rcp(new DummyConnManager(m_mesh));
+}
+
+std::vector<GO>
+DummyConnManager::getElementsInBlock (const std::string& blockId) const
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (blockId!=elem_block_name(), std::invalid_argument,
+      "Input part name does not match mesh eb name");
+  return m_mesh->my_elems();
+}
+
+void
+DummyConnManager::buildConnectivity(const panzer::FieldPattern& fp)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (m_is_connectivity_built, std::logic_error,
+      "[DummyConnManager::buildConnectivity] Connectivity was already built.\n");
+
+  const auto& topo = get_topology();
+  const int ne = m_mesh->get_num_local_elements();
+
+  const int patternDim = fp.getDimension();
+  GO nodeDofCount = 0;
+  GO edgeDofCount = 0;
+  GO faceDofCount = 0;
+  GO cellDofCount = 0;
+  switch(patternDim) {
+    case 3:
+      for (int iface=0; iface<topo.getFaceCount(); ++iface) {
+        m_num_dofs_per_elem += fp.getSubcellIndices(2,iface).size();
+        faceDofCount += fp.getSubcellIndices(2,iface).size();
+      }
+    case 2:
+      for (int iedge=0; iedge<topo.getEdgeCount(); ++iedge) {
+        m_num_dofs_per_elem += fp.getSubcellIndices(1,iedge).size();
+        edgeDofCount += fp.getSubcellIndices(1,iedge).size();
+      }
+    case 1:
+      for (int inode=0; inode<topo.getNodeCount(); ++inode) {
+        m_num_dofs_per_elem += fp.getSubcellIndices(0,inode).size();
+        nodeDofCount += fp.getSubcellIndices(0,inode).size();
+      }
+    case 0:
+      m_num_dofs_per_elem += fp.getSubcellIndices(patternDim,0).size();
+      cellDofCount += fp.getSubcellIndices(patternDim,0).size();
+      break;
+    default:
+       TEUCHOS_ASSERT(false);
+  };
+
+  GO nodeOffset = 0;
+  GO edgeOffset = nodeOffset + m_mesh->num_global_nodes();
+  GO faceOffset = edgeOffset + m_mesh->num_global_edges();
+  GO cellOffset = faceOffset + m_mesh->num_global_faces();
+  for (int ie=0; ie<ne; ++ie) {
+    const GO gelem = m_mesh->my_elems()[ie];
+    // std::cout << "dummy" << topo.getDimension() << "d, ie=" << ie << "\n";
+    int start = m_connectivity.size();
+    if (topo.getDimension()>0) {
+      // Add node indices
+      const auto& nodes = m_mesh->elem2node().at(ie);
+      for (int inode=0; inode<topo.getNodeCount(); ++inode) {
+        int nodeIdCnt = fp.getSubcellIndices(0,inode).size();
+        for (int id=0; id<nodeIdCnt; ++id) {
+          m_connectivity.push_back(nodeOffset + nodes[inode]*nodeIdCnt + id);
+        }
+      }
+    }
+
+    if (topo.getDimension()>1) {
+      // Add edge indices
+      const auto& edges = m_mesh->elem2edge().at(ie);
+      for (int iedge=0; iedge<topo.getEdgeCount(); ++iedge) {
+        int edgeIdCnt = fp.getSubcellIndices(1,iedge).size();
+        for (int id=0; id<edgeIdCnt; ++id) {
+          m_connectivity.push_back(edgeOffset + edges[iedge]*edgeIdCnt + id);
+        }
+      }
+    }
+
+    if (topo.getDimension()>2) {
+      // Add face indices
+      const auto& faces = m_mesh->elem2face().at(ie);
+      for (int iface=0; iface<topo.getFaceCount(); ++iface) {
+        int faceIdCnt = fp.getSubcellIndices(2,iface).size();
+        for (int id=0; id<faceIdCnt; ++id) {
+          m_connectivity.push_back(faceOffset + faces[iface]*faceIdCnt + id);
+        }
+      }
+    }
+
+    // Add cell indices
+    int cellIdCnt = fp.getSubcellIndices(patternDim,0).size();
+    for (int id=0; id<cellIdCnt; ++id) {
+      m_connectivity.push_back(cellOffset + gelem*cellIdCnt + id);
+    }
+
+    int cnt = m_connectivity.size()-start;
+    // for (int ii=0; ii<cnt; ++ii) {
+    //   std::cout << " " << m_connectivity[start+ii];
+    // }
+    // std::cout << "\n";
+  }
+
+  m_ownership.resize(m_connectivity.size(),Ownership::Owned);
+
+  m_is_connectivity_built = true;
+}
+
+} // namespace Albany

--- a/tests/unit/disc/generic/DummyConnManager.cpp
+++ b/tests/unit/disc/generic/DummyConnManager.cpp
@@ -42,7 +42,7 @@ DummyConnManager::getElementsInBlock (const std::string& blockId) const
 void
 DummyConnManager::buildConnectivity(const panzer::FieldPattern& fp)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_is_connectivity_built, std::logic_error,
+  TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
       "[DummyConnManager::buildConnectivity] Connectivity was already built.\n");
 
   const auto& topo = get_topology();
@@ -132,8 +132,6 @@ DummyConnManager::buildConnectivity(const panzer::FieldPattern& fp)
   }
 
   m_ownership.resize(m_connectivity.size(),Ownership::Owned);
-
-  m_is_connectivity_built = true;
 }
 
 } // namespace Albany

--- a/tests/unit/disc/generic/DummyConnManager.hpp
+++ b/tests/unit/disc/generic/DummyConnManager.hpp
@@ -1,0 +1,122 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_DUMMY_CONN_MANAGER_HPP
+#define ALBANY_DUMMY_CONN_MANAGER_HPP
+
+#include "DummyMesh.hpp"
+#include "Albany_ConnManager.hpp"
+
+#include <Shards_CellTopology.hpp>
+
+#include <vector>
+#include <map>
+
+namespace Albany {
+
+class DummyConnManager : public ConnManager {
+public:
+  DummyConnManager (const Teuchos::RCP<const DummyMesh>& mesh);
+
+  ~DummyConnManager() = default;
+
+  using ConnManager::getElementsInBlock;
+  std::vector<GO>
+  getElementsInBlock (const std::string& elem_block_name) const override;
+
+  void buildConnectivity(const panzer::FieldPattern & fp) override;
+
+  Teuchos::RCP<panzer::ConnManager> noConnectivityClone() const override;
+
+  const GO * getConnectivity(LO ielem) const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+        "Error! Cannot call getConnectivity before connectivity is build.\n");
+    return m_connectivity.data() + ielem*m_num_dofs_per_elem;
+  }
+
+  const Ownership* getOwnership(LO ielem) const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+        "Error! Cannot call getOwnership before connectivity is build.\n");
+    return m_ownership.data() + ielem*m_num_dofs_per_elem;
+  }
+
+  std::vector<int> getConnectivityMask (const std::string& /* sub_part_name */) const override
+  {
+    throw std::runtime_error("DummyConnManager::getConnectivityMask is not implemented");
+    return {};
+  }
+
+  int getConnectivityStart(const LO ielem) const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+        "Error! Cannot call getConnectivityStart before connectivity is build.\n");
+    return ielem*m_num_dofs_per_elem;
+  }
+
+  LO getConnectivitySize(LO /* localElmtId */) const override
+  {
+    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+        "Error! Cannot call getConnectivitySize before connectivity is build.\n");
+    return m_num_dofs_per_elem;
+  }
+
+  std::string getBlockId(LO localElmtId) const override
+  {
+    return m_elem_blocks_names[0];
+  }
+
+  std::size_t numElementBlocks() const override
+  {
+    return 1;
+  }
+
+  void getElementBlockIds(std::vector<std::string> & elementBlockIds) const override
+  {
+    const auto& ms = m_mesh->meshSpecs[0];
+    elementBlockIds.resize(1,ms->ebName);
+  }
+
+  void getElementBlockTopologies(std::vector<shards::CellTopology> & elementBlockTopologies) const override
+  {
+    const auto& ms = m_mesh->meshSpecs[0];
+    elementBlockTopologies.resize(1,shards::CellTopology(&ms->ctd));
+  }
+
+  const std::vector<LO> & getElementBlock(const std::string & /* elem_block_name */) const override
+  {
+    return m_elem_lids;
+  }
+
+  int getOwnedElementCount() const
+  {
+    return m_mesh->get_num_local_elements();
+  }
+
+  // // Queries the dimension of a part
+  int part_dim (const std::string& part_name) const override
+  {
+    const auto& ms = m_mesh->meshSpecs[0];
+    TEUCHOS_TEST_FOR_EXCEPTION (part_name!=ms->ebName, std::invalid_argument,
+        "Input part name does not match mesh eb name");
+    return ms->numDim;
+  }
+
+protected:
+
+  std::vector<GO>           m_connectivity;
+  std::vector<Ownership>    m_ownership;
+  std::vector<LO>           m_elem_lids;
+
+  int   m_num_dofs_per_elem = 0;
+
+  Teuchos::RCP<const DummyMesh> m_mesh;
+};
+
+} // namespace Albany
+
+#endif // ALBANY_DUMMY_CONN_MANAGER_HPP

--- a/tests/unit/disc/generic/DummyConnManager.hpp
+++ b/tests/unit/disc/generic/DummyConnManager.hpp
@@ -33,14 +33,14 @@ public:
 
   const GO * getConnectivity(LO ielem) const override
   {
-    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+    TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
         "Error! Cannot call getConnectivity before connectivity is build.\n");
     return m_connectivity.data() + ielem*m_num_dofs_per_elem;
   }
 
   const Ownership* getOwnership(LO ielem) const override
   {
-    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+    TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
         "Error! Cannot call getOwnership before connectivity is build.\n");
     return m_ownership.data() + ielem*m_num_dofs_per_elem;
   }
@@ -53,14 +53,14 @@ public:
 
   int getConnectivityStart(const LO ielem) const override
   {
-    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+    TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
         "Error! Cannot call getConnectivityStart before connectivity is build.\n");
     return ielem*m_num_dofs_per_elem;
   }
 
   LO getConnectivitySize(LO /* localElmtId */) const override
   {
-    TEUCHOS_TEST_FOR_EXCEPTION (not m_is_connectivity_built, std::logic_error,
+    TEUCHOS_TEST_FOR_EXCEPTION (not is_connectivity_built(), std::logic_error,
         "Error! Cannot call getConnectivitySize before connectivity is build.\n");
     return m_num_dofs_per_elem;
   }

--- a/tests/unit/disc/generic/DummyMesh.hpp
+++ b/tests/unit/disc/generic/DummyMesh.hpp
@@ -1,0 +1,210 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#ifndef ALBANY_DUMMY_MESH_HPP
+#define ALBANY_DUMMY_MESH_HPP
+
+#include "Albany_ExtrudedMesh.hpp"
+
+#include <numeric>
+
+namespace Albany {
+
+// This dummy mesh in 2d or 3d. The 2d part is made up of triangles,
+// obtained by dividing a strip of squares into triangle pairs,like so
+//
+//   +--+--+--+
+//   | /| /| /|...
+//   |/ |/ |/ |
+//   +--+--+--+
+// This allows to be able to compute node/edge GIDs from the elem GID. In particular:
+//  - node gids are left to right, bottom row first
+//  - edge gids are left to right, bottom row first, then top, then vertical, then oblique
+//  - face gids are left to right, square by square, with upside-down triangle first
+// For 3d mesh, we number all horiz entities first, bottom to top, and then all vertical ones,
+// using same ordering as in 2d
+struct DummyMesh : public AbstractMeshStruct {
+public:
+  DummyMesh (const int ne_x, const int ne_z,
+             const Teuchos::RCP<const Teuchos_Comm>& comm)
+   : m_mesh2d(new DummyMesh(ne_x,comm))
+   , m_num_local_nodes (m_mesh2d->get_num_local_nodes()*(ne_z+1))
+   , m_num_local_elems (m_mesh2d->get_num_local_elements()*ne_z)
+  {
+    const auto ctd = shards::getCellTopologyData<shards::Wedge<6>>();
+    meshSpecs.resize(1);
+    meshSpecs[0] = Teuchos::rcp(new MeshSpecsStruct(
+          MeshType::Structured, *ctd,
+          ctd->dimension, {}, {}, 1000, "eb0", { {"eb0",0} }));
+
+    m_num_global_elems = m_mesh2d->num_global_elems()*ne_z;
+    m_num_global_nodes = m_mesh2d->num_global_nodes()*(ne_z+1);
+    m_num_global_edges = m_mesh2d->num_global_edges()*(ne_z+1)
+                       + m_mesh2d->num_global_nodes()*ne_z;
+    m_num_global_faces = m_mesh2d->num_global_elems()*(ne_z+1)
+                       + m_mesh2d->num_global_edges()*ne_z;
+
+    m_my_elems.resize(m_num_local_elems);
+
+    auto ordering = LayeredMeshOrdering::LAYER;
+    LayeredMeshNumbering<LO> cell_layers_lid(m_mesh2d->get_num_local_elements(),ne_z,ordering);
+    LayeredMeshNumbering<GO> cell_layers_gid(m_mesh2d->num_global_elems(),ne_z,ordering);
+    LayeredMeshNumbering<GO> node_layers_gid(m_mesh2d->num_global_nodes(),ne_z+1,ordering);
+    LayeredMeshNumbering<GO> edge_layers_gid(m_mesh2d->num_global_edges(),ne_z+1,ordering);
+    for (int icol=0; icol<m_mesh2d->get_num_local_elements(); ++icol) {
+      const auto& nodes2d = m_mesh2d->elem2node().at(icol);
+      const auto& edges2d = m_mesh2d->elem2edge().at(icol);
+      GO gelem2d = m_mesh2d->my_elems()[icol];
+      for (int ilev=0; ilev<ne_z; ++ilev) {
+        LO ie = cell_layers_lid.getId(icol,ilev);
+        GO gelem = m_my_elems[ie] = cell_layers_gid.getId(gelem2d,ilev);
+        
+        // Nodes: bot face, then top face
+        auto& nodes = m_elem2node[ie];
+        for (auto n : nodes2d) {
+          nodes.push_back(node_layers_gid.getId(n,ilev));
+        }
+        for (auto n : nodes2d) {
+          nodes.push_back(node_layers_gid.getId(n,ilev+1));
+        }
+
+        // Edges: bot face edges, then top face edges, then vert edges
+        auto& edges = m_elem2edge[ie];
+        for (auto e : edges2d) {
+          edges.push_back(edge_layers_gid.getId(e,ilev));
+        }
+        for (auto e : edges2d) {
+          edges.push_back(edge_layers_gid.getId(e,ilev+1));
+        }
+        for (auto n : nodes2d) {
+          GO offset = 2*m_mesh2d->num_global_edges();
+          GO vertId = node_layers_gid.getId(n,ilev);
+          edges.push_back(offset+vertId);
+        }
+
+        // Faces: bot, top, then lateral, in same order of edges2d
+        auto& faces = m_elem2face[ie];
+        faces.push_back(cell_layers_gid.getId(gelem2d,ilev));
+        faces.push_back(cell_layers_gid.getId(gelem2d,ilev+1));
+        GO offset_vfaces = m_mesh2d->num_global_elems() * (ne_z+1);
+        for (auto e : edges2d) {
+          faces.push_back(edge_layers_gid.getId(e,ilev) + offset_vfaces);
+        }
+      }
+    }
+  }
+
+  DummyMesh (const int ne_x,
+             const Teuchos::RCP<const Teuchos_Comm>& comm)
+  {
+    auto lcl_ne_x = ne_x / comm->getSize();
+    auto rem = ne_x % comm->getSize();
+    if (comm->getRank()<rem) {
+      ++lcl_ne_x;
+    }
+
+    m_num_local_nodes = 2*(lcl_ne_x+1);
+    m_num_local_elems = 2*lcl_ne_x;
+
+    const auto ctd = shards::getCellTopologyData<shards::Triangle<3>>();
+    meshSpecs.resize(1);
+    meshSpecs[0] = Teuchos::rcp(new MeshSpecsStruct(
+          MeshType::Structured, *ctd,
+          ctd->dimension, {}, {}, 1000, "eb0", { {"eb0",0} }));
+
+    GO beg = 0;
+    for (int pid=0; pid<comm->getSize(); ++pid) {
+      int pid_ne = m_num_local_elems;
+      Teuchos::broadcast(*comm,pid,1,&pid_ne);
+      if (pid<comm->getRank()) {
+        beg += pid_ne;
+      }
+    }
+    std::iota(m_my_elems.begin(),m_my_elems.end(),beg);
+
+    GO ngnodes_x = ne_x+1;
+    m_num_global_elems = 2*ne_x;
+    m_num_global_nodes = 2*(ne_x+1);
+    m_num_global_edges = 4*ne_x+1;
+
+    const GO offset_edge_top =   ne_x;
+    const GO offset_edge_vrt = 2*ne_x;
+    const GO offset_edge_obl = 3*ne_x + 1;
+    m_my_elems.resize(m_num_local_elems);
+    for (LO isquare=0; isquare<ne_x; ++isquare) {
+      GO gsquare = isquare + beg;
+      for (LO isplit : {0,1}) {
+        int ie = 2*isquare + isplit;
+        const GO gelem = m_my_elems[ie] = 2*gsquare + isplit;
+
+        auto& nodes = m_elem2node[ie];
+        auto& edges = m_elem2edge[ie];
+        if (isplit==0) {
+          nodes.push_back(gsquare);
+          nodes.push_back(gsquare+ngnodes_x);
+          nodes.push_back(gsquare+ngnodes_x+1);
+
+          edges.push_back(offset_edge_obl+gsquare);
+          edges.push_back(offset_edge_top+gsquare);
+          edges.push_back(offset_edge_vrt+gsquare);
+        } else {
+          nodes.push_back(gsquare);
+          nodes.push_back(gsquare+1);
+          nodes.push_back(gsquare+ngnodes_x+1);
+
+          edges.push_back(gsquare);
+          edges.push_back(offset_edge_vrt+gsquare+1);
+          edges.push_back(offset_edge_obl+gsquare);
+        }
+      }
+    }
+  }
+
+  const std::vector<GO>& my_elems () const { return m_my_elems; }
+  const std::map<LO,std::vector<GO>>& elem2node () const { return m_elem2node; }
+  const std::map<LO,std::vector<GO>>& elem2edge () const { return m_elem2edge; }
+  const std::map<LO,std::vector<GO>>& elem2face () const { return m_elem2face; }
+
+  GO num_global_nodes () const { return m_num_global_nodes; }
+  GO num_global_edges () const { return m_num_global_edges; }
+  GO num_global_faces () const { return m_num_global_faces; }
+  GO num_global_elems () const { return m_num_global_elems; }
+
+  LO get_num_local_nodes () const override { return m_num_local_nodes; }
+  LO get_num_local_elements () const override { return m_num_local_elems; }
+  GO get_max_node_gid () const override { return num_global_nodes(); }
+  GO get_max_elem_gid () const override { return num_global_elems(); }
+  Teuchos::RCP<AbstractMeshFieldAccessor> get_field_accessor () const override { return Teuchos::null; }
+
+  //! Internal mesh specs type needed
+  std::string meshLibName() const override { return "dummy"; }
+
+  void setFieldData (const Teuchos::RCP<const Teuchos_Comm>& /* comm */,
+                     const Teuchos::RCP<StateInfoStruct>& /* sis */) override {}
+
+  void setBulkData(const Teuchos::RCP<const Teuchos_Comm>& /* comm */) override {}
+
+protected:
+
+  // If this mesh is 3d, store the 2d basal mesh, to help numbering
+  Teuchos::RCP<DummyMesh> m_mesh2d;
+
+  std::map<LO,std::vector<GO>> m_elem2node;
+  std::map<LO,std::vector<GO>> m_elem2edge;
+  std::map<LO,std::vector<GO>> m_elem2face;
+  std::vector<GO>              m_my_elems;
+
+  GO  m_num_global_nodes = 0;
+  GO  m_num_global_edges = 0;
+  GO  m_num_global_faces = 0;
+  GO  m_num_global_elems = 0;
+  LO  m_num_local_elems  = 0;
+  LO  m_num_local_nodes  = 0;
+};
+
+} // Namespace Albany
+
+#endif // ALBANY_DUMMY_MESH_HPP

--- a/tests/unit/disc/generic/DummyMesh.hpp
+++ b/tests/unit/disc/generic/DummyMesh.hpp
@@ -175,8 +175,8 @@ public:
 
   LO get_num_local_nodes () const override { return m_num_local_nodes; }
   LO get_num_local_elements () const override { return m_num_local_elems; }
-  GO get_max_node_gid () const override { return num_global_nodes(); }
-  GO get_max_elem_gid () const override { return num_global_elems(); }
+  GO get_max_node_gid () const override { return num_global_nodes()-1; }
+  GO get_max_elem_gid () const override { return num_global_elems()-1; }
   Teuchos::RCP<AbstractMeshFieldAccessor> get_field_accessor () const override { return Teuchos::null; }
 
   //! Internal mesh specs type needed

--- a/tests/unit/disc/generic/ExtrudedConnManager.cpp
+++ b/tests/unit/disc/generic/ExtrudedConnManager.cpp
@@ -1,0 +1,244 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Albany_UnitTestSession.hpp"
+#include "DummyConnManager.hpp"
+#include "Albany_ExtrudedConnManager.hpp"
+#include "Albany_ProblemUtils.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_CommUtils.hpp"
+#include "DummyMesh.hpp"
+
+
+#include <Panzer_IntrepidFieldPattern.hpp>
+#include <Panzer_ElemFieldPattern.hpp>
+#include <Intrepid2_HierarchicalBasisFamily.hpp>
+
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_UnitTestHelpers.hpp>
+#include <Teuchos_LocalTestingHelpers.hpp>
+
+#include <random>
+
+Teuchos::RCP<panzer::FieldPattern>
+create_agg_fp (const std::vector<Teuchos::RCP<panzer::FieldPattern>>& fps)
+{
+  std::vector<std::pair<panzer::FieldType,Teuchos::RCP<const panzer::FieldPattern>>> tmp;
+  std::vector<std::tuple< int, panzer::FieldType, Teuchos::RCP<const panzer::FieldPattern> > > faConstruct;
+  const auto CG = panzer::FieldType::CG;
+  for (std::size_t i=0; i<fps.size(); ++i) {
+    tmp.push_back(std::make_pair(CG,fps[i]));
+    faConstruct.emplace_back(i, CG, fps[i]);
+  }
+  auto ga_fp = Teuchos::rcp(new panzer::GeometricAggFieldPattern(tmp));
+  return Teuchos::rcp(new panzer::FieldAggPattern(faConstruct, ga_fp));
+}
+
+TEUCHOS_UNIT_TEST(ExtrudedConnMgr, Exceptions)
+{
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto& ts = UnitTestSession::instance();
+
+  // 2d, and 3d topologies
+  auto tria  = shards::getCellTopologyData<shards::Triangle<3>>();
+  auto wedge = shards::getCellTopologyData<shards::Wedge<6>>();
+
+  // Create an intrepid2 tensor basis
+  using basis_family_type = Intrepid2::HierarchicalBasisFamily<PHX::Device>;
+  using tria_basis_type  = typename basis_family_type::HGRAD_TRI;
+  using wedge_basis_type = typename basis_family_type::HGRAD_WEDGE;
+  using wedge_basis_mono_type = Intrepid2::Basis_HGRAD_WEDGE_C1_FEM<PHX::Device,RealType,RealType>;
+  using hexa_basis_type  = typename basis_family_type::HGRAD_HEX;
+
+  auto tria_basis  = Teuchos::rcp(new tria_basis_type(1));
+  auto wedge_p2_basis = Teuchos::rcp(new wedge_basis_type(2,2));
+  auto wedge_mono_basis = Teuchos::rcp(new wedge_basis_mono_type());
+  auto hexa_basis  = Teuchos::rcp(new hexa_basis_type(1));
+
+  // Create field patterns for testing
+  auto fp_2d = Teuchos::rcp(new panzer::Intrepid2FieldPattern(tria_basis));
+  auto fp_3d = Teuchos::rcp(new panzer::Intrepid2FieldPattern(wedge_mono_basis));
+  auto fp_3d_p2 = Teuchos::rcp(new panzer::Intrepid2FieldPattern(wedge_p2_basis));
+  auto fp_3d_hex = Teuchos::rcp(new panzer::Intrepid2FieldPattern(hexa_basis));
+  auto elem_fp = Teuchos::rcp(new panzer::ElemFieldPattern(wedge));
+
+  using ipdf = std::uniform_int_distribution<int>;
+  std::mt19937_64 engine;
+  ipdf nlay_pdf (1,5);
+  ipdf ntri_pdf (5,10);
+
+  // Create dummy basal mesh
+  GO ne_x_lcl = ntri_pdf(engine);
+  auto numLayers = nlay_pdf(engine);
+
+  // Basal mesh and monolithic (not extruded) 3d mesh
+  auto mesh_2d = Teuchos::rcp(new DummyMesh(ne_x_lcl,comm));
+
+  GO num_glb_tria;
+  Teuchos::reduceAll(*comm,Teuchos::REDUCE_SUM,1,&ne_x_lcl,&num_glb_tria);
+
+  for (auto ordering : {LayeredMeshOrdering::COLUMN,LayeredMeshOrdering::LAYER}) {
+    // Build 2d and 3d conn managers (not extruded)
+    auto conn_mgr_tria  = Teuchos::rcp(new DummyConnManager(mesh_2d));
+
+    auto params = Teuchos::rcp(new Teuchos::ParameterList());
+    params->set<int>("NumLayers",0);
+    params->set<int>("Workset Size",1000);
+    params->set("Columnwise Ordering", ordering==LayeredMeshOrdering::COLUMN);
+
+    // Bad pointers
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(Teuchos::null,params,comm)),
+                std::invalid_argument);
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(mesh_2d,Teuchos::null,comm)),
+                std::invalid_argument);
+
+    // Bad num layers
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm)),
+                Teuchos::Exceptions::InvalidParameterValue);
+
+    params->set<int>("NumLayers",numLayers);
+    auto extruded_mesh = Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm));
+
+    // Bad pointers
+    TEST_THROW (Teuchos::rcp(new ExtrudedConnManager(Teuchos::null,extruded_mesh)),
+                std::invalid_argument);
+    TEST_THROW (Teuchos::rcp(new ExtrudedConnManager(conn_mgr_tria,Teuchos::null)),
+                std::invalid_argument);
+
+    // Build extruded conn manager
+    auto conn_mgr_ext = Teuchos::rcp(new ExtrudedConnManager(conn_mgr_tria,extruded_mesh));
+
+    // Bad field agg pattern: contains non-intrepid patterns
+    auto bad_fp1 = create_agg_fp({elem_fp});
+    TEST_THROW (conn_mgr_ext->buildConnectivity(*bad_fp1),std::bad_cast);
+
+    // Bad field agg pattern: contains different intrepid patterns
+    auto bad_fp2 = create_agg_fp({fp_3d,fp_3d_p2});
+    TEST_THROW (conn_mgr_ext->buildConnectivity(*bad_fp2),std::runtime_error);
+
+    // Bad field agg pattern: contains patterns with wrong cell topo
+    auto bad_fp3 = create_agg_fp({fp_2d});
+    TEST_THROW (conn_mgr_ext->buildConnectivity(*bad_fp3),std::runtime_error);
+
+    // Bad field agg pattern: basis is tens prod with wrong basal basis topology
+    auto bad_fp4 = create_agg_fp({fp_3d_hex});
+    TEST_THROW (conn_mgr_ext->buildConnectivity(*bad_fp4),std::invalid_argument);
+  }
+}
+
+TEUCHOS_UNIT_TEST(ExtrudedConnMgr, Numbering)
+{
+  // We test the conn generated with ExtrudedConnManager with a tensor intrepid basis
+  // against the DummyConnMgr with the same tensor intrepid basis 
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto& ts = UnitTestSession::instance();
+
+  // 2d, and 3d topologies
+  auto tria  = shards::getCellTopologyData<shards::Triangle<3>>();
+  auto wedge = shards::getCellTopologyData<shards::Wedge<6>>();
+
+  // Create an intrepid2 tensor basis
+  using basis_family_type = Intrepid2::HierarchicalBasisFamily<PHX::Device>;
+  using tria_basis_type  = typename basis_family_type::HGRAD_TRI;
+  using wedge_basis_type = typename basis_family_type::HGRAD_WEDGE;
+  using pattern_ptr      = Teuchos::RCP<panzer::FieldPattern>;
+  const int nfields = 2;
+
+  // Comparisong works for order_z=1, order_xy=1, but fails with either one >1.
+  using ipdf = std::uniform_int_distribution<int>;
+  std::mt19937_64 engine;
+  ipdf nlay_pdf (1,5);
+  ipdf ntri_pdf (5,10);
+
+  GO ne_x_lcl = ntri_pdf(engine);
+  auto numElemLayers = nlay_pdf(engine);
+  for (int order_z : {1,2}) {
+    auto wedge_basis = Teuchos::rcp(new wedge_basis_type(1,order_z));
+
+    // Create field patterns for testing
+    auto fp_3d = Teuchos::rcp(new panzer::Intrepid2FieldPattern(wedge_basis));
+
+    // Create dummy basal mesh
+    GO ne_x_lcl = ntri_pdf(engine);
+    auto numElemLayers = nlay_pdf(engine);
+
+    auto numDofLayers = order_z*numElemLayers + 1;
+
+    // Basal mesh and monolithic (not extruded) 3d mesh
+    auto mesh_2d = Teuchos::rcp(new DummyMesh(ne_x_lcl,comm));
+
+    GO num_glb_tria;
+    Teuchos::reduceAll(*comm,Teuchos::REDUCE_SUM,1,&ne_x_lcl,&num_glb_tria);
+
+    const auto num_nodes2d = mesh_2d->num_global_nodes();
+    const auto num_edges2d = mesh_2d->num_global_edges();
+
+    for (auto ordering : {LayeredMeshOrdering::COLUMN,LayeredMeshOrdering::LAYER} ) {
+
+      std::cout << "RUNNING TESTS WITH:\n"
+                << "  order_z     : " << order_z << "\n"
+                << "  num 2d elems: " << 2*ne_x_lcl << "\n"
+                << "  num layers  : " << numElemLayers << "\n"
+                << "  ordering    : " << (ordering==LayeredMeshOrdering::COLUMN ? "COLUMN" : "LAYER") << "\n";
+
+      // Build extruded mesh
+      auto params = Teuchos::rcp(new Teuchos::ParameterList());
+      params->set<int>("NumLayers",numElemLayers);
+      params->set<int>("Workset Size",1000);
+      params->set("Columnwise Ordering", ordering==LayeredMeshOrdering::COLUMN);
+      auto extruded_mesh = Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm));
+
+      // Build 2d conn manager
+      auto conn_mgr_tria  = Teuchos::rcp(new DummyConnManager(mesh_2d));
+
+      // Build extruded conn manager
+      auto conn_mgr_ext = Teuchos::rcp(new ExtrudedConnManager(conn_mgr_tria,extruded_mesh));
+      conn_mgr_ext->buildConnectivity(*create_agg_fp(std::vector<pattern_ptr>(nfields,fp_3d)));
+
+      // Helper structures
+      const int ndofs_2d = nfields*num_nodes2d;
+      auto cell_layers_lid = extruded_mesh->cell_layers_lid();
+      auto dofs_layers_gid = Teuchos::rcp(new LayeredMeshNumbering<GO>(ndofs_2d,numDofLayers,ordering));
+
+      // Check
+      for (int icol=0; icol<mesh_2d->get_num_local_elements(); ++icol) {
+        const auto conn2d = conn_mgr_tria->getConnectivity(icol);
+        const auto size2d = conn_mgr_tria->getConnectivitySize(icol);
+
+        for (int ilev=0; ilev<numElemLayers; ++ilev) {
+          int ie = cell_layers_lid->getId(icol,ilev);
+          const auto conn3d = conn_mgr_ext->getConnectivity(ie);
+          const auto size3d = conn_mgr_ext->getConnectivitySize(ie);
+          TEST_EQUALITY( size3d, nfields*size2d*(order_z+1) );
+
+          // Test that 3d dofs on particular in-elem layer are the expected ones
+          // Check by computing expected dof from 2d dof and the dof level
+          auto test_dof_lev = [&](const int dof_lev, const int offset3d) {
+            for (int idof=0; idof<size2d; ++idof) {
+              for (int ifield=0; ifield<nfields; ++ifield) {
+                auto dof2d = nfields*conn2d[idof] + ifield;
+                auto dof3d = conn3d[offset3d+idof*nfields+ifield];
+                TEST_EQUALITY (dof3d,dofs_layers_gid->getId(dof2d,dof_lev));
+              }
+            }
+          };
+
+          for (int ilay=0; ilay<=order_z; ++ilay) {
+            int dof_lev = ilev*order_z + ilay;
+
+            test_dof_lev(dof_lev,ilay*nfields*size2d); 
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/disc/generic/ExtrudedMesh.cpp
+++ b/tests/unit/disc/generic/ExtrudedMesh.cpp
@@ -1,0 +1,174 @@
+//*****************************************************************//
+//    Albany 3.0:  Copyright 2016 Sandia Corporation               //
+//    This Software is released under the BSD license detailed     //
+//    in the file "license.txt" in the top-level Albany directory  //
+//*****************************************************************//
+
+#include "Albany_UnitTestSession.hpp"
+#include "Albany_Utils.hpp"
+#include "Albany_StringUtils.hpp"
+#include "Albany_CommUtils.hpp"
+#include "DummyMesh.hpp"
+#include "Albany_DiscretizationFactory.hpp"
+
+#include <Teuchos_CommHelpers.hpp>
+#include <Teuchos_UnitTestHelpers.hpp>
+#include <Teuchos_LocalTestingHelpers.hpp>
+
+#include <random>
+
+TEUCHOS_UNIT_TEST (ExtrudedMesh, DiscFactoryCreateMesh)
+{
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto top_level_params = Teuchos::rcp(new Teuchos::ParameterList(""));
+  auto disc_params = Teuchos::sublist(top_level_params,"Discretization");
+  disc_params->set<std::string>("Method", "NewExtruded");
+  disc_params->set<int>("NumLayers", 5);
+  disc_params->set<int>("Number Of Time Derivatives", 0);
+  disc_params->set<bool>("Columnwise Ordering", true);
+  disc_params->sublist("Side Set Discretizations").set("Side Sets",Teuchos::Array<std::string>{"basalside"});
+  auto& basal_params = disc_params->sublist("Side Set Discretizations").sublist("basalside");
+  basal_params.set<std::string>("Method", "STK2D");
+  basal_params.set<int>("1D Elements", 1);
+  basal_params.set<int>("2D Elements", 1);
+  basal_params.set<std::string>("Cell Topology", "Triangle");
+
+  DiscretizationFactory factory(top_level_params,comm,false);
+
+  auto mesh = factory.createMeshStruct(disc_params,comm,3);
+  (void) mesh;
+}
+
+TEUCHOS_UNIT_TEST(ExtrudedMesh, Exceptions)
+{
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto& ts = UnitTestSession::instance();
+
+  using ipdf = std::uniform_int_distribution<int>;
+  std::mt19937_64 engine;
+  ipdf nlay_pdf (1,5);
+  ipdf ne_x_pdf (2*comm->getSize(),10*comm->getSize());
+
+  // Create dummy basal mesh
+  GO ne_x = ne_x_pdf(engine);
+  auto numLayers = nlay_pdf(engine);
+  auto mesh_2d = Teuchos::rcp(new DummyMesh(ne_x,comm));
+
+  for (auto ordering : {LayeredMeshOrdering::COLUMN,LayeredMeshOrdering::LAYER}) {
+
+    auto params = Teuchos::rcp(new Teuchos::ParameterList());
+    params->set<int>("NumLayers",0);
+    params->set<int>("Workset Size",1000);
+    params->set("Columnwise Ordering", ordering==LayeredMeshOrdering::COLUMN);
+
+    // Bad pointers
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(Teuchos::null,params,comm)),
+                std::invalid_argument);
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(mesh_2d,Teuchos::null,comm)),
+                std::invalid_argument);
+
+    // Bad num layers
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm)),
+                Teuchos::Exceptions::InvalidParameterValue);
+
+    // Bad basal mesh dimension
+    params->set<int>("NumLayers",1);
+    auto bad_basal_mesh = Teuchos::rcp(new DummyMesh(ne_x,1,comm));
+    TEST_THROW (Teuchos::rcp(new ExtrudedMesh(bad_basal_mesh,params,comm)),
+                std::logic_error);
+  }
+}
+
+TEUCHOS_UNIT_TEST(ExtrudedMesh, Counters)
+{
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto& ts = UnitTestSession::instance();
+
+  using ipdf = std::uniform_int_distribution<int>;
+  std::mt19937_64 engine;
+  ipdf nlay_pdf (1,5);
+  ipdf ne_x_pdf (2*comm->getSize(),10*comm->getSize());
+
+  // Create dummy basal mesh
+  GO ne_x = ne_x_pdf(engine);
+  auto numLayers = nlay_pdf(engine);
+  auto mesh_2d = Teuchos::rcp(new DummyMesh(ne_x,comm));
+
+  for (auto ordering : {LayeredMeshOrdering::COLUMN,LayeredMeshOrdering::LAYER}) {
+    auto params = Teuchos::rcp(new Teuchos::ParameterList());
+    params->set<int>("NumLayers",numLayers);
+    params->set<int>("Workset Size",1000);
+    params->set("Columnwise Ordering", ordering==LayeredMeshOrdering::COLUMN);
+
+    auto mesh_3d = Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm));
+    mesh_3d->setBulkData(comm);
+
+    TEST_EQUALITY (mesh_3d->get_num_local_elements(),mesh_2d->get_num_local_elements()*numLayers);
+    TEST_EQUALITY (mesh_3d->get_num_local_nodes(),mesh_2d->get_num_local_nodes()*(numLayers+1));
+    TEST_EQUALITY (mesh_3d->get_max_elem_gid(),mesh_2d->get_max_elem_gid()*numLayers);
+    TEST_EQUALITY (mesh_3d->get_max_node_gid(),mesh_2d->get_max_node_gid()*(numLayers+1));
+  }
+}
+
+TEUCHOS_UNIT_TEST(ExtrudedMesh, MeshParts)
+{
+  using namespace Albany;
+
+  auto comm = getDefaultComm();
+
+  auto& ts = UnitTestSession::instance();
+
+  using ipdf = std::uniform_int_distribution<int>;
+  std::mt19937_64 engine;
+  ipdf nlay_pdf (1,5);
+  ipdf ne_x_pdf (2*comm->getSize(),10*comm->getSize());
+
+  // Create dummy basal mesh
+  GO ne_x = ne_x_pdf(engine);
+  auto numLayers = nlay_pdf(engine);
+  auto mesh_2d = Teuchos::rcp(new DummyMesh(ne_x,comm));
+  auto nsNames2d = mesh_2d->meshSpecs()[0]->nsNames;
+  auto ssNames2d = mesh_2d->meshSpecs()[0]->ssNames;
+
+  auto contains = [](const auto container, const auto val) {
+    return std::find(container.begin(),container.end(),val)!=container.end();
+  };
+  for (auto ordering : {LayeredMeshOrdering::COLUMN,LayeredMeshOrdering::LAYER}) {
+    auto params = Teuchos::rcp(new Teuchos::ParameterList());
+    params->set<int>("NumLayers",numLayers);
+    params->set<int>("Workset Size",1000);
+    params->set("Columnwise Ordering", ordering==LayeredMeshOrdering::COLUMN);
+
+    auto mesh_3d = Teuchos::rcp(new ExtrudedMesh(mesh_2d,params,comm));
+    mesh_3d->setBulkData(comm);
+
+    auto nsNames3d = mesh_3d->meshSpecs()[0]->nsNames;
+    auto ssNames3d = mesh_3d->meshSpecs()[0]->ssNames;
+
+    std::cout << "ns: " << util::join(nsNames3d,",") << "\n";
+    std::cout << "ss: " << util::join(ssNames3d,",") << "\n";
+    for (const auto& nsn : nsNames2d) {
+      TEST_ASSERT (contains(nsNames3d,"basal_" + nsn));
+      TEST_ASSERT (contains(nsNames3d,"extruded_" + nsn));
+    }
+    for (const auto& ssn : ssNames2d) {
+      TEST_ASSERT (contains(ssNames3d,"extruded_" + ssn));
+    }
+    TEST_ASSERT (contains(nsNames3d,"bottom"));
+    TEST_ASSERT (contains(nsNames3d,"top"));
+    TEST_ASSERT (contains(nsNames3d,"lateral"));
+
+    TEST_ASSERT (contains(ssNames3d,"basalside"));
+    TEST_ASSERT (contains(ssNames3d,"upperside"));
+    TEST_ASSERT (contains(ssNames3d,"lateralside"));
+  }
+}

--- a/tests/unit/disc/generic/ExtrudedMesh.cpp
+++ b/tests/unit/disc/generic/ExtrudedMesh.cpp
@@ -25,7 +25,7 @@ TEUCHOS_UNIT_TEST (ExtrudedMesh, DiscFactoryCreateMesh)
 
   auto top_level_params = Teuchos::rcp(new Teuchos::ParameterList(""));
   auto disc_params = Teuchos::sublist(top_level_params,"Discretization");
-  disc_params->set<std::string>("Method", "NewExtruded");
+  disc_params->set<std::string>("Method", "Extruded");
   disc_params->set<int>("NumLayers", 5);
   disc_params->set<int>("Number Of Time Derivatives", 0);
   disc_params->set<bool>("Columnwise Ordering", true);
@@ -114,8 +114,8 @@ TEUCHOS_UNIT_TEST(ExtrudedMesh, Counters)
 
     TEST_EQUALITY (mesh_3d->get_num_local_elements(),mesh_2d->get_num_local_elements()*numLayers);
     TEST_EQUALITY (mesh_3d->get_num_local_nodes(),mesh_2d->get_num_local_nodes()*(numLayers+1));
-    TEST_EQUALITY (mesh_3d->get_max_elem_gid(),mesh_2d->get_max_elem_gid()*numLayers);
-    TEST_EQUALITY (mesh_3d->get_max_node_gid(),mesh_2d->get_max_node_gid()*(numLayers+1));
+    TEST_EQUALITY (mesh_3d->get_max_elem_gid(),(mesh_2d->get_max_elem_gid()+1)*numLayers);
+    TEST_EQUALITY (mesh_3d->get_max_node_gid(),(mesh_2d->get_max_node_gid()+1)*(numLayers+1));
   }
 }
 


### PR DESCRIPTION
This branch does a few things:

- Add interface for an Extruded mesh that does not store full 3d mesh info
- Add interface for an Extruded conn mgr, that uses a basal mesh conn-mgr and layers data to create full 3d connectivity
- Add interface for an Extruded discretization, which relies on the above two

The extruded disc is still lacking some functionalities. E.g., it does not support saving the solution to the mesh or to file (it would likely have to save fields layer-by-layer, as N fields, or as a vector field at each basal DOF, depending on layered mesh ordering). The extruded disc is called "NewExtruded", to differentiate from the current "Extruded", which uses the ExtrudedSTKMeshStruct mesh.

I also found a bug in the STKConnManager::getConnectivityMask, which was creating the wrong mask.

I added a test, where I run the same Heat3D problem with either an Extuded disc or a good old STK3D disc. The test is only run as extruded, but there's a yaml file ready to run as monolithic, for debug purposes.