### PR TITLE
Fix scatter of volume eqn in presence of side eqn

### DIFF
--- a/src/corePDEs/problems/Albany_SideLaplacianProblem.hpp
+++ b/src/corePDEs/problems/Albany_SideLaplacianProblem.hpp
@@ -263,15 +263,7 @@ SideLaplacian::constructEvaluators3D (PHX::FieldManager<PHAL::AlbanyTraits>& fm0
   ev = evalUtils.constructScatterSideEqnResidualEvaluator(sideSetName, false, resid_names[1], offsetU, "Scatter SideLaplacian");
   fm0.template registerEvaluator<EvalT> (ev);
 
-  // We need to build this by hand, since we have to pass the volume eqn indices
-  p = Teuchos::rcp(new Teuchos::ParameterList("Dummy Residual"));
-  p->set<int>("Tensor Rank", 0);
-  p->set<std::string>("Residual Name", resid_names[0]);
-  p->set<int>("Offset of First DOF", 0);
-  p->set<std::string>("Scatter Field Name", "Scatter Dummy");
-  p->set<Teuchos::Array<int>>("Volume Equations",Teuchos::Array<int>(1,0));
-
-  ev = Teuchos::rcp(new PHAL::ScatterResidual<EvalT,PHAL::AlbanyTraits>(*p,dl));
+  ev = evalUtils.constructScatterResidualEvaluator(false, resid_names[0], 0, "Scatter Dummy");
   fm0.template registerEvaluator<EvalT> (ev);
 
   ev = evalUtils.constructMapToPhysicalFrameEvaluator(cellType, cellCubature);

--- a/src/evaluators/scatter/PHAL_ScatterResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterResidual.hpp
@@ -207,10 +207,6 @@ protected:
   using Base::m_fields_offsets;
 
   static constexpr bool is_atomic = KU::NeedsAtomic<PHX::Device::execution_space>::value;
-
-  Albany::DualView<int*> m_volume_eqns;
-  Albany::DualView<int*> m_volume_eqns_offsets;
-  Albany::DualView<int*> m_lids;
 };
 
 // **************************************************************

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual.hpp
@@ -87,10 +87,8 @@ protected:
 
   int tensorRank;
 
-  // We store the ss_nodes for all worksets, so we can zero residual
-  // and diagonalize jacobian OUTSIDE the side set
-  std::set<GO> ss_nodes_gids;
-  bool ss_nodes_gids_gathered = false;
+  std::vector<std::set<LO>> ss_eqns_dofs_lids;  // All lids of the ss eqn dofs, grouped by ws
+  bool ss_eqns_dofs_lids_gathered = false;
 };
 
 template<typename EvalT, typename Traits> class ScatterSideEqnResidual;

--- a/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
+++ b/src/evaluators/scatter/PHAL_ScatterSideEqnResidual_Def.hpp
@@ -103,7 +103,7 @@ void ScatterSideEqnResidualBase<EvalT, Traits>::
 gatherSideSetNodeGIDs (const Albany::AbstractDiscretization& disc)
 {
   // Check for early return
-  if (ss_nodes_gids_gathered) {
+  if (ss_eqns_dofs_lids_gathered) {
     return;
   }
 
@@ -135,7 +135,11 @@ gatherSideSetNodeGIDs (const Albany::AbstractDiscretization& disc)
   //       sideset (in the owned+shared map), then it also has a side containing
   //       that node on that sideset.
   const int num_ws = disc.getNumWorksets();
-  const auto node_dof_mgr = disc.getNodeDOFManager();
+  const auto dof_mgr = disc.getDOFManager();
+  const auto elem_dof_lids = dof_mgr->elem_dof_lids().host();
+  constexpr auto ALL = Kokkos::ALL();
+
+  std::set<LO> all_ss_eqns_lids;
   for (int ws=0; ws<num_ws; ++ws) {
     const auto& ssMap = disc.getSideSets(ws);
     if (ssMap.find(this->sideSetName)==ssMap.end()) {
@@ -148,16 +152,42 @@ gatherSideSetNodeGIDs (const Albany::AbstractDiscretization& disc)
       const int elem_LID = elem_lids(icell);
       const int side_pos = side.side_pos;
 
-      const auto& offsets = node_dof_mgr->getGIDFieldOffsetsSide(0,side_pos);
-      const auto& gids = node_dof_mgr->getElementGIDs(elem_LID);
-      for (auto o : offsets) {
-        ss_nodes_gids.insert(gids[o]);
+      const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
+      auto& gids = dof_mgr->getElementGIDs(elem_LID);
+      for (int eq = 0; eq < this->numFields; eq++) {
+        const auto& offsets = dof_mgr->getGIDFieldOffsetsSide(eq+this->offset,side_pos);
+        for (auto o : offsets) {
+          all_ss_eqns_lids.insert(dof_lids[o]);
+        }
+      }
+    }
+  }
+
+  // To speed up calculation at runtime, we now group them by ws
+  ss_eqns_dofs_lids.resize(num_ws);
+  if (num_ws==1) {
+    // All ss eqn dofs are in same ws, just copy and be done
+    ss_eqns_dofs_lids[0] = all_ss_eqns_lids;
+  } else {
+    for (int ws=0; ws<num_ws; ++ws) {
+      const auto& elem_lids = disc.getElementLIDs_host(ws);
+      for (size_t ie=0; ie<elem_lids.size(); ++ie) {
+        const int elem_LID = elem_lids(ie);
+        const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
+        for (int eq = 0; eq < this->numFields; eq++) {
+          const auto& offsets = dof_mgr->getGIDFieldOffsets(eq+this->offset);
+          for (auto o : offsets) {
+            if (all_ss_eqns_lids.count(dof_lids[o]>0)) {
+              ss_eqns_dofs_lids[ws].insert(dof_lids[0]);
+            }
+          }
+        }
       }
     }
   }
 
   // Avoid doing this again
-  ss_nodes_gids_gathered = true;
+  ss_eqns_dofs_lids_gathered = true;
 }
 
 template<typename EvalT, typename Traits>
@@ -168,7 +198,9 @@ evaluateFields(typename Traits::EvalData workset)
 
   if (workset.sideSets->find(this->sideSetName)!=workset.sideSets->end()) {
     sideSet = workset.sideSets->at(this->sideSetName);
-    doEvaluateFields(workset,sideSet);
+    if (sideSet.size()>0) {
+      doEvaluateFields(workset,sideSet);
+    }
   }
 
   // We might need to do something for dofs not on this side set
@@ -185,27 +217,24 @@ doPostEvaluate(typename Traits::EvalData workset)
   }
   const auto f_data = Albany::getNonconstLocalData(f);
 
-  // Set f=x outside the sideset
   Teuchos::RCP<Thyra_Vector const> x = workset.x;
   Teuchos::ArrayRCP<const ST> x_data = Albany::getLocalData(x);
 
   constexpr auto ALL = Kokkos::ALL();
-  const auto node_dof_mgr = workset.disc->getNodeDOFManager();
   const auto dof_mgr = workset.disc->getDOFManager();
   const auto elem_lids = workset.disc->getElementLIDs_host(workset.wsIndex);
   const auto elem_dof_lids = dof_mgr->elem_dof_lids().host();
 
-  const int numCellNodes = node_dof_mgr->getGIDFieldOffsets(0).size();
   for (size_t icell=0; icell<workset.numCells; ++icell) {
     const auto elem_LID = elem_lids(icell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
-    const auto& node_gids = node_dof_mgr->getElementGIDs(elem_LID);
-    for (int inode=0; inode<numCellNodes; ++inode) {
-      const auto node = node_gids[inode];
-      if (this->ss_nodes_gids.count(node)==0) {
-        for (int eq = 0; eq < this->numFields; eq++) {
-          const auto& offsets = dof_mgr->getGIDFieldOffsets(eq+this->offset);
-          const int lid = dof_lids(offsets[inode]);
+
+    for (int eq = 0; eq < numFields; eq++) {
+      const auto& offsets = dof_mgr->getGIDFieldOffsets(eq+offset);
+      for (auto o : offsets) {
+        auto lid = dof_lids[o];
+        if (ss_eqns_dofs_lids[workset.wsIndex].count(lid)==0) {
+          // Set f=x outside the sideset, so we converge in 1 newton iteration
           f_data[lid] = x_data[lid];
         }
       }
@@ -293,19 +322,26 @@ doPostEvaluate(typename Traits::EvalData workset)
   // Set J=identity outside of the sideset, so it's not singular
   auto Jac = workset.Jac;
   const int numCellNodes = node_dof_mgr->getGIDFieldOffsets(0).size();
+  const auto& ss_eqn_lids = this->ss_eqns_dofs_lids.at(workset.wsIndex);
+  const RealType j_coeff = workset.j_coeff;
+  Teuchos::Array<ST> vals;
+  Teuchos::Array<LO> cols;
   for (size_t icell=0; icell<workset.numCells; ++icell) {
     const auto elem_LID = elem_lids(icell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
 
-    const auto& node_gids = node_dof_mgr->getElementGIDs(elem_LID);
+    for (int eq = 0; eq < this->numFields; eq++) {
+      const auto& offsets = dof_mgr->getGIDFieldOffsets(eq+this->offset);
+      for (auto o : offsets) {
+        auto lrow = dof_lids[o];
+        if (ss_eqn_lids.count(lrow)==0) {
+          // LID not on the sideset. Diagonalize
 
-    for (int inode=0; inode<numCellNodes; ++inode) {
-      const auto node = node_gids[inode];
-      if (this->ss_nodes_gids.count(node)==0) {
-        for (int eq = 0; eq < this->numFields; eq++) {
-          const auto& offsets = dof_mgr->getGIDFieldOffsets(eq+this->offset);
-          const LO lrow = dof_lids(offsets[inode]);
-          Albany::setLocalRowValue(Jac,lrow,lrow, 1.0);
+          // Extract the row, zero it out, then put j_coeff on diagonal
+          Albany::getLocalRowValues(Jac, lrow, cols, vals);
+          for (auto& val : vals) { val = 0.0; }
+          Albany::setLocalRowValues(Jac, lrow, cols(), vals());
+          Albany::setLocalRowValue(Jac,lrow,lrow, j_coeff);
         }
       }
     }
@@ -333,18 +369,21 @@ doEvaluateFields(typename Traits::EvalData workset,
 
   const int numSides = sideSet.size();
   const int neq = dof_mgr->getNumFields();
+
+  Teuchos::Array<LO> cols;
+
   for (int iside=0; iside<numSides; ++iside) {
     const auto& side = sideSet[iside];
-    const auto ws_elem_pos = side.ws_elem_idx;
-    const auto elem_LID = elem_lids(ws_elem_pos);
+    const auto icell = side.ws_elem_idx;
+    const auto elem_LID = elem_lids(icell);
     const auto dof_lids = Kokkos::subview(elem_dof_lids,elem_LID,ALL);
     const auto side_nodes = node_dof_mgr->getGIDFieldOffsetsSide(0,side.side_pos);
     const int numNodes = side_nodes.size();
 
     // Precompute the column indices (same for all the rows in this side)
-    const int nunk = neq*numNodes;
-    Teuchos::Array<LO> cols(nunk);
     // Note: we couple the eq with ALL other dofs on the side, so loop on [0,neq)
+    const int nunk = neq*numNodes;
+    cols.resize(nunk*numNodes);
     for (int eq=0; eq<neq; ++eq) {
       const auto& offsets = dof_mgr->getGIDFieldOffsetsSide(eq,side.side_pos);
       for (int inode=0; inode<numNodes; ++inode){

--- a/tests/corePDEs/SideSetLaplacian/input_3D.yaml
+++ b/tests/corePDEs/SideSetLaplacian/input_3D.yaml
@@ -1,79 +1,79 @@
 %YAML 1.1
 ---
 ANONYMOUS:
-  Debug Output: 
+  Debug Output:
     Write Solution to MatrixMarket: 0
-  Problem: 
+  Problem:
     Phalanx Graph Visualization Detail: 0
     Solution Method: Steady
     Name: Side Laplacian 3D
     Solve As Side Set Equation: true
-    Side Set Name: SideSet2
+    Side Set Name: SideSet4
     Response Functions:
       Number Of Responses: 1
       Response 0:
         Name: Squared L2 Difference Side Source ST Target PST
-        Side Set Name: SideSet2
+        Side Set Name: SideSet4
         Field Rank: Scalar
         Source Field Name: u
         Target Value: 0.0
-    Dirichlet BCs: 
+    Dirichlet BCs:
       DBC on NS NodeSet0 for DOF U: 0.0
       DBC on NS NodeSet1 for DOF U: 0.0
-      DBC on NS NodeSet4 for DOF U: 0.0
-      DBC on NS NodeSet5 for DOF U: 0.0
+      DBC on NS NodeSet2 for DOF U: 0.0
+      DBC on NS NodeSet3 for DOF U: 0.0
     Cubature Degree: 2
 
-  Discretization: 
+  Discretization:
     Method: STK3D
     1D Elements: 2
     2D Elements: 2
     3D Elements: 2
     Build Node Sets From Side Sets: true
     Cell Topology: Quad
-    Side Set Discretizations: 
-      Side Sets: [SideSet2]
-      SideSet2: 
+    Side Set Discretizations:
+      Side Sets: [SideSet4]
+      SideSet4:
         Method: SideSetSTK
         Exodus Output File Name: side_laplacian_3d.exo
-  Regression For Response 0: 
+  Regression For Response 0:
     Test Value: 9.765625e-04
     Relative Tolerance: 1.0e-04
     Absolute Tolerance: 1.0e-04
-  Piro: 
-    NOX: 
+  Piro:
+    NOX:
       Nonlinear Solver: Line Search Based
-      Solver Options: 
+      Solver Options:
         Status Test Check Type: Minimal
-      Status Tests: 
+      Status Tests:
         Test Type: Combo
         Combo Type: OR
         Number of Tests: 2
-        Test 0: 
+        Test 0:
           Test Type: NormF
           Norm Type: Two Norm
           Scale Type: Unscaled
           Tolerance: 1.0e-05
-        Test 1: 
+        Test 1:
           Test Type: MaxIters
           Maximum Iterations: 50
-      Direction: 
+      Direction:
         Method: Newton
-        Newton: 
+        Newton:
           Forcing Term Method: Constant
           Rescue Bad Newton Solve: true
-          Linear Solver: 
+          Linear Solver:
             Write Linear System: false
             Tolerance: 1.0e-04
-          Stratimikos Linear Solver: 
+          Stratimikos Linear Solver:
             NOX Stratimikos Options: { }
-            Stratimikos: 
+            Stratimikos:
               Linear Solver Type: Belos
-              Linear Solver Types: 
-                Belos: 
+              Linear Solver Types:
+                Belos:
                   Solver Type: Block GMRES
-                  Solver Types: 
-                    Block GMRES: 
+                  Solver Types:
+                    Block GMRES:
                       Convergence Tolerance: 1.0e-06
                       Output Frequency: 10
                       Output Style: 1
@@ -85,22 +85,22 @@ ANONYMOUS:
                   VerboseObject:
                     Verbosity Level: low
               Preconditioner Type: Ifpack2
-              Preconditioner Types: 
-                Ifpack2: 
+              Preconditioner Types:
+                Ifpack2:
                   Overlap: 1
                   Prec Type: ILUT
-                  Ifpack2 Settings: 
+                  Ifpack2 Settings:
                     'fact: drop tolerance': 0.0
                     'fact: ilut level-of-fill': 1.0
                     'fact: level-of-fill': 1
-      Line Search: 
-        Full Step: 
+      Line Search:
+        Full Step:
           Full Step: 1.0
         Method: Backtrack
-      Printing: 
+      Printing:
         Output Precision: 3
         Output Processor: 0
-        Output Information: 
+        Output Information:
           Error: true
           Warning: true
           Outer Iteration: true


### PR DESCRIPTION
The current implementation was trying to be smart, by only scattering the FAD entries corresponding to volume equations. But it used a temporary for the vol eqn offsets that was shared by all threads in the RangePolicy, causing race conditions and a flat-out wrong jacobian.

I think I originally did that since the Jac was supposed to NOT be coupled with side eqn inside the volume. But a) I am not sure that's correct (you may still have a boundary integral that involves the side eqn dof), and b) it seems to work fine without this level of indirection. So I removed the vol-eqn handling altogether, and the test now passes on weaver.

Fixes #1030 