### PR TITLE
Fix MALI interface gpu

### DIFF
--- a/src/landIce/interfaceWithMPAS/Interface.cpp
+++ b/src/landIce/interfaceWithMPAS/Interface.cpp
@@ -255,6 +255,7 @@ void velocity_solver_solve_fo(int nLayers, int globalVerticesStride,
       //Compute mesh layers associated to quad points
       std::vector<int> layerVec(numQPs);
       auto quadPointCoordsHost = Kokkos::create_mirror_view(quadPointCoords);
+      Kokkos::deep_copy(quadPointCoordsHost, quadPointCoords);
       for(int qp=0; qp<numQPs; qp++) {
         int il=0; 
         auto z = (quadPointCoordsHost(qp,2)+1.0)/2; //quad points are defined on [-1,1]


### PR DESCRIPTION
forgot the deep copy. Thanks @mperego for catching this!

BTW, it looks like this case (https://github.com/sandialabs/ali-perf-tests/tree/master/perf_tests/mali-ais8km) still fails to converge with the gpu solver (even with a serial build). But it is converging slower on gpu (final residual after 50 iterations, gpu: `6.167e-01` vs. cpu:`1.874e-01`). I'm on the queue with this change. We'll see if it reproduces the cpu results at least.