### PR TITLE
omegah: set the kokkos install dir

### DIFF
--- a/cmake/GetOrInstallOmegah.cmake
+++ b/cmake/GetOrInstallOmegah.cmake
@@ -50,6 +50,8 @@ else ()
   )
 
   # Set options for Omega_h before adding the subdirectory
+  get_target_property(Kokkos_INCLUDE_DIR Kokkos::kokkos INTERFACE_INCLUDE_DIRECTORIES)
+  string(REPLACE "include/kokkos" "" Kokkos_INSTALL_DIR ${Kokkos_INCLUDE_DIR})
   set(Kokkos_PREFIX ${Kokkos_INSTALL_DIR} PATH "Path to Kokkos install")
 
   option (Omega_h_USE_Kokkos "Use Kokkos as a backend" ON)


### PR DESCRIPTION
Kokkos_INSTALL_DIR was being set by the Kokkos Tribits build system which is no longer supported: https://github.com/kokkos/kokkos/pull/6164.

This is an attempt to fix the omega_h configure errors discussed in https://github.com/sandialabs/Albany/issues/1092.

I'm not thrilled with the string manipulation part, but there surprisingly wasn't a cmake property for the `Kokkos::kokkos` target that directly provided the install path.  Unfortunately, the [`LOCATION` property](https://cmake.org/cmake/help/latest/prop_tgt/LOCATION.html) isn't defined by Kokkos.

Thanks to @jewatkins for the help debugging.