### PR TITLE
Security: Bound block name parsing to prevent stack overflow (fixes #…

### DIFF
--- a/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
+++ b/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
@@ -468,7 +468,8 @@ EBSpecsStruct<2>::Initialize(int i, const Teuchos::RCP<Teuchos::ParameterList>& 
       "begins at (0, 0) ends at (100, 100) length (1.0, 1.0) named Block0");
 
     // Parse it
-    sscanf(&blkinfo[0], "begins at (%lld,%lld) ends at (%lld,%lld) length (%lf,%lf) named %s",
+  // Bound the name to avoid buffer overflow (buf is size 256)
+  sscanf(&blkinfo[0], "begins at (%lld,%lld) ends at (%lld,%lld) length (%lf,%lf) named %255s",
       &min[0], &min[1], &max[0], &max[1], &blLength[0], &blLength[1], buf);
 
     name = buf;
@@ -494,7 +495,8 @@ EBSpecsStruct<3>::Initialize(int i, const Teuchos::RCP<Teuchos::ParameterList>& 
       "begins at (0, 0, 0) ends at (100, 100, 100) length (1.0, 1.0, 1.0) named Block0");
 
     // Parse it
-    sscanf(&blkinfo[0], "begins at (%lld,%lld,%lld) ends at (%lld,%lld,%lld) length (%lf,%lf,%lf) named %s",
+  // Bound the name to avoid buffer overflow (buf is size 256)
+  sscanf(&blkinfo[0], "begins at (%lld,%lld,%lld) ends at (%lld,%lld,%lld) length (%lf,%lf,%lf) named %255s",
       &min[0], &min[1], &min[2], &max[0], &max[1], &max[2], &blLength[0], &blLength[1], &blLength[2], buf);
 
     name = buf;


### PR DESCRIPTION
…1134)

"Security: Bound block name parsing to prevent overflow" -b "Fixes #1134.

Bound %%s to %%255s in EBSpecsStruct parsing to prevent stack buffer overflow when reading block names from input. Added comments clarifying buffer size and reasoning.

No behavior change besides safe truncation of overlong names.