### PR TITLE
Reworked implementation of writeSolution methods in disc classes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,7 @@ list (APPEND HEADERS
 
 #discretization
 list (APPEND SOURCES
+  disc/Albany_AbstractDiscretization.cpp
   disc/Albany_DiscretizationFactory.cpp
   disc/Albany_MeshSpecs.cpp
   disc/Albany_DOFManager.cpp

--- a/src/disc/Albany_AbstractDiscretization.cpp
+++ b/src/disc/Albany_AbstractDiscretization.cpp
@@ -1,0 +1,53 @@
+#include "Albany_AbstractDiscretization.hpp"
+
+namespace Albany
+{
+
+void AbstractDiscretization::
+writeSolution (const Thyra_Vector& soln,
+               const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+               const double        time,
+               const bool          overlapped,
+               const bool          force_write_solution)
+{
+  writeSolutionToMeshDatabase(soln, soln_dxdp, overlapped);
+  writeMeshDatabaseToFile(time, force_write_solution);
+}
+
+void AbstractDiscretization::
+writeSolution (const Thyra_Vector& soln,
+               const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+               const Thyra_Vector& soln_dot,
+               const double        time,
+               const bool          overlapped,
+               const bool          force_write_solution)
+{
+  writeSolutionToMeshDatabase(soln, soln_dxdp, soln_dot, overlapped);
+  writeMeshDatabaseToFile(time, force_write_solution);
+}
+
+void AbstractDiscretization::
+writeSolution (const Thyra_Vector& soln,
+               const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+               const Thyra_Vector& soln_dot,
+               const Thyra_Vector& soln_dotdot,
+               const double        time,
+               const bool          overlapped,
+               const bool          force_write_solution)
+{
+  writeSolutionToMeshDatabase(soln, soln_dxdp, soln_dot, soln_dotdot, overlapped);
+  writeMeshDatabaseToFile(time, force_write_solution);
+}
+
+void AbstractDiscretization::
+writeSolutionMV (const Thyra_MultiVector& soln,
+                 const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
+                 const double             time,
+                 const bool               overlapped,
+                 const bool               force_write_solution)
+{
+  writeSolutionMVToMeshDatabase(soln, soln_dxdp, overlapped);
+  writeMeshDatabaseToFile(time, force_write_solution);
+}
+
+} // namepace Albany

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -30,8 +30,8 @@ public:
   using conn_mgr_ptr_t = Teuchos::RCP<Albany::ConnManager>;
   using dof_mgr_ptr_t  = Teuchos::RCP<Albany::DOFManager>;
 
-  static const char* solution_dof_name () { return "ordinary_solution"; }
-  static const char* nodes_dof_name    () { return "mesh_nodes"; }
+  static std::string solution_dof_name () { return "ordinary_solution"; }
+  static std::string nodes_dof_name    () { return "mesh_nodes"; }
 
   //! Constructor
   AbstractDiscretization() = default;

--- a/src/disc/Albany_AbstractDiscretization.hpp
+++ b/src/disc/Albany_AbstractDiscretization.hpp
@@ -317,80 +317,51 @@ public:
 
   // --- Methods to write solution in the output file --- //
 
-  //! Write the solution to the output file. Calls next two together.
-  virtual void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false) = 0; 
-  virtual void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false) = 0; 
-  virtual void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false) = 0; 
-  virtual void
-  writeSolutionMV(
-      const Thyra_MultiVector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double             time,
-      const bool               overlapped = false,
-      const bool               force_write_solution = false) = 0; 
+  //! All these overloads call a corresponding overload of writeSolutionToMeshDatabase and writeMeshDatabaseToFile
+  void writeSolution(const Thyra_Vector& solution,
+                     const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                     const double        time,
+                     const bool          overlapped = false,
+                     const bool          force_write_solution = false);
+  void writeSolution (const Thyra_Vector& solution,
+                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                      const Thyra_Vector& solution_dot,
+                      const double        time,
+                      const bool          overlapped = false,
+                      const bool          force_write_solution = false);
+  void writeSolution (const Thyra_Vector& solution,
+                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                      const Thyra_Vector& solution_dot,
+                      const Thyra_Vector& solution_dotdot,
+                      const double        time,
+                      const bool          overlapped = false,
+                      const bool          force_write_solution = false);
+  virtual void writeSolutionMV (const Thyra_MultiVector& solution,
+                                const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                const double             time,
+                                const bool               overlapped = false,
+                                const bool               force_write_solution = false);
+
   //! Write the solution to the mesh database.
-  virtual void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double        time,
-      const bool          overlapped = false) = 0;
-  virtual void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const double        time,
-      const bool          overlapped = false) = 0;
-  virtual void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const double        time,
-      const bool          overlapped = false) = 0;
-  virtual void
-  writeSolutionMVToMeshDatabase(
-      const Thyra_MultiVector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double             time,
-      const bool               overlapped = false) = 0;
+  virtual void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                            const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                            const bool          overlapped) = 0;
+  virtual void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                            const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                            const Thyra_Vector& solution_dot,
+                                            const bool          overlapped) = 0;
+  virtual void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                            const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                            const Thyra_Vector& solution_dot,
+                                            const Thyra_Vector& solution_dotdot,
+                                            const bool          overlapped) = 0;
+  virtual void writeSolutionMVToMeshDatabase (const Thyra_MultiVector& solution,
+                                              const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                              const bool               overlapped) = 0;
 
   //! Write the solution to file. Must call writeSolution first.
-  virtual void
-  writeSolutionToFile(
-      const Thyra_Vector& solution,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false) = 0; 
-  virtual void
-  writeSolutionMVToFile(
-      const Thyra_MultiVector& solution,
-      const double             time,
-      const bool               overlapped = false,
-      const bool               force_write_solution = false) = 0; 
+  virtual void writeMeshDatabaseToFile (const double time,
+                                        const bool   force_write_solution) = 0;
 
   // Check if mesh adaptation is needed, and if so what kind (topological or just mesh-movement)
   virtual Teuchos::RCP<AdaptationData>

--- a/src/disc/Albany_ExtrudedDiscretization.cpp
+++ b/src/disc/Albany_ExtrudedDiscretization.cpp
@@ -87,60 +87,9 @@ ExtrudedDiscretization::setupMLCoords()
 }
 
 void
-ExtrudedDiscretization::writeSolution(
-    const Thyra_Vector& /* soln */,
-    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const double        /* time */,
-    const bool          /* overlapped */,
-    const bool          /* force_write_solution */)
-{
-  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
-  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
-}
-
-void
-ExtrudedDiscretization::writeSolution(
-    const Thyra_Vector& /* soln */,
-    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const Thyra_Vector& /* soln_dot */,
-    const double        /* time */,
-    const bool          /* overlapped */,
-    const bool          /* force_write_solution */)
-{
-  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
-  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
-}
-
-void
-ExtrudedDiscretization::writeSolution(
-    const Thyra_Vector& /* soln */,
-    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const Thyra_Vector& /* soln_dot */,
-    const Thyra_Vector& /* soln_dotdot */,
-    const double        /* time */,
-    const bool          /* overlapped */,
-    const bool          /* force_write_solution */)
-{
-  printf("WARNING ExtrudedDiscretization::writeSolution not yet implemented\n");
-  // throw NotYetImplemented("ExtrudedDiscretization::writeSolution");
-}
-
-void
-ExtrudedDiscretization::writeSolutionMV(
-    const Thyra_MultiVector& /* soln */,
-    const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const double             /* time */,
-    const bool               /* overlapped */,
-    const bool               /* force_write_solution */)
-{
-  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionMV");
-}
-
-void
 ExtrudedDiscretization::writeSolutionToMeshDatabase(
     const Thyra_Vector& /* soln */,
     const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const double /* time */,
     const bool /* overlapped */)
 {
   throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
@@ -151,7 +100,6 @@ ExtrudedDiscretization::writeSolutionToMeshDatabase(
     const Thyra_Vector& /* soln */,
     const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
     const Thyra_Vector& /* soln_dot */,
-    const double /* time */,
     const bool /* overlapped */)
 {
   throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
@@ -163,7 +111,6 @@ ExtrudedDiscretization::writeSolutionToMeshDatabase(
     const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
     const Thyra_Vector& /* soln_dot */,
     const Thyra_Vector& /* soln_dotdot */,
-    const double /* time */,
     const bool /* overlapped */)
 {
   throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
@@ -173,30 +120,17 @@ void
 ExtrudedDiscretization::writeSolutionMVToMeshDatabase(
     const Thyra_MultiVector& /* soln */,
     const Teuchos::RCP<const Thyra_MultiVector>& /* soln_dxdp */,
-    const double /* time */,
     const bool /* overlapped */)
 {
   throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToMeshDatabase");
 }
 
 void
-ExtrudedDiscretization::writeSolutionToFile(
-    const Thyra_Vector& /* soln */,
+ExtrudedDiscretization::writeMeshDatabaseToFile(
     const double        /* time */,
-    const bool          /* overlapped */,
     const bool          /* force_write_solution */)
 {
   throw NotYetImplemented("ExtrudedDiscretization::writeSolutionToFile");
-}
-
-void
-ExtrudedDiscretization::writeSolutionMVToFile(
-    const Thyra_MultiVector& /* soln */,
-    const double             /* time */,
-    const bool               /* overlapped */,
-    const bool               /* force_write_solution */)
-{
-  throw NotYetImplemented("ExtrudedDiscretization::writeSolutionMVToFile");
 }
 
 Teuchos::RCP<AdaptationData>

--- a/src/disc/Albany_ExtrudedDiscretization.hpp
+++ b/src/disc/Albany_ExtrudedDiscretization.hpp
@@ -116,61 +116,26 @@ public:
 
   // --- Methods to write solution in the output file --- //
 
-  void writeSolution (const Thyra_Vector& solution,
-                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                      const double        time,
-                      const bool          overlapped = false,
-                      const bool          force_write_solution = false) override; 
-  void writeSolution (const Thyra_Vector& solution,
-                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                      const Thyra_Vector& solution_dot,
-                      const double        time,
-                      const bool          overlapped = false,
-                      const bool          force_write_solution = false) override; 
-  void writeSolution (const Thyra_Vector& solution,
-                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                      const Thyra_Vector& solution_dot,
-                      const Thyra_Vector& solution_dotdot,
-                      const double        time,
-                      const bool          overlapped = false,
-                      const bool          force_write_solution = false) override; 
-  void writeSolutionMV (const Thyra_MultiVector& solution,
-                        const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                        const double             time,
-                        const bool               overlapped = false,
-                        const bool               force_write_solution = false) override; 
-
   //! Write the solution to the mesh database.
   void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
                                     const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                                    const double /* time */,
-                                    const bool overlapped = false) override;
+                                    const bool overlapped) override;
   void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
                                     const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
                                     const Thyra_Vector& solution_dot,
-                                    const double /* time */,
-                                    const bool overlapped = false) override;
+                                    const bool overlapped) override;
   void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
                                     const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
                                     const Thyra_Vector& solution_dot,
                                     const Thyra_Vector& solution_dotdot,
-                                    const double /* time */,
-                                    const bool overlapped = false) override;
+                                    const bool overlapped) override;
   void writeSolutionMVToMeshDatabase (const Thyra_MultiVector& solution,
                                       const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-                                      const double /* time */,
-                                      const bool overlapped = false) override;
+                                      const bool overlapped) override;
 
   //! Write the solution to file. Must call writeSolution first.
-  void writeSolutionToFile (const Thyra_Vector& solution,
-                            const double        time,
-                            const bool          overlapped = false,
-                            const bool          force_write_solution = false) override; 
-
-  void writeSolutionMVToFile (const Thyra_MultiVector& solution,
-                              const double             time,
-                              const bool               overlapped = false,
-                              const bool               force_write_solution = false) override; 
+  void writeMeshDatabaseToFile (const double        time,
+                                const bool          force_write_solution) override;
 
   Teuchos::RCP<AdaptationData>
   checkForAdaptation (const Teuchos::RCP<const Thyra_Vector>& solution,

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -304,4 +304,77 @@ create_dof_mgr (const std::string& field_name,
   return dof_mgr;
 }
 
+void OmegahDiscretization::
+writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                             const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                             const bool          overlapped)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (solution_dxdp != Teuchos::null, std::runtime_error,
+      "OmegahDiscretization::writeSolutionToMeshDatabase does not support writing sensitivities yet.");
+
+  const auto& dof_mgr = getDOFManager();
+  auto field_accessor = m_mesh_struct->get_field_accessor();
+  field_accessor->saveVector(solution, solution_dof_name(), dof_mgr, overlapped);
+}
+
+void OmegahDiscretization::
+writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                             const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                             const Thyra_Vector& solution_dot,
+                             const bool          overlapped)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (solution_dxdp != Teuchos::null, std::runtime_error,
+      "OmegahDiscretization::writeSolutionToMeshDatabase does not support writing sensitivities yet.");
+
+  const auto& dof_mgr = getDOFManager();
+  auto field_accessor = m_mesh_struct->get_field_accessor();
+  field_accessor->saveVector(solution,     solution_dof_name(),          dof_mgr, overlapped);
+  field_accessor->saveVector(solution_dot, solution_dof_name() + "_dot", dof_mgr, overlapped);
+}
+
+void OmegahDiscretization::
+writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                             const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                             const Thyra_Vector& solution_dot,
+                             const Thyra_Vector& solution_dotdot,
+                             const bool          overlapped)
+{
+  TEUCHOS_TEST_FOR_EXCEPTION (solution_dxdp != Teuchos::null, std::runtime_error,
+      "OmegahDiscretization::writeSolutionToMeshDatabase does not support writing sensitivities yet.");
+
+  const auto& dof_mgr = getDOFManager();
+  auto field_accessor = m_mesh_struct->get_field_accessor();
+  field_accessor->saveVector(solution,        solution_dof_name(),             dof_mgr, overlapped);
+  field_accessor->saveVector(solution_dot,    solution_dof_name() + "_dot",    dof_mgr, overlapped);
+  field_accessor->saveVector(solution_dotdot, solution_dof_name() + "_dotdot", dof_mgr, overlapped);
+}
+
+void OmegahDiscretization::
+writeSolutionMVToMeshDatabase (const Thyra_MultiVector& solution,
+                               const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                               const bool               overlapped)
+{
+  switch (m_num_time_deriv) {
+    case 0:
+      writeSolutionToMeshDatabase(*solution.col(0),solution_dxdp,overlapped);
+      break;
+    case 1:
+      writeSolutionToMeshDatabase(*solution.col(0),solution_dxdp,*solution.col(1),overlapped);
+      break;
+    case 2:
+      writeSolutionToMeshDatabase(*solution.col(0),solution_dxdp,*solution.col(1),*solution.col(2),overlapped);
+      break;
+    default:
+      throw std::runtime_error("Unexpected value for m_num_time_deriv:" + std::to_string(m_num_time_deriv) + "\n");
+  }
+}
+
+//! Write the solution to file. Must call writeSolution first.
+void OmegahDiscretization::
+writeMeshDatabaseToFile (const double /* time */,
+                         const bool   force_write_solution)
+{
+  throw NotYetImplemented("OmegahDiscretization::writeMeshDatabaseToFile");
+}
+
 }  // namespace Albany

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -147,45 +147,28 @@ public:
   void setFieldData(const Teuchos::RCP<StateInfoStruct>& sis) override;
 
   //! Write the solution to the mesh database.
-  void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const bool          /* overlapped */) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
-  }
-  void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const Thyra_Vector& /* solution_dot */,
-      const bool          /* overlapped */) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
-  }
-  void
-  writeSolutionToMeshDatabase(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const Thyra_Vector& /* solution_dot */,
-      const Thyra_Vector& /* solution_dotdot */,
-      const bool          /* overlapped */) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
-  }
-  void
-  writeSolutionMVToMeshDatabase(
-      const Thyra_MultiVector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const bool               /* overlapped */) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
-  }
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const bool          overlapped) override;
 
-  //! Write the solution to file. Must call writeSolution first.
-  void
-  writeMeshDatabaseToFile(
-      const double        /* time */,
-      const bool          /* force_write_solution */) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
-  }
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const Thyra_Vector& solution_dot,
+                                    const bool          overlapped) override;
+
+  void writeSolutionToMeshDatabase (const Thyra_Vector& solution,
+                                    const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                    const Thyra_Vector& solution_dot,
+                                    const Thyra_Vector& solution_dotdot,
+                                    const bool          overlapped) override;
+
+  void writeSolutionMVToMeshDatabase (const Thyra_MultiVector& solution,
+                                      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
+                                      const bool               overlapped) override;
+
+  //! Write the current mesh database to file
+  void writeMeshDatabaseToFile (const double time,
+                                const bool   force_write_solution) override;
 
   Teuchos::RCP<AdaptationData>
   checkForAdaptation (const Teuchos::RCP<const Thyra_Vector>& /* solution */,

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -146,55 +146,12 @@ public:
 
   void setFieldData(const Teuchos::RCP<StateInfoStruct>& sis) override;
 
-  // --- Methods to write solution in the output file --- //
-
-  //! Write the solution to the output file. Calls next two together.
-  void
-  writeSolution(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false,
-      const bool          /* force_write_solution */ = false) override {
-    std::cout << "WARNING! This call to OmegahDiscretization::writeSolution does nothing.\n";
-  } 
-  void
-  writeSolution(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const Thyra_Vector& /* solution_dot */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false,
-      const bool          /* force_write_solution */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolution");
-  } 
-  void
-  writeSolution(
-      const Thyra_Vector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const Thyra_Vector& /* solution_dot */,
-      const Thyra_Vector& /* solution_dotdot */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false,
-      const bool          /* force_write_solution */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolution");
-  } 
-  void
-  writeSolutionMV(
-      const Thyra_MultiVector& /* solution */,
-      const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const double             /* time */,
-      const bool               /* overlapped */ = false,
-      const bool               /* force_write_solution */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionMV");
-  } 
   //! Write the solution to the mesh database.
   void
   writeSolutionToMeshDatabase(
       const Thyra_Vector& /* solution */,
       const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false) override {
+      const bool          /* overlapped */) override {
     TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
   }
   void
@@ -202,8 +159,7 @@ public:
       const Thyra_Vector& /* solution */,
       const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
       const Thyra_Vector& /* solution_dot */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false) override {
+      const bool          /* overlapped */) override {
     TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
   }
   void
@@ -212,36 +168,24 @@ public:
       const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
       const Thyra_Vector& /* solution_dot */,
       const Thyra_Vector& /* solution_dotdot */,
-      const double        /* time */,
-      const bool          /* overlapped */ = false) override {
+      const bool          /* overlapped */) override {
     TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
   }
   void
   writeSolutionMVToMeshDatabase(
       const Thyra_MultiVector& /* solution */,
       const Teuchos::RCP<const Thyra_MultiVector>& /* solution_dxdp */,
-      const double             /* time */,
-      const bool               /* overlapped */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionMVToMeshDatabase");
+      const bool               /* overlapped */) override {
+    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
   }
 
   //! Write the solution to file. Must call writeSolution first.
   void
-  writeSolutionToFile(
-      const Thyra_Vector& /* solution */,
+  writeMeshDatabaseToFile(
       const double        /* time */,
-      const bool          /* overlapped */ = false,
-      const bool          /* force_write_solution */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToFile");
-  } 
-  void
-  writeSolutionMVToFile(
-      const Thyra_MultiVector& /* solution */,
-      const double             /* time */,
-      const bool               /* overlapped */ = false,
-      const bool               /* force_write_solution */ = false) override {
-    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionMVToFile");
-  } 
+      const bool          /* force_write_solution */) override {
+    TEUCHOS_TEST_FOR_EXCEPTION(true,NotYetImplemented,"OmegahDiscretization::writeSolutionToMeshDatabase");
+  }
 
   Teuchos::RCP<AdaptationData>
   checkForAdaptation (const Teuchos::RCP<const Thyra_Vector>& /* solution */,

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -594,16 +594,13 @@ STKDiscretization::writeCoordsToMatrixMarket() const
 }
 
 void
-STKDiscretization::writeSolution(
+STKDiscretization::writeSolutionToMeshDatabase(
     const Thyra_Vector& soln,
     const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const double        time,
-    const bool          overlapped,
-    const bool          force_write_solution)
+    const bool overlapped)
 {
-  writeSolutionToMeshDatabase(soln, soln_dxdp, time, overlapped);
-  // IKT, FIXME? extend writeSolutionToFile to take in soln_dxdp?
-  writeSolutionToFile(soln, time, overlapped, force_write_solution);
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, dof_mgr, overlapped);
 
   // If any, process side discs as well
   for (auto it : sideSetDiscretizations) {
@@ -618,22 +615,20 @@ STKDiscretization::writeSolution(
       ss_soln_dxdp = Thyra::createMembers(vs,dim);
       P->apply(Thyra::NOTRANS, *soln_dxdp, ss_soln_dxdp.ptr(), 1.0, 0.0);
     }
-    disc->writeSolution(*ss_soln,ss_soln_dxdp,time,overlapped,force_write_solution);
+    disc->writeSolutionToMeshDatabase(*ss_soln,ss_soln_dxdp,overlapped);
   }
 }
 
 void
-STKDiscretization::writeSolution(
+STKDiscretization::writeSolutionToMeshDatabase(
     const Thyra_Vector& soln,
     const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
     const Thyra_Vector& soln_dot,
-    const double        time,
-    const bool          overlapped,
-    const bool          force_write_solution)
+    const bool overlapped)
 {
-  writeSolutionToMeshDatabase(soln, soln_dxdp, soln_dot, time, overlapped);
-  // IKT, FIXME? extend writeSolutionToFile to take in soln_dot and/or soln_dxdp?
-  writeSolutionToFile(soln, time, overlapped, force_write_solution);
+  // Put solution into STK Mesh
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, dof_mgr, overlapped);
 
   // If any, process side discs as well
   for (auto it : sideSetDiscretizations) {
@@ -650,23 +645,21 @@ STKDiscretization::writeSolution(
       ss_soln_dxdp = Thyra::createMembers(vs,dim);
       P->apply(Thyra::NOTRANS, *soln_dxdp, ss_soln_dxdp.ptr(), 1.0, 0.0);
     }
-    disc->writeSolution(*ss_soln,ss_soln_dxdp,*ss_soln_dot,time,overlapped,force_write_solution);
+    disc->writeSolutionToMeshDatabase(*ss_soln,ss_soln_dxdp,*ss_soln_dot,overlapped);
   }
 }
 
 void
-STKDiscretization::writeSolution(
+STKDiscretization::writeSolutionToMeshDatabase(
     const Thyra_Vector& soln,
     const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
     const Thyra_Vector& soln_dot,
     const Thyra_Vector& soln_dotdot,
-    const double        time,
-    const bool          overlapped,
-    const bool          force_write_solution)
+    const bool overlapped)
 {
-  writeSolutionToMeshDatabase(soln, soln_dxdp, soln_dot, soln_dotdot, time, overlapped);
-  // IKT, FIXME? extend writeSolutionToFile to take in soln_dot and soln_dotdot?
-  writeSolutionToFile(soln, time, overlapped, force_write_solution);
+  // Put solution into STK Mesh
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, soln_dotdot, dof_mgr, overlapped);
 
   // If any, process side discs as well
   for (auto it : sideSetDiscretizations) {
@@ -685,21 +678,19 @@ STKDiscretization::writeSolution(
       ss_soln_dxdp = Thyra::createMembers(vs,dim);
       P->apply(Thyra::NOTRANS, *soln_dxdp, ss_soln_dxdp.ptr(), 1.0, 0.0);
     }
-    disc->writeSolution(*ss_soln,ss_soln_dxdp,*ss_soln_dot,*ss_soln_dotdot,time,overlapped,force_write_solution);
+    disc->writeSolutionToMeshDatabase(*ss_soln,ss_soln_dxdp,*ss_soln_dot,*ss_soln_dotdot,overlapped);
   }
 }
 
 void
-STKDiscretization::writeSolutionMV(
+STKDiscretization::writeSolutionMVToMeshDatabase(
     const Thyra_MultiVector& soln,
     const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const double             time,
-    const bool               overlapped,
-    const bool               force_write_solution)
+    const bool overlapped)
 {
-  writeSolutionMVToMeshDatabase(soln, soln_dxdp, time, overlapped);
-  // IKT, FIXME? extend writeSolutionToFile to take in soln_dxdp?
-  writeSolutionMVToFile(soln, time, overlapped, force_write_solution);
+  // Put solution into STK Mesh
+  const auto& dof_mgr = getDOFManager();
+  solutionFieldContainer->saveSolnMultiVector(soln, soln_dxdp, dof_mgr, overlapped);
 
   // If any, process side discs as well
   for (auto it : sideSetDiscretizations) {
@@ -714,69 +705,17 @@ STKDiscretization::writeSolutionMV(
       ss_soln_dxdp = Thyra::createMembers(vs,dim);
       P->apply(Thyra::NOTRANS, *soln_dxdp, ss_soln_dxdp.ptr(), 1.0, 0.0);
     }
-    disc->writeSolutionMV(*ss_soln,ss_soln_dxdp,time,overlapped,force_write_solution);
+    disc->writeSolutionMVToMeshDatabase(*ss_soln,ss_soln_dxdp,overlapped);
   }
 }
 
 void
-STKDiscretization::writeSolutionToMeshDatabase(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const double /* time */,
-    const bool overlapped)
-{
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::writeSolutionToMeshDatabase(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const Thyra_Vector& soln_dot,
-    const double /* time */,
-    const bool overlapped)
-{
-  // Put solution into STK Mesh
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::writeSolutionToMeshDatabase(
-    const Thyra_Vector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const Thyra_Vector& soln_dot,
-    const Thyra_Vector& soln_dotdot,
-    const double /* time */,
-    const bool overlapped)
-{
-  // Put solution into STK Mesh
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnVector(soln, soln_dxdp, soln_dot, soln_dotdot, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::writeSolutionMVToMeshDatabase(
-    const Thyra_MultiVector& soln,
-    const Teuchos::RCP<const Thyra_MultiVector>& soln_dxdp,
-    const double /* time */,
-    const bool overlapped)
-{
-  // Put solution into STK Mesh
-  const auto& dof_mgr = getDOFManager();
-  solutionFieldContainer->saveSolnMultiVector(soln, soln_dxdp, dof_mgr, overlapped);
-}
-
-void
-STKDiscretization::writeSolutionToFile(
-    const Thyra_Vector& soln,
+STKDiscretization::writeMeshDatabaseToFile(
     const double        time,
-    const bool          overlapped,
     const bool          force_write_solution)
 {
 #ifdef ALBANY_DISABLE_OUTPUT_MESH
-  *out << "[STKDiscretization::writeSolutionToFile] ALBANY_DISABLE_OUTPUT_MESH=TRUE. Skip.\n";
+  *out << "[STKDiscretization::writeMeshDatabaseToFile] ALBANY_DISABLE_OUTPUT_MESH=TRUE. Skip.\n";
   (void) time;
   (void) force_write_solution;
 #else
@@ -814,69 +753,7 @@ STKDiscretization::writeSolutionToFile(
     mesh_data->end_output_step(outputFileIdx);
 
     if (comm->getRank() == 0) {
-      *out << "STKDiscretization::writeSolutionToFile: writing time " << time;
-      if (time_label != time) *out << " with label " << time_label;
-      *out << " to index " << out_step << " in file "
-           << stkMeshStruct->exoOutFile << std::endl;
-    }
-  }
-  outputInterval++;
-#endif
-#endif
-  (void) soln;
-  (void) overlapped;
-}
-
-void
-STKDiscretization::writeSolutionMVToFile(
-    const Thyra_MultiVector& soln,
-    const double             time,
-    const bool               overlapped,
-    const bool               force_write_solution)
-{
-#ifdef ALBANY_DISABLE_OUTPUT_MESH
-  *out << "[STKDiscretization::writeSolutionMVToFile] ALBANY_DISABLE_OUTPUT_MESH=TRUE. Skip.\n";
-  (void) time;
-  (void) soln;
-  (void) overlapped;
-  (void) force_write_solution;
-#else
-#ifdef ALBANY_SEACAS
-  TEUCHOS_FUNC_TIME_MONITOR("Albany: write solution MV to file");
-
-  if (stkMeshStruct->exoOutput && stkMeshStruct->transferSolutionToCoords) {
-    solutionFieldContainer->transferSolutionToCoords();
-
-    if (!mesh_data.is_null()) {
-      // Mesh coordinates have changed. Rewrite output file by deleting the mesh
-      // data object and recreate it
-      setupExodusOutput();
-    }
-  }
-
-  // Skip this write unless the proper interval has been reached
-  if ((stkMeshStruct->exoOutput &&
-      !(outputInterval % stkMeshStruct->exoOutputInterval)) ||
-      (force_write_solution == true) ) {
-    double time_label = monotonicTimeLabel(time);
-
-    mesh_data->begin_output_step(outputFileIdx, time_label);
-    int out_step = mesh_data->write_defined_output_fields(outputFileIdx);
-    // Writing mesh global variables
-    auto fc = stkMeshStruct->getFieldContainer();
-    for (auto& it : fc->getMeshVectorStates()) {
-      mesh_data->write_global(outputFileIdx, it.first, it.second);
-    }
-    for (const auto& it : fc->getMeshScalarIntegerStates()) {
-      mesh_data->write_global(outputFileIdx, it.first, it.second);
-    }
-    for (const auto& it : fc->getMeshScalarInteger64States()) {
-      mesh_data->write_global(outputFileIdx, it.first, static_cast<int64_t>(it.second), stk::util::ParameterType::INT64);
-    }
-    mesh_data->end_output_step(outputFileIdx);
-
-    if (comm->getRank() == 0) {
-      *out << "STKDiscretization::writeSolutionMVToFile: writing time " << time;
+      *out << "STKDiscretization::writeMeshDatabaseToFile: writing time " << time;
       if (time_label != time) *out << " with label " << time_label;
       *out << " to index " << out_step << " in file "
            << stkMeshStruct->exoOutFile << std::endl;
@@ -885,19 +762,7 @@ STKDiscretization::writeSolutionMVToFile(
   outputInterval++;
 
   for (auto it : sideSetDiscretizations) {
-    if (overlapped) {
-      auto ss_soln = Thyra::createMembers(
-          it.second->getOverlapVectorSpace(), soln.domain()->dim());
-      const Thyra_LinearOp& P = *ov_projectors.at(it.first);
-      P.apply(Thyra::NOTRANS, soln, ss_soln.ptr(), 1.0, 0.0);
-      it.second->writeSolutionMVToFile(*ss_soln, time, overlapped, force_write_solution);
-    } else {
-      auto ss_soln = Thyra::createMembers(
-          it.second->getVectorSpace(), soln.domain()->dim());
-      const Thyra_LinearOp& P = *projectors.at(it.first);
-      P.apply(Thyra::NOTRANS, soln, ss_soln.ptr(), 1.0, 0.0);
-      it.second->writeSolutionMVToFile(*ss_soln, time, overlapped, force_write_solution);
-    }
+    it.second->writeMeshDatabaseToFile(time, force_write_solution);
   }
 #endif
 #endif
@@ -2544,7 +2409,7 @@ adapt (const Teuchos::RCP<AdaptationData>& adaptData)
     }
   }
 
-  writeSolutionMVToMeshDatabase(*x_mv_new, Teuchos::null, 0, false);
+  writeSolutionMVToMeshDatabase(*x_mv_new, Teuchos::null, false);
 }
 
 }  // namespace Albany

--- a/src/disc/stk/Albany_STKDiscretization.hpp
+++ b/src/disc/stk/Albany_STKDiscretization.hpp
@@ -208,82 +208,36 @@ public:
       const std::string&  field_name,
       const bool          overlapped = false);
 
-  // --- Methods to write solution in the output file --- //
-
-  void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false); 
-  void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false); 
-  void
-  writeSolution(
-      const Thyra_Vector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const Thyra_Vector& solution_dot,
-      const Thyra_Vector& solution_dotdot,
-      const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false); 
-  void
-  writeSolutionMV(
-      const Thyra_MultiVector& solution,
-      const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double             time,
-      const bool               overlapped = false,
-      const bool               force_write_solution = false); 
-
   //! Write the solution to the mesh database.
   void
   writeSolutionToMeshDatabase(
       const Thyra_Vector& solution,
       const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double /* time */,
-      const bool overlapped = false);
+      const bool overlapped);
   void
   writeSolutionToMeshDatabase(
       const Thyra_Vector& solution,
       const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
       const Thyra_Vector& solution_dot,
-      const double /* time */,
-      const bool overlapped = false);
+      const bool overlapped);
   void
   writeSolutionToMeshDatabase(
       const Thyra_Vector& solution,
       const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
       const Thyra_Vector& solution_dot,
       const Thyra_Vector& solution_dotdot,
-      const double /* time */,
-      const bool overlapped = false);
+      const bool overlapped);
   void
   writeSolutionMVToMeshDatabase(
       const Thyra_MultiVector& solution,
       const Teuchos::RCP<const Thyra_MultiVector>& solution_dxdp,
-      const double /* time */,
-      const bool overlapped = false);
+      const bool overlapped);
 
   //! Write the solution to file. Must call writeSolution first.
   void
-  writeSolutionToFile(
-      const Thyra_Vector& solution,
+  writeMeshDatabaseToFile(
       const double        time,
-      const bool          overlapped = false,
-      const bool          force_write_solution = false); 
-  void
-  writeSolutionMVToFile(
-      const Thyra_MultiVector& solution,
-      const double             time,
-      const bool               overlapped = false,
-      const bool               force_write_solution = false); 
+      const bool          force_write_solution) override;
 
   Teuchos::RCP<AdaptationData>
   checkForAdaptation (const Teuchos::RCP<const Thyra_Vector>& solution,


### PR DESCRIPTION
Changes summary:

- Renamed writeSolutionToFile as writeMeshDatabaseToFile
- Implement writeSolution by calling writeSolutionToMeshDatabase followed by writeMeshDatabaseToFile in base class
- Removed time arg in writeSolutionToMeshDatabase (it's only needed when writing to file)
- Removed overlapped arg in writeMeshDatabaseToFile (it's only needed when writing to the mesh db)
- Removed defaults in virtual methods (not a good practice)
- Add _some_ impl for omegah disc