### PR TITLE
Moved STK field container members to AbstractMeshFieldAccessor

### DIFF
--- a/src/disc/Albany_AbstractMeshFieldAccessor.hpp
+++ b/src/disc/Albany_AbstractMeshFieldAccessor.hpp
@@ -27,11 +27,16 @@ namespace Albany {
 class AbstractMeshFieldAccessor
 {
 public:
+  using ValueState               = std::vector<std::string>;
+  using MeshScalarState          = std::map<std::string, double>;
+  using MeshVectorState          = std::map<std::string, std::vector<double>>;
+  using MeshScalarIntegerState   = std::map<std::string, int>;
+  using MeshScalarInteger64State = std::map<std::string, GO>;
+  using MeshVectorIntegerState   = std::map<std::string, std::vector<int>>;
 
   using dof_mgr_ptr_t = Teuchos::RCP<const DOFManager>;
   using mv_ptr_t      = Teuchos::RCP<const Thyra_MultiVector>;
 
-  //! Destructor
   virtual ~AbstractMeshFieldAccessor () = default;
 
   // Add states to mesh (and possibly to nodal_sis/nodal_parameter_sis)
@@ -89,9 +94,25 @@ public:
                                     const mv_ptr_t&          soln_dxdp,
                                     const dof_mgr_ptr_t&     node_vs,
                                     const bool          overlapped) = 0;
+
+  ValueState&         getScalarValueStates () { return scalarValue_states; }
+  MeshScalarState&    getMeshScalarStates  () { return mesh_scalar_states; }
+  MeshVectorState&    getMeshVectorStates  () { return mesh_vector_states; }
+
+  MeshScalarIntegerState&   getMeshScalarIntegerStates   () { return mesh_scalar_integer_states;    }
+  MeshScalarInteger64State& getMeshScalarInteger64States () { return mesh_scalar_integer_64_states; }
+  MeshVectorIntegerState&   getMeshVectorIntegerStates   () { return mesh_vector_integer_states;    }
+
 protected:
   StateInfoStruct nodal_sis;
   StateInfoStruct nodal_parameter_sis;
+
+  ValueState                scalarValue_states;
+  MeshScalarState           mesh_scalar_states;
+  MeshVectorState           mesh_vector_states;
+  MeshScalarIntegerState    mesh_scalar_integer_states;
+  MeshScalarInteger64State  mesh_scalar_integer_64_states;
+  MeshVectorIntegerState    mesh_vector_integer_states;
 };
 
 }  // namespace Albany

--- a/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_AbstractSTKFieldContainer.hpp
@@ -26,14 +26,7 @@ public:
   // STK int field
   using STKIntState  = stk::mesh::Field<int>;
 
-  using ValueState = std::vector<const std::string*>;
   using STKState   = std::vector<STKFieldType*>;
-
-  using MeshScalarState          = std::map<std::string, double>;
-  using MeshVectorState          = std::map<std::string, std::vector<double>>;
-  using MeshScalarIntegerState   = std::map<std::string, int>;
-  using MeshScalarInteger64State = std::map<std::string, GO>;
-  using MeshVectorIntegerState   = std::map<std::string, std::vector<int>>;
 
   AbstractSTKFieldContainer (bool solutionFieldContainer_) : solutionFieldContainer(solutionFieldContainer_) {}
 
@@ -69,36 +62,6 @@ public:
     return proc_rank_field;
   }
 
-  ValueState&
-  getScalarValueStates()
-  {
-    return scalarValue_states;
-  }
-  MeshScalarState&
-  getMeshScalarStates()
-  {
-    return mesh_scalar_states;
-  }
-  MeshVectorState&
-  getMeshVectorStates()
-  {
-    return mesh_vector_states;
-  }
-  MeshScalarIntegerState&
-  getMeshScalarIntegerStates()
-  {
-    return mesh_scalar_integer_states;
-  }
-  MeshScalarInteger64State&
-  getMeshScalarInteger64States()
-  {
-    return mesh_scalar_integer_64_states;
-  }
-  MeshVectorIntegerState&
-  getMeshVectorIntegerStates()
-  {
-    return mesh_vector_integer_states;
-  }
   STKState&
   getCellScalarStates()
   {
@@ -146,12 +109,6 @@ protected:
   STKFieldType*    coordinates_field   = nullptr;
   STKIntState*     proc_rank_field     = nullptr;
 
-  ValueState                scalarValue_states;
-  MeshScalarState           mesh_scalar_states;
-  MeshVectorState           mesh_vector_states;
-  MeshScalarIntegerState    mesh_scalar_integer_states;
-  MeshScalarInteger64State  mesh_scalar_integer_64_states;
-  MeshVectorIntegerState    mesh_vector_integer_states;
   STKState                  cell_scalar_states;
   STKState                  cell_vector_states;
   STKState                  cell_tensor_states;

--- a/src/disc/stk/Albany_GenericSTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_GenericSTKFieldContainer.cpp
@@ -76,12 +76,10 @@ inline Ioss::Field::RoleType role_type(const bool output) {
 #endif
 
 void GenericSTKFieldContainer::
-addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
+addStateStructs(const Teuchos::RCP<StateInfoStruct>& sis)
 {
   if (sis==Teuchos::null)
     return;
-
-  using namespace Albany;
 
   // Code to parse the vector of StateStructs and create STK fields
   for(std::size_t i = 0; i < sis->size(); i++) {
@@ -169,7 +167,7 @@ addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis)
     } // end QuadPoint
     // Single scalar at center of the workset
     else if(dim.size() == 1 && st.entity == StateStruct::WorksetValue) { // A single value that applies over the entire workset (time)
-      scalarValue_states.push_back(&st.name); // Just save a pointer to the name allocated in st
+      scalarValue_states.push_back(st.name); // Just save a pointer to the name allocated in st
     } // End scalar at center of element
     else if((st.entity == StateStruct::NodalData) ||(st.entity == StateStruct::NodalDataToElemNode) || (st.entity == StateStruct::NodalDistParameter))
     { // Data at the node points

--- a/src/disc/stk/Albany_GenericSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_GenericSTKFieldContainer.hpp
@@ -41,7 +41,7 @@ public:
   virtual ~GenericSTKFieldContainer() = default;
 
   // Add StateStructs to the list of stored ones
-  void addStateStructs(const Teuchos::RCP<Albany::StateInfoStruct>& sis);
+  void addStateStructs(const Teuchos::RCP<StateInfoStruct>& sis);
 
   Teuchos::RCP<Teuchos::ParameterList> getParams() const {return params; }
 

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -6,7 +6,6 @@
 
 #include "Albany_DiscretizationFactory.hpp"
 #include "Albany_GenericSTKMeshStruct.hpp"
-#include "Albany_SideSetSTKMeshStruct.hpp"
 #include <Albany_STKNodeSharing.hpp>
 #include <Albany_ThyraUtils.hpp>
 #include <Albany_CombineAndScatterManager.hpp>
@@ -128,11 +127,12 @@ setFieldData (const Teuchos::RCP<const Teuchos_Comm>& comm,
   // Build the usual Albany fields unless the user explicitly specifies the residual or solution vector layout
   if(user_specified_solution_components && (residual_vector.length() > 0)){
     this->fieldContainer = Teuchos::rcp(new MultiSTKFieldContainer(params,
-        metaData, bulkData, numDim, sis, num_params));
+        metaData, bulkData, numDim, num_params));
   } else {
     this->fieldContainer = Teuchos::rcp(new OrdinarySTKFieldContainer(params,
-        metaData, bulkData, numDim, sis, num_params));
+        metaData, bulkData, numDim, num_params));
   }
+  fieldContainer->addStateStructs(sis);
 
 // Exodus is only for 2D and 3D. Have 1D version as well
   exoOutput = params->isType<std::string>("Exodus Output File Name");

--- a/src/disc/stk/Albany_MultiSTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_MultiSTKFieldContainer.cpp
@@ -41,7 +41,6 @@ MultiSTKFieldContainer::MultiSTKFieldContainer(
     const Teuchos::RCP<stk::mesh::MetaData>&      metaData_,
     const Teuchos::RCP<stk::mesh::BulkData>&      bulkData_,
     const int                                     numDim_,
-    const Teuchos::RCP<Albany::StateInfoStruct>&  sis,
     const int                                     num_params_)
     : GenericSTKFieldContainer(
           params_,
@@ -82,8 +81,6 @@ MultiSTKFieldContainer::MultiSTKFieldContainer(
   }
 
   initializeProcRankField();
-
-  this->addStateStructs(sis);
 }
 
 MultiSTKFieldContainer::MultiSTKFieldContainer(
@@ -92,7 +89,6 @@ MultiSTKFieldContainer::MultiSTKFieldContainer(
     const Teuchos::RCP<stk::mesh::BulkData>&           bulkData_,
     const int                                          neq_,
     const int                                          numDim_,
-    const Teuchos::RCP<StateInfoStruct>&               /* sis */,
     const Teuchos::Array<Teuchos::Array<std::string>>& solution_vector,
     const int                                          num_params_)
     : GenericSTKFieldContainer(

--- a/src/disc/stk/Albany_MultiSTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_MultiSTKFieldContainer.hpp
@@ -20,7 +20,6 @@ public:
       const Teuchos::RCP<stk::mesh::MetaData>&        metaData_,
       const Teuchos::RCP<stk::mesh::BulkData>&        bulkData_,
       const int                                       numDim_,
-      const Teuchos::RCP<Albany::StateInfoStruct>&    sis,
       const int                                       num_params);
  
   MultiSTKFieldContainer(
@@ -29,7 +28,6 @@ public:
       const Teuchos::RCP<stk::mesh::BulkData>&              bulkData_,
       const int                                             neq_,
       const int                                             numDim_,
-      const Teuchos::RCP<Albany::StateInfoStruct>&          sis,
       const Teuchos::Array<Teuchos::Array<std::string>>&    solution_vector,
       const int                                             num_params);
 

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.cpp
@@ -45,7 +45,6 @@ OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
     const Teuchos::RCP<stk::mesh::MetaData>&                  metaData_,
     const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
     const int                                                 numDim_,
-    const Teuchos::RCP<Albany::StateInfoStruct>&              sis,
     const int                                                 num_params_)
     : GenericSTKFieldContainer(
           params_,
@@ -87,8 +86,6 @@ OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
   }
 
   initializeProcRankField();
-
-  this->addStateStructs(sis);
 }
 
 OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
@@ -97,7 +94,6 @@ OrdinarySTKFieldContainer::OrdinarySTKFieldContainer(
     const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
     const int                                                 neq_,
     const int                                                 numDim_,
-    const Teuchos::RCP<StateInfoStruct>&                      /* sis */,
     const int                                                 num_params_)
     : GenericSTKFieldContainer(
           params_,

--- a/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
+++ b/src/disc/stk/Albany_OrdinarySTKFieldContainer.hpp
@@ -19,7 +19,6 @@ class OrdinarySTKFieldContainer : public GenericSTKFieldContainer
       const Teuchos::RCP<stk::mesh::MetaData>&                  metaData_,
       const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
       const int                                                 numDim_,
-      const Teuchos::RCP<Albany::StateInfoStruct>&              sis,
       const int                                                 num_params);
 
   OrdinarySTKFieldContainer(
@@ -28,7 +27,6 @@ class OrdinarySTKFieldContainer : public GenericSTKFieldContainer
       const Teuchos::RCP<stk::mesh::BulkData>&                  bulkData_,
       const int                                                 neq_,
       const int                                                 numDim_,
-      const Teuchos::RCP<Albany::StateInfoStruct>&              sis,
       const int                                                 num_params);
 
   ~OrdinarySTKFieldContainer() = default;


### PR DESCRIPTION
They will be used by Omegah as well.

Also, removed StateInfoStruct from STK field containers constructors. Simply call `addStateStructs(sis)` after construction (avoids the clumsy unused arg in the solution-type consturctor).