### PR TITLE
Clean up observer interfaces

### DIFF
--- a/src/Albany_ObserverImpl.hpp
+++ b/src/Albany_ObserverImpl.hpp
@@ -13,25 +13,26 @@
 
 namespace Albany {
 
-class ObserverImpl : public StatelessObserverImpl, public Piro::ROL_ObserverBase<ST> {
+class ObserverImpl : public StatelessObserverImpl,
+                     public Piro::ROL_ObserverBase<ST>
+{
 public:
   explicit ObserverImpl(const Teuchos::RCP<Application>& app);
 
   // Bring in scope the version we don't override
   using StatelessObserverImpl::observeSolution;
 
-  void observeSolution(
-    double stamp, const Thyra_Vector& nonOverlappedSolution,
-    const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp,
-    const Teuchos::Ptr<const Thyra_Vector>& nonOverlappedSolutionDot,
-    const Teuchos::Ptr<const Thyra_Vector>& nonOverlappedSolutionDotDot) override;
+  // Override from ROL_ObserverBase
+  void observeSolution (double stamp, const Thyra_Vector& x,
+                        const Teuchos::Ptr<const Thyra_MultiVector>& x_dxdp,
+                        const Teuchos::Ptr<const Thyra_Vector>& x_dot,
+                        const Teuchos::Ptr<const Thyra_Vector>& x_dotdot) override;
 
-  void observeSolution(
-      double stamp, const Thyra_MultiVector& nonOverlappedSolution, 
-      const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp) override;
+  void observeSolution (double stamp,
+                        const Thyra_MultiVector& x, 
+                        const Teuchos::Ptr<const Thyra_MultiVector>& dxdp) override;
 
-  void parameterChanged(
-      const std::string& param) override;
+  void parameterChanged (const std::string& param) override;
 
   void parametersChanged() override;
   

--- a/src/Albany_PiroObserver.cpp
+++ b/src/Albany_PiroObserver.cpp
@@ -38,334 +38,222 @@ PiroObserver(const Teuchos::RCP<Application> &app,
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution)
-{
-  this->observeSolutionImpl(solution, Teuchos::ScalarTraits<ST>::zero());
-  stepper_counter_++;
-}
-
-void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_MultiVector &solution_dxdp)
-{
-  this->observeSolutionImpl(solution, solution_dxdp, Teuchos::ScalarTraits<ST>::zero());
-  stepper_counter_++;
-}
-
-void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
+observeSolution(const Thyra_Vector& x,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::null, // xdot
+                            Teuchos::null, // xdotdot
+                            Teuchos::null, // dxdp
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_MultiVector &solution_dxdp, 
+observeSolution(const Thyra_Vector &x,
+                const Thyra_MultiVector& dxdp, 
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dxdp, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::null, // xdot
+                            Teuchos::null, // xdotdot
+                            Teuchos::rcpFromRef(dxdp),
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_Vector &solution_dot,
+observeSolution(const Thyra_Vector& x,
+                const Thyra_Vector& x_dot,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dot, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::rcpFromRef(x_dot),
+                            Teuchos::null, // xdotdot
+                            Teuchos::null, // dxdp
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_MultiVector &solution_dxdp,
-                const Thyra_Vector &solution_dot,
+observeSolution(const Thyra_Vector& x,
+                const Thyra_MultiVector& dxdp,
+                const Thyra_Vector& x_dot,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dxdp, solution_dot, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::rcpFromRef(x_dot),
+                            Teuchos::null, // xdotdot
+                            Teuchos::rcpFromRef(dxdp),
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_Vector &solution_dot,
-                const Thyra_Vector &solution_dotdot,
+observeSolution(const Thyra_Vector& x,
+                const Thyra_Vector& x_dot,
+                const Thyra_Vector& x_dotdot,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dot, solution_dotdot, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::rcpFromRef(x_dot),
+                            Teuchos::rcpFromRef(x_dotdot),
+                            Teuchos::null, // dxdp
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_Vector &solution,
-                const Thyra_MultiVector &solution_dxdp,
-                const Thyra_Vector &solution_dot,
-                const Thyra_Vector &solution_dotdot,
+observeSolution(const Thyra_Vector& x,
+                const Thyra_MultiVector& dxdp,
+                const Thyra_Vector& x_dot,
+                const Thyra_Vector& x_dotdot,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dxdp, solution_dot, solution_dotdot, stamp);
-  stepper_counter_++; 
+  this->observeSolutionImpl(Teuchos::rcpFromRef(x),
+                            Teuchos::rcpFromRef(x_dot),
+                            Teuchos::rcpFromRef(x_dotdot),
+                            Teuchos::rcpFromRef(dxdp),
+                            stamp);
 }
 
 void PiroObserver::
-observeSolution(const Thyra_MultiVector &solution,
+observeSolution(const Thyra_MultiVector& x,
                 const ST stamp)
 {
-  this->observeSolutionImpl(solution, stamp);
-  stepper_counter_++; 
+  int x_ncols = x.domain()->dim();
+  if (x_ncols==1) {
+    observeSolutionImpl(x.col(0),Teuchos::null,Teuchos::null,Teuchos::null,stamp);
+  } else if (x_ncols==2) {
+    observeSolutionImpl(x.col(0),x.col(1),Teuchos::null,Teuchos::null,stamp);
+  } else {
+    observeSolutionImpl(x.col(0),x.col(1),x.col(2),Teuchos::null,stamp);
+  }
 }
 
 void PiroObserver::
-observeSolution(const Thyra_MultiVector &solution,
-                const Thyra_MultiVector &solution_dxdp, const ST stamp)
+observeSolution(const Thyra_MultiVector& x,
+                const Thyra_MultiVector& dxdp,
+                const ST stamp)
 {
-  this->observeSolutionImpl(solution, solution_dxdp, stamp);
-  stepper_counter_++; 
+  int x_ncols = x.domain()->dim();
+  if (x_ncols==1) {
+    observeSolutionImpl(x.col(0),Teuchos::null,Teuchos::null,Teuchos::rcpFromRef(dxdp),stamp);
+  } else if (x_ncols==2) {
+    observeSolutionImpl(x.col(0),x.col(1),Teuchos::null,Teuchos::rcpFromRef(dxdp),stamp);
+  } else {
+    observeSolutionImpl(x.col(0),x.col(1),x.col(2),Teuchos::rcpFromRef(dxdp),stamp);
+  }
 }
 
 void PiroObserver::
-parameterChanged(const std::string& param)
-{
-  impl_.parameterChanged(param);
-}
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution,
+observeSolutionImpl(const Teuchos::RCP<const Thyra_Vector>& x,
+                    const Teuchos::RCP<const Thyra_Vector>& x_dot,
+                    const Teuchos::RCP<const Thyra_Vector>& x_dotdot,
+                    const Teuchos::RCP<const Thyra_MultiVector>& dxdp, 
                     const ST defaultStamp)
 {
-  // Determine the stamp associated with the snapshot
-  const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::null, 
-                        Teuchos::null, Teuchos::null);
-  
-  // observe responses 
-  if (observe_responses_ == true) {
-    if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp, Teuchos::rcpFromRef(solution));
-   }
-}
+  stepper_counter_++; 
 
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution, 
-                    const Thyra_MultiVector &solution_dxdp, 
-                    const ST defaultStamp)
-{
   // Determine the stamp associated with the snapshot
   const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::constPtr(solution_dxdp), Teuchos::null, Teuchos::null);
-  
-  // observe responses 
-  if (observe_responses_ == true) {
-    if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp, Teuchos::rcpFromRef(solution));
-   }
-}
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution,
-                    const Thyra_Vector &solution_dot,
-                    const ST defaultStamp)
-{
-  // Determine the stamp associated with the snapshot
-  const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::null, 
-                        Teuchos::constPtr(solution_dot), Teuchos::null);
+  impl_.observeSolution(stamp, *x, dxdp.ptr(), x_dot.ptr(), x_dotdot.ptr());
 
   // observe responses 
   if (observe_responses_ == true) {
     if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp,
-                            Teuchos::rcpFromRef(solution),
-                            Teuchos::rcpFromRef(solution_dot));
+      this->observeResponse(defaultStamp,x,x_dot,x_dotdot);
    }
 }
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution,
-                    const Thyra_MultiVector &solution_dxdp, 
-                    const Thyra_Vector &solution_dot,
-                    const ST defaultStamp)
-{
-  // Determine the stamp associated with the snapshot
-  const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::constPtr(solution_dxdp), Teuchos::constPtr(solution_dot), Teuchos::null);
-
-  // observe responses 
-  if (observe_responses_ == true) {
-    if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp,
-                            Teuchos::rcpFromRef(solution),
-                            Teuchos::rcpFromRef(solution_dot));
-   }
-}
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution,
-                    const Thyra_Vector &solution_dot,
-                    const Thyra_Vector &solution_dotdot,
-                    const ST defaultStamp)
-{
-  // Determine the stamp associated with the snapshot
-  const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::null, Teuchos::constPtr(solution_dot), Teuchos::constPtr(solution_dotdot));
-
-  // observe responses 
-  if (observe_responses_ == true) {
-    if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp,
-                            Teuchos::rcpFromRef(solution),
-                            Teuchos::rcpFromRef(solution_dot), 
-                            Teuchos::rcpFromRef(solution_dotdot));
-   }
-}
-
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_Vector &solution,
-                    const Thyra_MultiVector &solution_dxdp,
-                    const Thyra_Vector &solution_dot,
-                    const Thyra_Vector &solution_dotdot,
-                    const ST defaultStamp)
-{
-  // Determine the stamp associated with the snapshot
-  const ST stamp = impl_.getTimeParamValueOrDefault(defaultStamp);
-  impl_.observeSolution(stamp, solution, Teuchos::constPtr(solution_dxdp), 
-                  Teuchos::constPtr(solution_dot), Teuchos::constPtr(solution_dotdot));
-
-  // observe responses 
-  if (observe_responses_ == true) {
-    if (stepper_counter_ % observe_responses_every_n_steps_ == 0) 
-      this->observeResponse(defaultStamp,
-                            Teuchos::rcpFromRef(solution),
-                            Teuchos::rcpFromRef(solution_dot), 
-                            Teuchos::rcpFromRef(solution_dotdot));
-   }
-} 
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_MultiVector &solution,
-                    const ST defaultStamp)
-{
-  impl_.observeSolution(defaultStamp, solution, Teuchos::null);
-}
-
-void PiroObserver::
-observeSolutionImpl(const Thyra_MultiVector &solution,
-                    const Thyra_MultiVector &solution_dxdp, 
-                    const ST defaultStamp)
-{
-  impl_.observeSolution(defaultStamp, solution, 
-                        Teuchos::constPtr(solution_dxdp));
-}
-
 
 void PiroObserver::
 observeResponse(const ST defaultStamp, 
-                Teuchos::RCP<const Thyra_Vector> solution,
-                Teuchos::RCP<const Thyra_Vector> solution_dot,
-                Teuchos::RCP<const Thyra_Vector> /* solution_dotdot */)
+                Teuchos::RCP<const Thyra_Vector> x,
+                Teuchos::RCP<const Thyra_Vector> x_dot,
+                Teuchos::RCP<const Thyra_Vector> /* x_dotdot */)
 {
-  //IKT 5/10/17: note that this function takes solution_dotdot as an input 
+  //IKT 5/10/17: note that this function takes x_dotdot as an input 
   //argument but does not do anything with it yet.  This can be modified 
   //if desired.
 
-  std::map<int,std::string> m_response_index_to_name;
-  
   // build out args and evaluate responses if they exist
-  Thyra::ModelEvaluatorBase::OutArgs<double> outArgs = model_->createOutArgs();
-  if(outArgs.Ng()>0) {
-    // build the in arguments
-    Thyra::ModelEvaluatorBase::InArgs<double> nominal_values = model_->getNominalValues();
-    Thyra::ModelEvaluatorBase::InArgs<double> inArgs = model_->createInArgs();
-    inArgs.setArgs(nominal_values); 
-    inArgs.set_x(solution);
-    if(inArgs.supports(Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
-      inArgs.set_x_dot(solution_dot);
-    if (inArgs.supports(Thyra::ModelEvaluatorBase::IN_ARG_t)) { 
-      const ST time = impl_.getTimeParamValueOrDefault(defaultStamp);
-      inArgs.set_t(time);
-      *out << "Time = " << time << "\n";  
-    }
-  
-    // set up the output arguments, in this case only the responses
-    for(int i=0;i<outArgs.Ng();i++)
-      outArgs.set_g(i,Thyra::createMember(*model_->get_g_space(i)));
-
-    // Solve the model
-    model_->evalModel(inArgs, outArgs);
-  
-    std::size_t precision = 8;
-    std::size_t value_width = precision + 7;
-    *out << std::scientific << std::showpoint << std::setprecision(precision) << std::left;
-
-
-    // Note that we don't have g_names support in thyra yet.  Once
-    // this is added, we can print response names as well.
-
-    //OG It seems that outArgs.Ng() always returns 1, so, there is 1 response vector only, Response[0].
-    //This response vector contains different responses (min, max, norms) and it would be good
-    //to have functionality to obtain relative responses only for some values. But it would require more
-    //parameters in param list. Alternatively, one can rewrite the code below to use is_relative
-    //as an array of markers for relative responses for Response[0] only. This is not the case
-    //right now and if in the param list "Relative Responses"="{0}", the code below will compute
-    //relative values for all terms in vector Response[0].
-    if((!firstResponseObtained) && calculateRelativeResponses ){
-	  storedResponses.resize(outArgs.Ng());
-	  is_relative.resize(outArgs.Ng(), false);
-    }
-
-    for(int i=0;i<outArgs.Ng();i++) {
-      std::stringstream ss;
-      std::map<int,std::string>::const_iterator itr = m_response_index_to_name.find(i);
-      if(itr!=m_response_index_to_name.end())
-        ss << "         Response \"" << itr->second << "\" = ";
-      else
-        ss << "         Response[" << i << "] = ";
-
-      //ss << "relative resp size? " << relative_responses.size() << "\n";
-      //ss << "relative resp values? " << relative_responses << "\n";
-
-      Teuchos::RCP<Thyra::VectorBase<double> > g = outArgs.get_g(i);
-      *out << ss.str(); // "   Response[" << i << "] = ";
-      for(Thyra::Ordinal k=0;k<g->space()->dim();k++)
-        *out << std::setw(value_width) << Thyra::get_ele(*g,k) << " ";
-      *out << std::endl;
-
-      if(firstResponseObtained && calculateRelativeResponses )
-      if(is_relative[i]){
-    	  *out << "\n";
-	      *out << "Relative Response[" << i << "] = ";
-          for( size_t j = 0; j < storedResponses[i].size(); j++){
-        	  double prevresp = storedResponses[i][j];
-        	  if( std::abs(prevresp) > tol ){
-        		  *out << std::setw(value_width) << (Thyra::get_ele(*g,j) - prevresp)/prevresp << " ";
-        	  }else{
-        		  *out << " N/A(int. value 0) ";
-        	  }
-          }
-    	  *out << "\n";
-      }
-
-      if( (!firstResponseObtained) && calculateRelativeResponses ){
-    	  for(int j = 0; j < relative_responses.size(); j++){
-    		  int resp_index = relative_responses[j];
-    		  if( (resp_index < outArgs.Ng()) )
-    			  is_relative[resp_index] = true;
-    	  }
-
-      }
-      //Save first responses for relative changes in st
-      if( (!firstResponseObtained) && calculateRelativeResponses ){
-      	  int gsize = g->space()->dim();
-      	  storedResponses[i].resize(gsize);
-      	  for (int j = 0; j < gsize; j++)
-      		  storedResponses[i][j] = Thyra::get_ele(*g,j);
-      }//end if !firstRessponseObtained
-    }//end of loop over outArgs.Ng()
-    firstResponseObtained = true;
+  auto outArgs = model_->createOutArgs();
+  if (outArgs.Ng()==0) {
+    return;
   }
+  // build the in arguments
+  auto nominal_values = model_->getNominalValues();
+  auto inArgs = model_->createInArgs();
+  inArgs.setArgs(nominal_values); 
+  inArgs.set_x(x);
+  if (inArgs.supports(Thyra::ModelEvaluatorBase::IN_ARG_x_dot))
+    inArgs.set_x_dot(x_dot);
+  if (inArgs.supports(Thyra::ModelEvaluatorBase::IN_ARG_t)) { 
+    const ST time = impl_.getTimeParamValueOrDefault(defaultStamp);
+    inArgs.set_t(time);
+    *out << "Time = " << time << "\n";  
+  }
+
+  // set up the output arguments, in this case only the responses
+  for(int i=0;i<outArgs.Ng();i++)
+    outArgs.set_g(i,Thyra::createMember(*model_->get_g_space(i)));
+
+  // Solve the model
+  model_->evalModel(inArgs, outArgs);
+
+  std::size_t precision = 8;
+  std::size_t value_width = precision + 7;
+  *out << std::scientific << std::showpoint << std::setprecision(precision) << std::left;
+
+  // Note that we don't have g_names support in thyra yet.  Once
+  // this is added, we can print response names as well.
+
+  //OG It seems that outArgs.Ng() always returns 1, so, there is 1 response vector only, Response[0].
+  //This response vector contains different responses (min, max, norms) and it would be good
+  //to have functionality to obtain relative responses only for some values. But it would require more
+  //parameters in param list. Alternatively, one can rewrite the code below to use is_relative
+  //as an array of markers for relative responses for Response[0] only. This is not the case
+  //right now and if in the param list "Relative Responses"="{0}", the code below will compute
+  //relative values for all terms in vector Response[0].
+  if((!firstResponseObtained) && calculateRelativeResponses ){
+    storedResponses.resize(outArgs.Ng());
+    is_relative.resize(outArgs.Ng(), false);
+  }
+
+  for (int i=0; i<outArgs.Ng(); ++i) {
+    *out << "         Response[" << i << "] = ";
+
+    auto g = outArgs.get_g(i);
+    for (Thyra::Ordinal k=0;k<g->space()->dim();k++)
+      *out << std::setw(value_width) << Thyra::get_ele(*g,k) << " ";
+    *out << std::endl;
+
+    if (firstResponseObtained and calculateRelativeResponses and is_relative[i]) {
+      *out << "\n";
+      *out << "Relative Response[" << i << "] = ";
+        for( size_t j = 0; j < storedResponses[i].size(); j++){
+          double prevresp = storedResponses[i][j];
+          if( std::abs(prevresp) > tol ){
+            *out << std::setw(value_width) << (Thyra::get_ele(*g,j) - prevresp)/prevresp << " ";
+          }else{
+            *out << " N/A(int. value 0) ";
+          }
+        }
+      *out << "\n";
+    }
+
+    if (not firstResponseObtained and calculateRelativeResponses) {
+      for(int j = 0; j < relative_responses.size(); j++){
+        int resp_index = relative_responses[j];
+        if( (resp_index < outArgs.Ng()) )
+          is_relative[resp_index] = true;
+      }
+    }
+
+    //Save first responses for relative changes in st
+    if (not firstResponseObtained and calculateRelativeResponses) {
+      int gsize = g->space()->dim();
+      storedResponses[i].resize(gsize);
+      for (int j = 0; j < gsize; j++)
+        storedResponses[i][j] = Thyra::get_ele(*g,j);
+    }
+  }
+  firstResponseObtained = true;
 }
 
 } // namespace Albany

--- a/src/Albany_PiroObserver.hpp
+++ b/src/Albany_PiroObserver.hpp
@@ -24,121 +24,76 @@ public:
   explicit PiroObserver(const Teuchos::RCP<Albany::Application> &app, 
                          Teuchos::RCP<const Thyra_ModelEvaluator> model = Teuchos::null);
 
-  virtual void observeSolution(
-      const Thyra_Vector& solution);
+  void observeSolution (const Thyra_Vector& x)
+  {
+    observeSolution(x,zero());
+  }
 
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp);
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_MultiVector& dxdp)
+  {
+    observeSolution(x,dxdp);
+  }
 
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const ST stamp);
-  
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const ST stamp);
+  void observeSolution (const Thyra_Vector& x,
+                        const ST stamp);
+                    
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_MultiVector& dxdp,
+                        const ST stamp);
 
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_Vector& solution_dot,
-      const ST stamp);
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_Vector& x_dot,
+                        const ST stamp);
   
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const ST stamp);
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_MultiVector& dxdp,
+                        const Thyra_Vector& x_dot,
+                        const ST stamp);
   
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const ST stamp);
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_Vector& x_dot,
+                        const Thyra_Vector& x_dotdot,
+                        const ST stamp);
 
-  virtual void observeSolution(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const ST stamp);
+  void observeSolution (const Thyra_Vector& x,
+                        const Thyra_MultiVector& dxdp,
+                        const Thyra_Vector& x_dot,
+                        const Thyra_Vector& x_dotdot,
+                        const ST stamp);
   
-  virtual void observeSolution(
-      const Thyra_MultiVector& solution,
-      const ST stamp);
+  void observeSolution (const Thyra_MultiVector& solution,
+                        const ST stamp);
   
-  virtual void observeSolution(
-      const Thyra_MultiVector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const ST stamp);
+  void observeSolution (const Thyra_MultiVector& solution,
+                        const Thyra_MultiVector& solution_dxdp,
+                        const ST stamp);
 
-  virtual void parameterChanged(
-      const std::string& param);
+  void parameterChanged (const std::string& param) { impl_.parameterChanged(param); }
 
 private:
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const ST defaultStamp);
 
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const ST defaultStamp);
-
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const Thyra_Vector& solution_dot,
-      const ST defaultStamp);
-  
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const ST defaultStamp);
-  
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const ST defaultStamp);
-
-  void observeSolutionImpl(
-      const Thyra_Vector& solution,
-      const Thyra_MultiVector& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const ST defaultStamp);
-
-  void observeSolutionImpl(
-      const Thyra_MultiVector &solution,
-      const ST defaultStamp);
-
-  void observeSolutionImpl(
-      const Thyra_MultiVector &solution,
-      const Thyra_MultiVector &solution_dxdp,
-      const ST defaultStamp);
-
-  void observeTpetraSolutionImpl(
-      const Tpetra_Vector &solution,
-      Teuchos::Ptr<const Tpetra_Vector> solution_dot,
-      Teuchos::Ptr<const Tpetra_Vector> solution_dotdot,
-      const ST defaultStamp);
+  void observeSolutionImpl (const Teuchos::RCP<const Thyra_Vector>& x,
+                            const Teuchos::RCP<const Thyra_Vector>& x_dot,
+                            const Teuchos::RCP<const Thyra_Vector>& x_dotdot,
+                            const Teuchos::RCP<const Thyra_MultiVector>& dxdp,
+                            const ST defaultStamp);
   
   // The following function is for calculating / printing responses every step.
   // It is currently not implemented for the case of an Teuchos::RCP<const Thyra_MultiVector>
   // argument; this may be desired at some point in the future. 
-  void observeResponse(
-      const ST defaultStamp,  
-      Teuchos::RCP<const Thyra_Vector> solution,
-      Teuchos::RCP<const Thyra_Vector> solution_dot = Teuchos::null, 
-      Teuchos::RCP<const Thyra_Vector> solution_dotdot = Teuchos::null); 
+  void observeResponse(const ST defaultStamp,  
+                       Teuchos::RCP<const Thyra_Vector> x,
+                       Teuchos::RCP<const Thyra_Vector> x_dot,
+                       Teuchos::RCP<const Thyra_Vector> x_dotdot);
 
   ObserverImpl impl_;
 
   Teuchos::RCP<const Thyra_ModelEvaluator> model_; 
 
 protected: 
+
+  static ST zero () { return Teuchos::ScalarTraits<ST>::zero(); }
 
   bool observe_responses_;  
   

--- a/src/Albany_SolverFactory.cpp
+++ b/src/Albany_SolverFactory.cpp
@@ -155,9 +155,8 @@ SolverFactory::createModel (const Teuchos::RCP<Application>& app,
 
 Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<ST>>
 SolverFactory::
-createSolver (const Teuchos::RCP<const Teuchos_Comm>& solverComm,
-	      const Teuchos::RCP<ModelEvaluator>&     model_tmp,
-	      const Teuchos::RCP<ModelEvaluator>&     adjointModel_tmp,
+createSolver (const Teuchos::RCP<ModelEvaluator>&     model_tmp,
+              const Teuchos::RCP<ModelEvaluator>&     adjointModel_tmp,
               const bool                              forwardMode)
 {
   const auto piroParams = Teuchos::sublist(m_appParams, "Piro");
@@ -254,24 +253,13 @@ createSolver (const Teuchos::RCP<const Teuchos_Comm>& solverComm,
     }
   }
 
-  const auto app    = model_tmp->getAlbanyApp();
-  const auto solMgr = app->getAdaptSolMgr();
+  const auto app = model_tmp->getAlbanyApp();
+
+  auto observer = Teuchos::rcp(new PiroObserver(app, modelWithSolve));
 
   Piro::SolverFactory piroFactory;
-  m_observer = Teuchos::rcp(new PiroObserver(app, modelWithSolve));
-
   return piroFactory.createSolver<ST>(
-       piroParams, modelWithSolve, adjointModelWithSolve, m_observer);
-  TEUCHOS_TEST_FOR_EXCEPTION(
-      true,
-      std::logic_error,
-      "Reached end of createModel()"
-          << "\n");
-
-  // Silence compiler warning in case it wasn't used (due to ifdef logic)
-  (void) solverComm;
-
-  return Teuchos::null;
+       piroParams, modelWithSolve, adjointModelWithSolve, observer);
 }
 
 void SolverFactory::

--- a/src/Albany_SolverFactory.hpp
+++ b/src/Albany_SolverFactory.hpp
@@ -50,9 +50,8 @@ public:
 	       const bool adjoint_model = false);
 
   Teuchos::RCP<Thyra::ResponseOnlyModelEvaluatorBase<ST>>
-  createSolver (const Teuchos::RCP<const Teuchos_Comm>&    solverComm, 
-                const Teuchos::RCP<ModelEvaluator>&  model,
-		const Teuchos::RCP<ModelEvaluator>&  adjointModel,
+  createSolver (const Teuchos::RCP<ModelEvaluator>&  model,
+                const Teuchos::RCP<ModelEvaluator>&  adjointModel,
                 const bool forwardMode); 
 
   Teuchos::ParameterList&
@@ -66,12 +65,6 @@ public:
   {
     return m_appParams;
   }
-
-  Teuchos::RCP<Piro::ObserverBase<double>>
-  returnObserver() const
-  {
-    return m_observer;
-  };
 
   // Functions to generate reference parameter lists for validation
   //  EGN 9/2013: made these three functions public, as they pertain to valid
@@ -91,8 +84,6 @@ protected:
               const Teuchos::RCP<const Teuchos_Comm>&     comm);
 
   void setSolverParamDefaults(Teuchos::ParameterList* appParams, int myRank);
-
-  Teuchos::RCP<Piro::ObserverBase<double>>  m_observer;
 
   //! Parameter list specifying what solver to create
   Teuchos::RCP<Teuchos::ParameterList>      m_appParams;

--- a/src/Albany_StatelessObserverImpl.hpp
+++ b/src/Albany_StatelessObserverImpl.hpp
@@ -27,25 +27,11 @@ public:
 
   RealType getTimeParamValueOrDefault(RealType defaultValue) const;
 
-  Teuchos::RCP<const Thyra_VectorSpace> getNonOverlappedVectorSpace() const;
-
-  virtual void observeSolution (
-    double stamp,
-    const Thyra_Vector& nonOverlappedSolution,
-    const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp,
-    const Teuchos::Ptr<const Thyra_Vector>& nonOverlappedSolutionDot,
-    const Teuchos::Ptr<const Thyra_Vector>& nonOverlappedSolutionDotDot);
-
-  virtual void observeSolution (
-    double stamp,
-    const Thyra_Vector& nonOverlappedSolution,
-    const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp,
-    const Teuchos::Ptr<const Thyra_Vector>& nonOverlappedSolutionDot);
-
-  virtual void observeSolution (
-    double stamp,
-    const Thyra_MultiVector& nonOverlappedSolution,
-    const Teuchos::Ptr<const Thyra_MultiVector>& nonOverlappedSolution_dxdp);
+  void observeSolution (double stamp,
+                        const Teuchos::RCP<const Thyra_Vector>& x,
+                        const Teuchos::RCP<const Thyra_Vector>& x_dot,
+                        const Teuchos::RCP<const Thyra_Vector>& x_dotdot,
+                        const Teuchos::RCP<const Thyra_MultiVector>& x_dxdp);
 
 protected:
   Teuchos::RCP<Application> app_;

--- a/src/Main_Analysis.cpp
+++ b/src/Main_Analysis.cpp
@@ -81,7 +81,7 @@ int main(int argc, char *argv[]) {
                                    && slvrfctry.getParameters()->sublist("Piro").sublist("Analysis").get<bool>("Transient");
 
     const auto albanyAdjointModel = explicitMatrixTranspose || transientAnalysis ? slvrfctry.createModel(albanyApp, true) : Teuchos::null; 
-    const auto solver      = slvrfctry.createSolver(comm, albanyModel, albanyAdjointModel, false);
+    const auto solver      = slvrfctry.createSolver(albanyModel, albanyAdjointModel, false);
 
     stackedTimer->stop("Albany: Setup Time");
 

--- a/src/Main_Solve.cpp
+++ b/src/Main_Solve.cpp
@@ -139,7 +139,7 @@ int main(int argc, char *argv[])
     // Explicit adjoint model is not needed if we are not computing adjoint sensitivities
     const bool explicitAdjointModel = albanyApp->isAdjointSensitivities() && explicitMatrixTranspose;
     const auto albanyAdjointModel = explicitAdjointModel ? slvrfctry.createModel(albanyApp, true) : Teuchos::null; 
-    const auto solver = slvrfctry.createSolver(comm, albanyModel, albanyAdjointModel, true);
+    const auto solver = slvrfctry.createSolver(albanyModel, albanyAdjointModel, true);
 
     stackedTimer->stop("Albany: Setup Time");
 

--- a/src/landIce/interfaceWithMPAS/Interface.cpp
+++ b/src/landIce/interfaceWithMPAS/Interface.cpp
@@ -315,7 +315,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
   Teuchos::ArrayRCP<const ST> solution_constView;
   try {
     auto model = slvrfctry->createModel(albanyApp);
-    solver = slvrfctry->createSolver(mpiComm, model, Teuchos::null, true);
+    solver = slvrfctry->createSolver(model, Teuchos::null, true);
 
     Teuchos::ParameterList solveParams;
     solveParams.set("Compute Sensitivities", false);


### PR DESCRIPTION
Observers have lots of interfaces, depending on how they are called (e.g., with/without xdot/xdotdot, with Vector's vs a MultiVector, etc). Rather than having lots of XYZimpl functions, try to make all the interfaces call a single impl function. This makes modifications of actual implementation easier, since we only have to mod one fcn.

As a side note: I think I would remove all the MultiVector interfaces in the discretization: as I did in one of the observers, the interface that takes a MultiVector (consisting of x, possibly xdot, possibly xdotdot) can simply extract the MV columns, and call the proper interface with Vector's. This would reduce the amount of interfaces we need to implement in our classes. But that's just a wishlist thought.