### PR TITLE
Fix nightly GPU failures after kokkos 4.5.0

### DIFF
--- a/src/PHAL_Utilities_Def.hpp
+++ b/src/PHAL_Utilities_Def.hpp
@@ -260,35 +260,4 @@ void scale (ArrayT& a, const T& val) {
   loop(sl, a);
 }
 
-template< class T , class ... P >
-inline
-typename std::enable_if<
-  !Kokkos::is_dynrankview_fad<Kokkos::DynRankView<T,P...>>::value,
-  typename Kokkos::DynRankView<T,P...>::non_const_type >::type
-create_copy( const std::string& name,
-    const Kokkos::DynRankView<T,P...> & src )
-{
-  using dst_type = typename Kokkos::DynRankView<T,P...>::non_const_type;
-  auto layout = Kokkos::Impl::reconstructLayout(src.layout(), src.rank());
-  return dst_type( name , layout );
-}
-
-template< class T , class ... P >
-inline
-typename std::enable_if<
-  Kokkos::is_dynrankview_fad<Kokkos::DynRankView<T,P...>>::value,
-  typename Kokkos::DynRankView<T,P...>::non_const_type >::type
-create_copy( const std::string& /* name */,
-    const Kokkos::DynRankView<T,P...> & src )
-{
-  using Dst = typename Kokkos::DynRankView<T,P...>::non_const_type;
-  auto sm = src.impl_map();
-  auto sl = sm.layout();
-  auto fad_rank = src.rank();
-  sl.dimension[fad_rank] = sm.dimension_scalar();
-  auto real_rank = fad_rank + 1;
-  auto ml = Kokkos::Impl::reconstructLayout(sl, real_rank);
-  return Dst ( src.label(), ml );
-}
-
 } // namespace PHAL

--- a/src/corePDEs/evaluators/PHAL_HeatEqResid.hpp
+++ b/src/corePDEs/evaluators/PHAL_HeatEqResid.hpp
@@ -60,6 +60,7 @@ private:
   bool haverhoCp;
   unsigned int numQPs, numDims, numNodes, worksetSize;
   Kokkos::DynRankView<ScalarT, PHX::Device> flux;
+  Kokkos::DynRankView<ScalarT, PHX::Device> neg_source;
   Kokkos::DynRankView<ScalarT, PHX::Device> aterm;
   Kokkos::DynRankView<ScalarT, PHX::Device> convection;
 };

--- a/src/corePDEs/evaluators/PHAL_HeatEqResid_Def.hpp
+++ b/src/corePDEs/evaluators/PHAL_HeatEqResid_Def.hpp
@@ -107,9 +107,10 @@ postRegistrationSetup(typename Traits::SetupData /* d */,
   this->utils.setFieldData(TResidual,fm);
 
   // Allocate workspace
-  flux = Kokkos::createDynRankView(Temperature.get_view(), "XXX", worksetSize, numQPs, numDims);
-  if (haveAbsorption) aterm = Kokkos::createDynRankView(Temperature.get_view(), "XXX", worksetSize, numQPs);
-  if (haveConvection) convection = Kokkos::createDynRankView(Temperature.get_view(), "XXX", worksetSize, numQPs);
+  flux = Kokkos::createDynRankView(Temperature.get_view(), "flux", worksetSize, numQPs, numDims);
+  if (haveSource) neg_source = Kokkos::createDynRankView(Temperature.get_view(), "neg_source", worksetSize, numQPs);
+  if (haveAbsorption) aterm = Kokkos::createDynRankView(Temperature.get_view(), "aterm", worksetSize, numQPs);
+  if (haveConvection) convection = Kokkos::createDynRankView(Temperature.get_view(), "convection", worksetSize, numQPs);
 }
 
 //**********************************************************************
@@ -124,8 +125,6 @@ evaluateFields(typename Traits::EvalData workset)
   FST::integrate(TResidual.get_view(), flux, wGradBF.get_view(), false); // "false" overwrites
 
   if (haveSource) {
-    auto neg_source = PHAL::create_copy("neg_source", Source.get_view());
-
     for (size_t i =0; i< Source.extent(0); i++)
      for (size_t j =0; j< Source.extent(1); j++)
        neg_source(i,j) = Source(i,j) * -1.0;

--- a/src/demoPDEs/evaluators/PHAL_HelmholtzResid.hpp
+++ b/src/demoPDEs/evaluators/PHAL_HelmholtzResid.hpp
@@ -54,7 +54,10 @@ private:
 
   bool haveSource;
 
+  unsigned int worksetSize, numQPs;
   ScalarT ksqr;
+  Kokkos::DynRankView<ScalarT, PHX::Device> U_ksqr;
+  Kokkos::DynRankView<ScalarT, PHX::Device> V_ksqr;
 
   // Output:
   PHX::MDField<ScalarT,Cell,Node> UResidual;

--- a/src/demoPDEs/evaluators/PHAL_PoissonResid.hpp
+++ b/src/demoPDEs/evaluators/PHAL_PoissonResid.hpp
@@ -44,6 +44,8 @@ private:
   PHX::MDField<const ScalarT> Source;
 
   bool haveSource;
+  unsigned int worksetSize, numQPs;
+  Kokkos::DynRankView<ScalarT, PHX::Device> neg_source;
 
   // Output:
   PHX::MDField<ScalarT> PhiResidual;

--- a/tests/demoPDEs/CMakeLists.txt
+++ b/tests/demoPDEs/CMakeLists.txt
@@ -4,6 +4,7 @@
 ##    in the file "license.txt" in the top-level Albany directory  //
 ##*****************************************************************//
 
+  add_subdirectory(Helmholtz2D)
   add_subdirectory(AdvDiff)
   add_subdirectory(ReactDiffSystem)
   add_subdirectory(ODE)


### PR DESCRIPTION
 - remove create_copy() and create temp workspace
 - add Helmholtz back in

This fixes #1097. The residual was fine but the Jacobian was zero. I had to backtrack to this routine: https://github.com/sandialabs/Albany/compare/jewatkins/fix-cudauvm-build?expand=1#diff-b8f4f1c28bdb086398fa7e2b2af2ff512bc8dc3df7c5af97e4979760004e8fdeL132
where derivative components were not being computed properly. `create_copy()` is not really needed and looks a bit hacky (also it's not tested and probably not worth fixing). It seems easier to just allocate some memory for these temp fields.

Also, it looks like Helmholtz2D was removed, so I added that back in. I traced the removal back to https://github.com/sandialabs/Albany/commit/cbca81477c480d706aa0111fbdecbfb5cff8d137 based on this issue: https://github.com/sandialabs/Albany/issues/840 and this wiki doc: https://acme-climate.atlassian.net/wiki/spaces/FAN/pages/3539469051/Albany+tests+and+problems+re-organization
which says we want to keep it around.