### PR TITLE
Adding AlbanyLaunchBounds to control Kokkos Launch Bounds configurations for GPU kernel optimization

### DIFF
--- a/src/landIce/evaluators/LandIce_StokesFOResid.hpp
+++ b/src/landIce/evaluators/LandIce_StokesFOResid.hpp
@@ -14,6 +14,7 @@
 
 #include "Albany_Layouts.hpp"
 #include "PHAL_Dimension.hpp"
+#include "Albany_KokkosUtils.hpp"
 
 namespace LandIce {
 /** \brief Finite Element Interpolation Evaluator
@@ -77,8 +78,8 @@ public:
   struct POISSON_2D_Tag{};
 
   typedef Kokkos::RangePolicy<ExecutionSpace,LandIce_3D_Tag> LandIce_3D_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,LandIce_3D_Opt_Tag<8>> LandIce_3D_Opt_Hex_Policy;
-  typedef Kokkos::RangePolicy<ExecutionSpace,LandIce_3D_Opt_Tag<6>> LandIce_3D_Opt_Wedge_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace,KU::AlbanyLaunchBounds,LandIce_3D_Opt_Tag<8>> LandIce_3D_Opt_Hex_Policy;
+  typedef Kokkos::RangePolicy<ExecutionSpace,KU::AlbanyLaunchBounds,LandIce_3D_Opt_Tag<6>> LandIce_3D_Opt_Wedge_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace,POISSON_3D_Tag> POISSON_3D_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace,LandIce_2D_Tag> LandIce_2D_Policy;
   typedef Kokkos::RangePolicy<ExecutionSpace,LandIce_XZ_2D_Tag> LandIce_XZ_2D_Policy;

--- a/src/utility/Albany_KokkosUtils.hpp
+++ b/src/utility/Albany_KokkosUtils.hpp
@@ -97,6 +97,12 @@ atomic_add(D dst, const V& val)
   KU::AtomicAddImpl<ExeSpace, D, V>::atomic_add(dst, val);
 }
 
+#ifdef KOKKOS_ENABLE_CUDA
+typedef Kokkos::LaunchBounds<> AlbanyLaunchBounds;
+#else
+typedef Kokkos::LaunchBounds<128,2> AlbanyLaunchBounds;
+#endif
+
 }
 
 #endif // ALBANY_KOKKOS_UTILS_HPP


### PR DESCRIPTION
By adding AlbanyLaunchBounds, we can control the default behavior of Kokkos launchbounds for AMD GPUs. 
We found that by using  Kokkos::LaunchBounds<128,2> on AMD MI250X GPUs, we could improve performance of the StokesFOResid<Jacobian> kernel by 1.54x