### PR TITLE
Fix ISMIP tests mesh modification

### DIFF
--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -1321,41 +1321,33 @@ STKDiscretization::computeWorksetInfo()
         }
         for (std::size_t i = 0; i < buckets[b]->size(); i++) {
           int  nodes_per_element = buckets[b]->num_nodes(i);
-          bool anyXeqZero        = false;
-          for (int j = 0; j < nodes_per_element; j++)
-            if (m_ws_elem_coords[b][i][j][d] == 0.0) anyXeqZero = true;
-          if (anyXeqZero) {
-            bool flipZeroToScale = false;
-            for (int j = 0; j < nodes_per_element; j++)
-              if (m_ws_elem_coords[b][i][j][d] > stkMeshStruct->PBCStruct.scale[d] / 1.9)
-                flipZeroToScale = true;
-            if (flipZeroToScale) {
-              for (int j = 0; j < nodes_per_element; j++) {
-                if (m_ws_elem_coords[b][i][j][d] == 0.0) {
-                  double* xleak = new double[stkMeshStruct->numDim];
-                  for (int k = 0; k < stkMeshStruct->numDim; k++)
-                    if (k == d)
-                      xleak[d] = stkMeshStruct->PBCStruct.scale[d];
-                    else
-                      xleak[k] = m_ws_elem_coords[b][i][j][k];
-                  std::string transformType = stkMeshStruct->transformType;
-                  double      alpha         = stkMeshStruct->felixAlpha;
-                  alpha *= M_PI / 180.;  // convert alpha, read in from
-                                       // ParameterList, to radians
-                  if ((transformType == "ISMIP-HOM Test A" ||
-                       transformType == "ISMIP-HOM Test B" ||
-                       transformType == "ISMIP-HOM Test C" ||
-                       transformType == "ISMIP-HOM Test D") &&
-                      d == 0) {
-                    xleak[2] -= stkMeshStruct->PBCStruct.scale[d] * tan(alpha);
-                    if (has_sheight) {
-                      sHeight.host()(i, j) -=
-                          stkMeshStruct->PBCStruct.scale[d] * tan(alpha);
-                    }
-                  }
-                  m_ws_elem_coords[b][i][j] = xleak;  // replace ptr to coords
-                  toDelete.push_back(xleak);
-        }}}}}
+          for (int j = 0; j < nodes_per_element; j++) {
+            if (m_ws_elem_coords[b][i][j][d] == 0.0) {
+              double* xleak = new double[stkMeshStruct->numDim];
+              for (int k = 0; k < stkMeshStruct->numDim; k++)
+                if (k == d)
+                  xleak[d] = stkMeshStruct->PBCStruct.scale[d];
+                else
+                  xleak[k] = m_ws_elem_coords[b][i][j][k];
+              std::string transformType = stkMeshStruct->transformType;
+              double      alpha         = stkMeshStruct->felixAlpha;
+              alpha *= M_PI / 180.;  // convert alpha, read in from
+                                   // ParameterList, to radians
+              if ((transformType == "ISMIP-HOM Test A" ||
+                   transformType == "ISMIP-HOM Test B" ||
+                   transformType == "ISMIP-HOM Test C" ||
+                   transformType == "ISMIP-HOM Test D") &&
+                  d == 0) {
+                xleak[2] -= stkMeshStruct->PBCStruct.scale[d] * tan(alpha);
+                if (has_sheight) {
+                  sHeight.host()(i, j) -= stkMeshStruct->PBCStruct.scale[d] * tan(alpha);
+                }
+              }
+              m_ws_elem_coords[b][i][j] = xleak;  // replace ptr to coords
+              toDelete.push_back(xleak);
+            }
+          }
+        }
         if (has_sheight) {
           sHeight.sync_to_dev();
         }


### PR DESCRIPTION
I think the current way we modify the mesh in ISMIP tests is not right. This PR aims to fix (and simplify) the logic.

The current implementation, does the following on each element:

- check if any coord is 0 (along the dim where periodic mesh is requested). If none are 0, go to next elem
- If at least 1 coord is 0, check if any coord (along the periodic dim) is larger than the mesh width / 1.9. If not, go to the next elem
- At this point, loop over nodes, and if any node has coord 0 (along the periodic dim) set it equal to the mesh width (meaning the node wraps around). ALSO, subtract the factor x[d]*tan(alpha) to surface height, which makes surf_height match the value it would have gotten when computed (during transformMesh) with the right (meaning periodic) coordinates.

My concern is mostly with step 2: first, what's with 1.9? It's such an arbitrary number. Second, and most important, why flipping the coord (to the other end of the mesh) only if any coord is larger than L/1.9? It makes no sense. We should just set coord[d]=L whenever coord[d]=0.

@mperego @ikalash Maybe I'm missing something here, but I don't know what it is. This block of code is very old (8 years), so the rationale of it may have gotten lost in the cracks.

If we agree on the mods, I will go ahead and modify also the regression tests values. I wanted to check with you guys before doing that.