### PR TITLE
Move load-field routines out of GenericSTKMeshStruct

### DIFF
--- a/src/disc/Albany_DiscretizationUtils.cpp
+++ b/src/disc/Albany_DiscretizationUtils.cpp
@@ -1,5 +1,8 @@
 #include "Albany_DiscretizationUtils.hpp"
 
+#include "Albany_CombineAndScatterManager.hpp"
+#include "Albany_ThyraUtils.hpp"
+
 #include "Intrepid2_HGRAD_LINE_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_LINE_Cn_FEM.hpp"
 #include "Intrepid2_HGRAD_TRI_C1_FEM.hpp"
@@ -115,5 +118,394 @@ getIntrepid2Basis (const CellTopologyData& cell_topo,
 //   return fp;
 // }
 
+
+Teuchos::RCP<Thyra_MultiVector>
+readScalarFileSerial (const std::string& fname,
+                      const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                      const Teuchos::RCP<const Teuchos_Comm>& comm)
+{
+  // It's a scalar, so we already know MultiVector has only 1 vector
+  auto mvec = Thyra::createMembers(vs,1);
+
+  if (comm->getRank() != 0) {
+    // Only process 0 will load the file...
+    return mvec;
+  }
+
+  auto nonConstData = getNonconstLocalData(mvec->col(0));
+
+  std::ifstream ifile;
+  ifile.open(fname.c_str());
+  TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error,
+        "[readScalarFileSerial] Error! Unable to open the file.\n"
+        "  - file name: " << fname << "\n");
+
+  GO numNodes;
+  ifile >> numNodes;
+  TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstData.size(),
+      Teuchos::Exceptions::InvalidParameterValue,
+      "[readScalarFileSerial] Error! Unexpected number of nodes.\n"
+      "  - file name: " << fname << "\n"
+      "  - number of nodes in file: " << numNodes << "\n"
+      "  - expected number of nodes: " << nonConstData.size() << "\n");
+
+  for (GO i = 0; i < numNodes; i++) {
+    ifile >> nonConstData[i];
+  }
+
+  ifile.close();
+
+  return mvec;
+}
+
+Teuchos::RCP<Thyra_MultiVector>
+readVectorFileSerial (const std::string& fname,
+                      const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                      const Teuchos::RCP<const Teuchos_Comm>& comm)
+{
+  int numComponents;
+  GO numNodes;
+  std::ifstream ifile;
+  if (comm->getRank() == 0) {
+    ifile.open(fname.c_str());
+    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error,
+          "[readVectorFileSerial] Error! Unable to open the file.\n"
+          "  - file name: " << fname << "\n");
+
+    ifile >> numNodes >> numComponents;
+  }
+
+  Teuchos::broadcast(*comm,0,1,&numComponents);
+  auto mvec = Thyra::createMembers(vs,numComponents);
+
+  if (comm->getRank()==0) {
+    auto nonConstData = getNonconstLocalData(mvec);
+    TEUCHOS_TEST_FOR_EXCEPTION (numComponents != nonConstData.size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readVectorFileSerial] Error! Unexpected number of components.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of components in file: " << numComponents << "\n"
+        "  - expected number of components: " << nonConstData.size() << "\n");
+
+    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstData[0].size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readVectorFileSerial] Error! Unexpected number of nodes.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of nodes in file: " << numNodes << "\n"
+        "  - expected number of nodes: " << nonConstData[0].size() << "\n");
+
+    for (int icomp=0; icomp<numComponents; ++icomp) {
+      auto comp_view = nonConstData[icomp];
+      for (GO i=0; i<numNodes; ++i)
+        ifile >> comp_view[i];
+    }
+    ifile.close();
+  }
+
+  return mvec;
+}
+
+Teuchos::RCP<Thyra_MultiVector>
+readLayeredScalarFileSerial (const std::string &fname,
+                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                             std::vector<double>& normalizedLayersCoords,
+                             const Teuchos::RCP<const Teuchos_Comm>& comm)
+{
+  size_t numLayers=0;
+  GO numNodes;
+
+  std::ifstream ifile;
+  if (comm->getRank()==0) {
+    ifile.open(fname.c_str());
+    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error,
+        "[readLayeredScalarFileSerial] Error! Unable to open the file.\n"
+        "  - file name: " << fname << "\n");
+
+    ifile >> numNodes >> numLayers;
+  }
+
+  Teuchos::broadcast(*comm,0,1,&numLayers);
+  auto mvec = Thyra::createMembers(vs,numLayers);
+
+  if (comm->getRank()==0) {
+    auto nonConstData = getNonconstLocalData(mvec);
+    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstData[0].size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readLayeredScalarFileSerial] Error! Unexpected number of nodes.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of nodes in file: " << numNodes << "\n"
+        "  - expected number of nodes: " << nonConstData[0].size() << "\n");
+    TEUCHOS_TEST_FOR_EXCEPTION (numLayers != normalizedLayersCoords.size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readLayeredScalarFileSerial] Error! Unexpected number of layers.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of layers in file: " << numLayers << "\n"
+        "  - expected number of layers: " << normalizedLayersCoords.size() << "\n"
+        " To fix this, please specify the correct layered data dimension when you register the state.\n");
+
+    for (size_t il = 0; il < numLayers; ++il) {
+      ifile >> normalizedLayersCoords[il];
+    }
+
+    for (size_t il=0; il<numLayers; ++il) {
+      for (GO i=0; i<numNodes; ++i) {
+        ifile >> nonConstData[il][i];
+      }
+    }
+    ifile.close();
+  }
+
+  return mvec;
+}
+
+
+Teuchos::RCP<Thyra_MultiVector>
+readLayeredVectorFileSerial (const std::string &fname,
+                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                             std::vector<double>& normalizedLayersCoords,
+                             const Teuchos::RCP<const Teuchos_Comm>& comm)
+{
+  int numVectors=0;
+  int numLayers,numComponents;
+  GO numNodes;
+  std::ifstream ifile;
+  if (comm->getRank()==0) {
+    ifile.open(fname.c_str());
+    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error,
+        "[readLayeredVectorFileSerial] Error! Unable to open the file.\n"
+        "  - file name: " << fname << "\n");
+
+    ifile >> numNodes >> numComponents >> numLayers;
+    numVectors = numLayers*numComponents;
+  }
+
+  Teuchos::broadcast(*comm,0,1,&numVectors);
+  auto mvec = Thyra::createMembers(vs,numVectors);
+
+  if (comm->getRank()==0) {
+    auto nonConstData = getNonconstLocalData(mvec);
+
+    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstData[0].size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readLayeredVectorFileSerial] Error! Unexpected number of nodes.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of nodes in file: " << numNodes << "\n"
+        "  - expected number of nodes: " << nonConstData[0].size() << "\n");
+    TEUCHOS_TEST_FOR_EXCEPTION (numLayers != normalizedLayersCoords.size(),
+        Teuchos::Exceptions::InvalidParameterValue,
+        "[readLayeredVectorFileSerial] Error! Unexpected number of layers.\n"
+        "  - file name: " << fname << "\n"
+        "  - number of layers in file: " << numLayers << "\n"
+        "  - expected number of layers: " << normalizedLayersCoords.size() << "\n"
+        " To fix this, please specify the correct layered data dimension when you register the state.\n");
+
+    normalizedLayersCoords.resize(numLayers);
+    for (int il=0; il<numLayers; ++il) {
+      ifile >> normalizedLayersCoords[il];
+    }
+
+    // Layer ordering: before switching component, we first do all the layers of the current component
+    // This is because with the stk field (natural ordering) we want to keep the layer dimension last.
+    // Ex: a 2D field f(i,j) would be stored at the raw array position i*num_cols+j. In our case,
+    //     num_cols is the number of layers, and num_rows the number of field components
+    for (int il=0; il<numLayers; ++il) {
+      for (int icomp(0); icomp<numComponents; ++icomp) {
+        Teuchos::ArrayRCP<ST> col_vals = nonConstData[icomp*numLayers+il];
+        for (GO i=0; i<numNodes; ++i) {
+          ifile >> col_vals[i];
+        }
+      }
+    }
+    ifile.close();
+  }
+
+  return mvec;
+}
+
+Teuchos::RCP<Thyra_MultiVector>
+loadField (const std::string& field_name,
+           const Teuchos::ParameterList& field_params,
+           const CombineAndScatterManager& cas_manager,
+           const Teuchos::RCP<const Teuchos_Comm>& comm,
+           bool node, bool scalar, bool layered,
+           const Teuchos::RCP<Teuchos::FancyOStream> out,
+           std::vector<double>& norm_layers_coords)
+{
+  // Getting the serial and (possibly) parallel vector spaces
+  auto serial_vs = cas_manager.getOwnedVectorSpace();
+  auto vs        = cas_manager.getOverlappedVectorSpace();
+
+  std::string field_type = (node ? "Node" : "Elem");
+  field_type += (layered ? " Layered" : "");
+  field_type += (scalar ? " Scalar" : " Vector");
+
+  // The serial service multivector
+  Teuchos::RCP<Thyra_MultiVector> serial_req_mvec;
+
+  std::string fname = field_params.get<std::string>("File Name");
+
+  *out << "  - Reading " << field_type << " field '" << field_name << "' from file '" << fname << "' ... ";
+  out->getOStream()->flush();
+  // Read the input file and stuff it in the Tpetra multivector
+
+  if (scalar) {
+    if (layered) {
+      serial_req_mvec = readLayeredScalarFileSerial (fname,cas_manager.getOwnedVectorSpace(),norm_layers_coords,comm);
+
+      // Broadcast the normalized layers coordinates
+      int size = norm_layers_coords.size();
+      Teuchos::broadcast(*comm,0,size,norm_layers_coords.data());
+    } else {
+      serial_req_mvec = readScalarFileSerial (fname,cas_manager.getOwnedVectorSpace(),comm);
+    }
+  } else {
+    if (layered) {
+      serial_req_mvec = readLayeredVectorFileSerial (fname,cas_manager.getOwnedVectorSpace(),norm_layers_coords,comm);
+
+      // Broadcast the normalized layers coordinates
+      int size = norm_layers_coords.size();
+      Teuchos::broadcast(*comm,0,size,norm_layers_coords.data());
+    } else {
+      serial_req_mvec = readVectorFileSerial (fname,cas_manager.getOwnedVectorSpace(),comm);
+    }
+  }
+  *out << "done!\n";
+
+  if (field_params.isParameter("Scale Factor")) {
+    Teuchos::Array<double> scale_factors;
+    if (field_params.isType<Teuchos::Array<double>>("Scale Factor")) {
+      scale_factors = field_params.get<Teuchos::Array<double> >("Scale Factor");
+      TEUCHOS_TEST_FOR_EXCEPTION (scale_factors.size()!=static_cast<int>(serial_req_mvec->domain()->dim()),
+                                  Teuchos::Exceptions::InvalidParameter,
+                                  "Error! The given scale factors vector size does not match the field dimension.\n");
+    } else if (field_params.isType<double>("Scale Factor")) {
+      scale_factors.resize(serial_req_mvec->domain()->dim());
+      std::fill_n(scale_factors.begin(),scale_factors.size(),field_params.get<double>("Scale Factor"));
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
+                                 "Error! Invalid type for parameter 'Scale Factor'. Should be either 'double' or 'Array(double)'.\n");
+    }
+
+    *out << "   - Scaling " << field_type << " field '" << field_name << "' with scaling factors [" << scale_factors[0];
+    for (int i=1; i<scale_factors.size(); ++i) {
+      *out << " " << scale_factors[i];
+    }
+    *out << "]\n";
+
+    for (int i=0; i<scale_factors.size(); ++i) {
+      serial_req_mvec->col(i)->scale (scale_factors[i]);
+    }
+  }
+
+  // Fill the (possibly) parallel vector
+  auto field_mv = Thyra::createMembers(vs,serial_req_mvec->domain()->dim());
+  cas_manager.scatter(*serial_req_mvec, *field_mv, CombineMode::INSERT);
+  return field_mv;
+}
+
+Teuchos::RCP<Thyra_MultiVector>
+fillField (const std::string& field_name,
+           const Teuchos::ParameterList& field_params,
+           const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
+           bool nodal, bool scalar, bool layered,
+           const Teuchos::RCP<Teuchos::FancyOStream> out,
+           std::vector<double>& norm_layers_coords)
+{
+  std::string temp_str;
+  std::string field_type = (nodal ? "Node" : "Elem");
+  field_type += (layered ? " Layered" : "");
+  field_type += (scalar ? " Scalar" : " Vector");
+
+  Teuchos::RCP<Thyra_MultiVector> field_mv;
+  if (field_params.isParameter("Random Value")) {
+    *out << "  - Filling " << field_type << " field '" << field_name << "' with random values.\n";
+
+    Teuchos::Array<std::string> randomize = field_params.get<Teuchos::Array<std::string> >("Random Value");
+    field_mv = Thyra::createMembers(entities_vs,randomize.size());
+
+    if (layered) {
+      *out << "    - Filling layers normalized coordinates linearly in [0,1].\n";
+
+      int size = norm_layers_coords.size();
+      if (size==1) {
+        norm_layers_coords[0] = 1.;
+      } else {
+        int n_int = size-1;
+        double dx = 1./n_int;
+        norm_layers_coords[0] = 0.;
+        for (int i=0; i<n_int; ++i) {
+          norm_layers_coords[i+1] = norm_layers_coords[i]+dx;
+        }
+      }
+    }
+
+    // If there are components that were marked to not be randomized,
+    // we look for the parameter 'Field Value' and use the corresponding entry.
+    // If there is no such parameter, we fill the non random entries with zeroes.
+    Teuchos::Array<double> values;
+    if (field_params.isParameter("Field Value")) {
+      values = field_params.get<Teuchos::Array<double> >("Field Value");
+    } else {
+      values.resize(randomize.size(),0.);
+    }
+
+    for (int iv=0; iv<randomize.size(); ++iv) {
+      if (randomize[iv]=="false" || randomize[iv]=="no") {
+        *out << "    - Using constant value " << values[iv] << " for component " << iv << ", which was marked as not random.\n";
+        field_mv->col(iv)->assign(values[iv]);
+      }
+    }
+  } else if (field_params.isParameter("Field Value")) {
+    Teuchos::Array<double> values;
+    if (field_params.isType<Teuchos::Array<double>>("Field Value")) {
+      values = field_params.get<Teuchos::Array<double> >("Field Value");
+      TEUCHOS_TEST_FOR_EXCEPTION (values.size()==0 , Teuchos::Exceptions::InvalidParameter,
+          "Error! The given field value array has size 0.\n");
+      TEUCHOS_TEST_FOR_EXCEPTION (values.size()==1 && !scalar , Teuchos::Exceptions::InvalidParameter,
+          "Error! The given field value array has size 1, but the field is not scalar.\n");
+      TEUCHOS_TEST_FOR_EXCEPTION (values.size()>1 && scalar , Teuchos::Exceptions::InvalidParameter,
+          "Error! The given field value array has size >1, but the field is scalar.\n");
+    } else if (field_params.isType<double>("Field Value")) {
+      if (scalar) {
+        values.resize(1);
+        values[0] = field_params.get<double>("Field Value");
+      } else {
+        TEUCHOS_TEST_FOR_EXCEPTION (!field_params.isParameter("Vector Dim"), std::logic_error,
+            "Error! Cannot determine dimension of " << field_type << " field '" << field_name << "'. "
+            "In order to fill with constant value, either specify 'Vector Dim', or make 'Field Value' an Array(double).\n");
+        values.resize(field_params.get<int>("Vector Dim"));
+        std::fill_n(values.begin(),values.size(),field_params.get<double>("Field Value"));
+      }
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
+            "Error! Invalid type for parameter 'Field Value'. Should be either 'double' or 'Array(double)'.\n");
+    }
+
+    if (layered) {
+      *out << "  - Filling " << field_type << " field '" << field_name << "' with constant value " << values << " and filling layers normalized coordinates linearly in [0,1].\n";
+
+      int size = norm_layers_coords.size();
+      if (size==1) {
+        norm_layers_coords[0] = 1.;
+      } else {
+        int n_int = size-1;
+        double dx = 1./n_int;
+        norm_layers_coords[0] = 0.;
+        for (int i=0; i<n_int; ++i) {
+          norm_layers_coords[i+1] = norm_layers_coords[i]+dx;
+        }
+      }
+    } else {
+      *out << "  - Filling " << field_type << " field '" << field_name << "' with constant value " << values << ".\n";
+    }
+
+    field_mv = Thyra::createMembers(entities_vs,values.size());
+    for (int iv(0); iv<field_mv->domain()->dim(); ++iv) {
+      field_mv->col(iv)->assign(values[iv]);
+    }
+  }
+
+  return field_mv;
+}
 
 } // namespace Albany

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -9,6 +9,7 @@
 
 #include "Albany_KokkosTypes.hpp"
 #include "Albany_ThyraTypes.hpp"
+#include "Albany_CommTypes.hpp"
 #include "Albany_ScalarOrdinalTypes.hpp"
 
 #include "Kokkos_DualView.hpp"
@@ -174,6 +175,47 @@ using WorksetArray = Teuchos::ArrayRCP<T>;
 //             dependencies.
 using WorksetConn = Kokkos::View<LO***, Kokkos::LayoutRight, PHX::Device>;
 using Conn        = WorksetArray<WorksetConn>;
+
+// ===== Utilities to serially read data from file ====== //
+
+// Fwd-declare
+class CombineAndScatterManager;
+
+Teuchos::RCP<Thyra_MultiVector>
+readScalarFileSerial (const std::string& fname,
+                      const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                      const Teuchos::RCP<const Teuchos_Comm>& comm);
+
+Teuchos::RCP<Thyra_MultiVector>
+readLayeredScalarFileSerial (const std::string &fname,
+                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                             std::vector<double>& normalizedLayersCoords,
+                             const Teuchos::RCP<const Teuchos_Comm>& comm);
+
+Teuchos::RCP<Thyra_MultiVector>
+readLayeredVectorFileSerial (const std::string &fname,
+                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
+                             std::vector<double>& normalizedLayersCoords,
+                             const Teuchos::RCP<const Teuchos_Comm>& comm);
+
+// Calls one of the above, depending on inputs, and takes care of
+// redistributing the vector over MPI ranks, as well as set scaling fators (if requested)
+Teuchos::RCP<Thyra_MultiVector>
+loadField (const std::string& field_name,
+           const Teuchos::ParameterList& field_params,
+           const CombineAndScatterManager& cas_manager,
+           const Teuchos::RCP<const Teuchos_Comm>& comm,
+           bool node, bool scalar, bool layered,
+           const Teuchos::RCP<Teuchos::FancyOStream> out,
+           std::vector<double>& norm_layers_coords);
+
+Teuchos::RCP<Thyra_MultiVector>
+fillField (const std::string& field_name,
+           const Teuchos::ParameterList& field_params,
+           const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
+           bool nodal, bool scalar, bool layered,
+           const Teuchos::RCP<Teuchos::FancyOStream> out,
+           std::vector<double>& norm_layers_coords);
 
 }  // namespace Albany
 

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -793,11 +793,11 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm)
     auto vs = cas_manager->getOverlappedVectorSpace();  // It is not overlapped, it is just distributed.
     Teuchos::RCP<Thyra_MultiVector> field_mv;
     if (load_ascii) {
-      loadField (fname, fparams, field_mv, *cas_manager, comm, nodal, scalar, layered, out);
+      field_mv = loadField (fname, fparams, *cas_manager, comm, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_value) {
-      fillField (fname, fparams, field_mv, vs, nodal, scalar, layered, out);
+      field_mv = fillField (fname, fparams, vs, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_math_expr) {
-      computeField (fname, fparams, field_mv, vs, *entities, nodal, scalar, layered, out);
+      field_mv = computeField (fname, fparams, vs, *entities, nodal, scalar, layered, out);
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error, "Error! No means were specified for loading field '" + fname + "'.\n");
     }
@@ -826,200 +826,10 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm)
   }
 }
 
-void GenericSTKMeshStruct::
-loadField (const std::string& field_name, const Teuchos::ParameterList& field_params,
-           Teuchos::RCP<Thyra_MultiVector>& field_mv,
-           const CombineAndScatterManager& cas_manager,
-           const Teuchos::RCP<const Teuchos_Comm>& comm,
-           bool node, bool scalar, bool layered,
-           const Teuchos::RCP<Teuchos::FancyOStream> out)
-{
-  // Getting the serial and (possibly) parallel vector spaces
-  auto serial_vs = cas_manager.getOwnedVectorSpace();
-  auto vs        = cas_manager.getOverlappedVectorSpace();
-
-  std::string temp_str;
-  std::string field_type = (node ? "Node" : "Elem");
-  field_type += (layered ? " Layered" : "");
-  field_type += (scalar ? " Scalar" : " Vector");
-
-  // The serial service multivector
-  Teuchos::RCP<Thyra_MultiVector> serial_req_mvec;
-
-  std::string fname = field_params.get<std::string>("File Name");
-
-  *out << "  - Reading " << field_type << " field '" << field_name << "' from file '" << fname << "' ... ";
-  out->getOStream()->flush();
-  // Read the input file and stuff it in the Tpetra multivector
-
-  if (scalar) {
-    if (layered) {
-      temp_str = field_name + "_NLC";
-      auto& norm_layers_coords = fieldContainer->getMeshVectorStates()[temp_str];
-      readLayeredScalarFileSerial (fname,serial_req_mvec,cas_manager.getOwnedVectorSpace(),norm_layers_coords,comm);
-
-      // Broadcast the normalized layers coordinates
-      int size = norm_layers_coords.size();
-      Teuchos::broadcast(*comm,0,size,norm_layers_coords.data());
-    } else {
-      readScalarFileSerial (fname,serial_req_mvec,cas_manager.getOwnedVectorSpace(),comm);
-    }
-  } else {
-    if (layered) {
-      temp_str = field_name + "_NLC";
-      auto& norm_layers_coords = fieldContainer->getMeshVectorStates()[temp_str];
-      readLayeredVectorFileSerial (fname,serial_req_mvec,cas_manager.getOwnedVectorSpace(),norm_layers_coords,comm);
-
-      // Broadcast the normalized layers coordinates
-      int size = norm_layers_coords.size();
-      Teuchos::broadcast(*comm,0,size,norm_layers_coords.data());
-    } else {
-      readVectorFileSerial (fname,serial_req_mvec,cas_manager.getOwnedVectorSpace(),comm);
-    }
-  }
-  *out << "done!\n";
-
-  if (field_params.isParameter("Scale Factor")) {
-    Teuchos::Array<double> scale_factors;
-    if (field_params.isType<Teuchos::Array<double>>("Scale Factor")) {
-      scale_factors = field_params.get<Teuchos::Array<double> >("Scale Factor");
-      TEUCHOS_TEST_FOR_EXCEPTION (scale_factors.size()!=static_cast<int>(serial_req_mvec->domain()->dim()),
-                                  Teuchos::Exceptions::InvalidParameter,
-                                  "Error! The given scale factors vector size does not match the field dimension.\n");
-    } else if (field_params.isType<double>("Scale Factor")) {
-      scale_factors.resize(serial_req_mvec->domain()->dim());
-      std::fill_n(scale_factors.begin(),scale_factors.size(),field_params.get<double>("Scale Factor"));
-    } else {
-      TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
-                                 "Error! Invalid type for parameter 'Scale Factor'. Should be either 'double' or 'Array(double)'.\n");
-    }
-
-    *out << "   - Scaling " << field_type << " field '" << field_name << "' with scaling factors [" << scale_factors[0];
-    for (int i=1; i<scale_factors.size(); ++i) {
-      *out << " " << scale_factors[i];
-    }
-    *out << "]\n";
-
-    for (int i=0; i<scale_factors.size(); ++i) {
-      serial_req_mvec->col(i)->scale (scale_factors[i]);
-    }
-  }
-
-  // Fill the (possibly) parallel vector
-  field_mv = Thyra::createMembers(vs,serial_req_mvec->domain()->dim());
-  cas_manager.scatter(*serial_req_mvec, *field_mv, CombineMode::INSERT);
-}
-
-void GenericSTKMeshStruct::
-fillField (const std::string& field_name,
-           const Teuchos::ParameterList& field_params,
-           Teuchos::RCP<Thyra_MultiVector>& field_mv,
-           const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
-           bool nodal, bool scalar, bool layered,
-           const Teuchos::RCP<Teuchos::FancyOStream> out)
-{
-  std::string temp_str;
-  std::string field_type = (nodal ? "Node" : "Elem");
-  field_type += (layered ? " Layered" : "");
-  field_type += (scalar ? " Scalar" : " Vector");
-
-  if (field_params.isParameter("Random Value")) {
-    *out << "  - Filling " << field_type << " field '" << field_name << "' with random values.\n";
-
-    Teuchos::Array<std::string> randomize = field_params.get<Teuchos::Array<std::string> >("Random Value");
-    field_mv = Thyra::createMembers(entities_vs,randomize.size());
-
-    if (layered) {
-      *out << "    - Filling layers normalized coordinates linearly in [0,1].\n";
-
-      temp_str = field_name + "_NLC";
-      auto& norm_layers_coords = fieldContainer->getMeshVectorStates()[temp_str];
-      int size = norm_layers_coords.size();
-      if (size==1) {
-        norm_layers_coords[0] = 1.;
-      } else {
-        int n_int = size-1;
-        double dx = 1./n_int;
-        norm_layers_coords[0] = 0.;
-        for (int i=0; i<n_int; ++i) {
-          norm_layers_coords[i+1] = norm_layers_coords[i]+dx;
-        }
-      }
-    }
-
-    // If there are components that were marked to not be randomized,
-    // we look for the parameter 'Field Value' and use the corresponding entry.
-    // If there is no such parameter, we fill the non random entries with zeroes.
-    Teuchos::Array<double> values;
-    if (field_params.isParameter("Field Value")) {
-      values = field_params.get<Teuchos::Array<double> >("Field Value");
-    } else {
-      values.resize(randomize.size(),0.);
-    }
-
-    for (int iv=0; iv<randomize.size(); ++iv) {
-      if (randomize[iv]=="false" || randomize[iv]=="no") {
-        *out << "    - Using constant value " << values[iv] << " for component " << iv << ", which was marked as not random.\n";
-        field_mv->col(iv)->assign(values[iv]);
-      }
-    }
-  } else if (field_params.isParameter("Field Value")) {
-    Teuchos::Array<double> values;
-    if (field_params.isType<Teuchos::Array<double>>("Field Value")) {
-      values = field_params.get<Teuchos::Array<double> >("Field Value");
-      TEUCHOS_TEST_FOR_EXCEPTION (values.size()==0 , Teuchos::Exceptions::InvalidParameter,
-                                  "Error! The given field value array has size 0.\n");
-      TEUCHOS_TEST_FOR_EXCEPTION (values.size()==1 && !scalar , Teuchos::Exceptions::InvalidParameter,
-                                  "Error! The given field value array has size 1, but the field is not scalar.\n");
-      TEUCHOS_TEST_FOR_EXCEPTION (values.size()>1 && scalar , Teuchos::Exceptions::InvalidParameter,
-                                  "Error! The given field value array has size >1, but the field is scalar.\n");
-    } else if (field_params.isType<double>("Field Value")) {
-      if (scalar) {
-        values.resize(1);
-        values[0] = field_params.get<double>("Field Value");
-      } else {
-        TEUCHOS_TEST_FOR_EXCEPTION (!field_params.isParameter("Vector Dim"), std::logic_error,
-                                    "Error! Cannot determine dimension of " << field_type << " field '" << field_name << "'. "
-                                    "In order to fill with constant value, either specify 'Vector Dim', or make 'Field Value' an Array(double).\n");
-        values.resize(field_params.get<int>("Vector Dim"));
-        std::fill_n(values.begin(),values.size(),field_params.get<double>("Field Value"));
-      }
-    } else {
-      TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameter,
-                                 "Error! Invalid type for parameter 'Field Value'. Should be either 'double' or 'Array(double)'.\n");
-    }
-
-    if (layered) {
-      *out << "  - Filling " << field_type << " field '" << field_name << "' with constant value " << values << " and filling layers normalized coordinates linearly in [0,1].\n";
-
-      temp_str = field_name + "_NLC";
-      auto& norm_layers_coords = fieldContainer->getMeshVectorStates()[temp_str];
-      int size = norm_layers_coords.size();
-      if (size==1) {
-        norm_layers_coords[0] = 1.;
-      } else {
-        int n_int = size-1;
-        double dx = 1./n_int;
-        norm_layers_coords[0] = 0.;
-        for (int i=0; i<n_int; ++i) {
-          norm_layers_coords[i+1] = norm_layers_coords[i]+dx;
-        }
-      }
-    } else {
-      *out << "  - Filling " << field_type << " field '" << field_name << "' with constant value " << values << ".\n";
-    }
-
-    field_mv = Thyra::createMembers(entities_vs,values.size());
-    for (int iv(0); iv<field_mv->domain()->dim(); ++iv) {
-      field_mv->col(iv)->assign(values[iv]);
-    }
-  }
-}
-
-void GenericSTKMeshStruct::
+Teuchos::RCP<Thyra_MultiVector>
+GenericSTKMeshStruct::
 computeField (const std::string& field_name,
               const Teuchos::ParameterList& field_params,
-              Teuchos::RCP<Thyra_MultiVector>& field_mv,
               const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
               const std::vector<stk::mesh::Entity>& entities,
               bool nodal, bool scalar, bool layered,
@@ -1071,7 +881,7 @@ computeField (const std::string& field_name,
   *out << ".\n";
 
   // Extract coordinates of all nodes
-  field_mv = Thyra::createMembers(entities_vs,field_dim);
+  auto field_mv = Thyra::createMembers(entities_vs,field_dim);
   using exec_space = Tpetra_MultiVector::execution_space;
   using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
   using layout = view_type::traits::array_layout;
@@ -1117,167 +927,8 @@ computeField (const std::string& field_name,
 #else
   TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Error! Cannot read the field from a mathematical expression, since PanzerExprEval package was not found in Trilinos.\n");
 #endif
-}
 
-void GenericSTKMeshStruct::
-readScalarFileSerial (const std::string& fname,
-                      Teuchos::RCP<Thyra_MultiVector>& mvec,
-                      const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                      const Teuchos::RCP<const Teuchos_Comm>& comm) const
-{
-  // It's a scalar, so we already know MultiVector has only 1 vector
-  mvec = Thyra::createMembers(vs,1);
-
-  if (comm->getRank() != 0)
-  {
-    // Only process 0 will load the file...
-    return;
-  }
-
-  GO numNodes;
-  Teuchos::ArrayRCP<ST> nonConstView = getNonconstLocalData(mvec->col(0));
-
-  std::ifstream ifile;
-  ifile.open(fname.c_str());
-  TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error, "Error in GenericSTKMeshStruct: unable to open the file " << fname << ".\n");
-
-  ifile >> numNodes;
-  TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstView.size(), Teuchos::Exceptions::InvalidParameterValue,
-                              "Error in GenericSTKMeshStruct: Number of nodes in file " << fname << " (" << numNodes << ") " <<
-                              "is different from the number expected (" << nonConstView.size() << ").\n");
-
-  for (GO i = 0; i < numNodes; i++) {
-    ifile >> nonConstView[i];
-  }
-
-  ifile.close();
-}
-
-void GenericSTKMeshStruct::
-readVectorFileSerial (const std::string& fname,
-                      Teuchos::RCP<Thyra_MultiVector>& mvec,
-                      const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                      const Teuchos::RCP<const Teuchos_Comm>& comm) const
-{
-  int numComponents;
-  GO numNodes;
-  std::ifstream ifile;
-  if (comm->getRank() == 0) {
-    ifile.open(fname.c_str());
-    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error, "Error in GenericSTKMeshStruct: unable to open the file " << fname << ".\n");
-
-    ifile >> numNodes >> numComponents;
-  }
-
-  Teuchos::broadcast(*comm,0,1,&numComponents);
-  mvec = Thyra::createMembers(vs,numComponents);
-
-  if (comm->getRank()==0) {
-    auto nonConstView = getNonconstLocalData(mvec);
-    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstView[0].size(), Teuchos::Exceptions::InvalidParameterValue,
-                                "Error in GenericSTKMeshStruct: Number of nodes in file " << fname << " (" << numNodes << ") " <<
-                                "is different from the number expected (" << nonConstView[0].size() << ").\n");
-
-    for (int icomp=0; icomp<numComponents; ++icomp) {
-      auto comp_view = nonConstView[icomp];
-      for (GO i=0; i<numNodes; ++i)
-        ifile >> comp_view[i];
-    }
-    ifile.close();
-  }
-}
-
-void GenericSTKMeshStruct::
-readLayeredScalarFileSerial (const std::string &fname,
-                             Teuchos::RCP<Thyra_MultiVector>& mvec,
-                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                             std::vector<double>& normalizedLayersCoords,
-                             const Teuchos::RCP<const Teuchos_Comm>& comm) const
-{
-  size_t numLayers=0;
-  GO numNodes;
-  std::ifstream ifile;
-  if (comm->getRank()==0) {
-    ifile.open(fname.c_str());
-    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error, "Error in GenericSTKMeshStruct: unable to open the file " << fname << ".\n");
-
-    ifile >> numNodes >> numLayers;
-  }
-
-  Teuchos::broadcast(*comm,0,1,&numLayers);
-  mvec = Thyra::createMembers(vs,numLayers);
-
-  if (comm->getRank()==0) {
-    auto nonConstView = getNonconstLocalData(mvec);
-    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstView[0].size(), Teuchos::Exceptions::InvalidParameterValue,
-                                "Error in GenericSTKMeshStruct: Number of nodes in file " << fname << " (" << numNodes << ") " <<
-                                "is different from the number expected (" << nonConstView[0].size() << ").\n");
-    TEUCHOS_TEST_FOR_EXCEPTION (numLayers != normalizedLayersCoords.size(), Teuchos::Exceptions::InvalidParameterValue,
-                                "Error in GenericSTKMeshStruct: Number of layers in file " << fname << " (" << numLayers << ") " <<
-                                "is different from the number expected (" << normalizedLayersCoords.size() << ")." <<
-                                " To fix this, please specify the correct layered data dimension when you register the state.\n");
-
-    for (size_t il = 0; il < numLayers; ++il) {
-      ifile >> normalizedLayersCoords[il];
-    }
-
-    for (size_t il=0; il<numLayers; ++il) {
-      for (GO i=0; i<numNodes; ++i) {
-        ifile >> nonConstView[il][i];
-      }
-    }
-    ifile.close();
-  }
-}
-
-void GenericSTKMeshStruct::
-readLayeredVectorFileSerial (const std::string &fname, Teuchos::RCP<Thyra_MultiVector>& mvec,
-                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                             std::vector<double>& normalizedLayersCoords,
-                             const Teuchos::RCP<const Teuchos_Comm>& comm) const
-{
-  int numVectors=0;
-  int numLayers,numComponents;
-  GO numNodes;
-  std::ifstream ifile;
-  if (comm->getRank()==0) {
-
-    ifile.open(fname.c_str());
-    TEUCHOS_TEST_FOR_EXCEPTION (!ifile.is_open(), std::runtime_error, "Error in GenericSTKMeshStruct: unable to open the file " << fname << ".\n");
-
-    ifile >> numNodes >> numComponents >> numLayers;
-    numVectors = numLayers*numComponents;
-  }
-
-  Teuchos::broadcast(*comm,0,1,&numVectors);
-  mvec = Thyra::createMembers(vs,numVectors);
-
-  if (comm->getRank()==0) {
-    auto nonConstView = getNonconstLocalData(mvec);
-
-    TEUCHOS_TEST_FOR_EXCEPTION (numNodes != nonConstView[0].size(), Teuchos::Exceptions::InvalidParameterValue,
-                                "Error in GenericSTKMeshStruct: Number of nodes in file " << fname << " (" << numNodes << ") " <<
-                                "is different from the number expected (" << nonConstView[0].size() << ").\n");
-
-    normalizedLayersCoords.resize(numLayers);
-    for (int il=0; il<numLayers; ++il) {
-      ifile >> normalizedLayersCoords[il];
-    }
-
-    // Layer ordering: before switching component, we first do all the layers of the current component
-    // This is because with the stk field (natural ordering) we want to keep the layer dimension last.
-    // Ex: a 2D field f(i,j) would be stored at the raw array position i*num_cols+j. In our case,
-    //     num_cols is the number of layers, and num_rows the number of field components
-    for (int il=0; il<numLayers; ++il) {
-      for (int icomp(0); icomp<numComponents; ++icomp) {
-        Teuchos::ArrayRCP<ST> col_vals = nonConstView[icomp*numLayers+il];
-        for (GO i=0; i<numNodes; ++i) {
-          ifile >> col_vals[i];
-        }
-      }
-    }
-    ifile.close();
-  }
+  return field_mv;
 }
 
 void GenericSTKMeshStruct::checkFieldIsInMesh (const std::string& fname, const std::string& ftype) const

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -792,6 +792,11 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm)
     auto serial_vs = cas_manager->getOwnedVectorSpace();
     auto vs = cas_manager->getOverlappedVectorSpace();  // It is not overlapped, it is just distributed.
     Teuchos::RCP<Thyra_MultiVector> field_mv;
+
+    std::vector<double> norm_layers_coords;
+    if (layered) {
+      norm_layers_coords = fieldContainer->getMeshVectorStates()[fname + "_NLC"];
+    }
     if (load_ascii) {
       field_mv = loadField (fname, fparams, *cas_manager, comm, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_value) {

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.hpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.hpp
@@ -67,50 +67,14 @@ public:
   //! Loads from file input required fields not found in the mesh
   void loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm);
 
-  // Routines to load, fill, or compute a field
-  void loadField (const std::string& field_name,
-                  const Teuchos::ParameterList& params,
-                  Teuchos::RCP<Thyra_MultiVector>& field_mv,
-                  const CombineAndScatterManager& cas_manager,
-                  const Teuchos::RCP<const Teuchos_Comm>& comm,
-                  bool node, bool scalar, bool layered,
-                  const Teuchos::RCP<Teuchos::FancyOStream> out);
-  void fillField (const std::string& field_name,
-                  const Teuchos::ParameterList& params,
-                  Teuchos::RCP<Thyra_MultiVector>& field_mv,
-                  const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
-                  bool node, bool scalar, bool layered,
-                  const Teuchos::RCP<Teuchos::FancyOStream> out);
-  void computeField (const std::string& field_name,
-                     const Teuchos::ParameterList& params,
-                     Teuchos::RCP<Thyra_MultiVector>& field_mv,
-                     const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
-                     const std::vector<stk::mesh::Entity>& entities,
-                     bool node, bool scalar, bool layered,
-                     const Teuchos::RCP<Teuchos::FancyOStream> out);
-
-  // Routines to read a field from file
-  void readScalarFileSerial (const std::string& fname,
-                             Teuchos::RCP<Thyra_MultiVector>& contentVec,
-                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                             const Teuchos::RCP<const Teuchos_Comm>& comm) const;
-
-  void readVectorFileSerial (const std::string& fname,
-                             Teuchos::RCP<Thyra_MultiVector>& contentVec,
-                             const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                             const Teuchos::RCP<const Teuchos_Comm>& comm) const;
-
-  void readLayeredScalarFileSerial (const std::string& fname,
-                                    Teuchos::RCP<Thyra_MultiVector>& contentVec,
-                                    const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                                    std::vector<double>& normalizedLayersCoords,
-                                    const Teuchos::RCP<const Teuchos_Comm>& comm) const;
-
-  void readLayeredVectorFileSerial (const std::string& fname,
-                                    Teuchos::RCP<Thyra_MultiVector>& contentVec,
-                                    const Teuchos::RCP<const Thyra_VectorSpace>& vs,
-                                    std::vector<double>& normalizedLayersCoords,
-                                    const Teuchos::RCP<const Teuchos_Comm>& comm) const;
+  // Compute a field from a string expression
+  Teuchos::RCP<Thyra_MultiVector>
+  computeField (const std::string& field_name,
+                const Teuchos::ParameterList& params,
+                const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
+                const std::vector<stk::mesh::Entity>& entities,
+                bool node, bool scalar, bool layered,
+                const Teuchos::RCP<Teuchos::FancyOStream> out);
 
   void checkFieldIsInMesh (const std::string& fname, const std::string& ftype) const;
 


### PR DESCRIPTION
Omegah discretization will use these same utils, which had little-to-no dependence on the fact that we were in a STK mesh. I move the utils to `Albany_DiscretizationUtils.hpp`, although they may very well just go into the utility folder, since there's little-to-no mention of the fact that this is related to a mesh.

On mappy, landice tests fail, but I get the same regression values as I get with master, so I am assuming some settings are different on mappy. If approved, I will merge this next week, and if something goes bad with nightlies, fix (or revert) the next day.