### PR TITLE
Add Teko/MueLu preconditioner for ALI FO Thermo Coupled problem

### DIFF
--- a/src/Albany_Application.cpp
+++ b/src/Albany_Application.cpp
@@ -28,6 +28,11 @@
 #include "Teuchos_TimeMonitor.hpp"
 #include "Zoltan2_TpetraCrsColorer.hpp"
 
+#ifdef ALBANY_TEKO
+#include "Teko_BlockedTpetraOperator.hpp"
+#include "Teko_InverseLibrary.hpp"
+#endif
+
 #include <stdexcept>
 #include <string>
 
@@ -322,13 +327,6 @@ Application::initialSetUp(const RCP<Teuchos::ParameterList>& params)
 
   physicsBasedPreconditioner =
       problemParams->get("Use Physics-Based Preconditioner", false);
-  if (physicsBasedPreconditioner) {
-    precType = problemParams->get("Physics-Based Preconditioner", "Teko");
-#ifdef ALBANY_TEKO
-    if (precType == "Teko")
-      precParams = Teuchos::sublist(problemParams, "Teko", true);
-#endif
-  }
 
   //validate Hessian parameters
   if(problemParams->isSublist("Hessian")) {
@@ -811,6 +809,63 @@ Application::setDynamicLayoutSizes(Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTr
   }
 }
 
+void
+Application::initializePreconditioner()
+{
+  TEUCHOS_ASSERT(physicsBasedPreconditioner);
+  TEUCHOS_FUNC_TIME_MONITOR("Albany: Initialize Preconditioner");
+#ifdef ALBANY_TEKO
+  // Initialize Teko preconditioner operator
+  const auto precParams = problem->getNullSpace()->getPL();
+  const auto invLibParams = Teuchos::sublist(precParams, "Inverse Factory Library", true);
+  const auto linearSolverBuilder = Teuchos::rcp(new Stratimikos::DefaultLinearSolverBuilder);
+  Stratimikos::enableMueLu<ST, LO, Tpetra_GO, KokkosNode>(*linearSolverBuilder);
+  const auto invLib = Teko::InverseLibrary::buildFromParameterList(*invLibParams, linearSolverBuilder);
+  const auto invFactory = invLib->getInverseFactory("myBlocks");
+  invFactoryOp = Teuchos::rcp(new Teko::TpetraHelpers::InverseFactoryOperator(invFactory));
+  invFactoryOp->initInverse();
+
+  // Read block decomposition
+  std::vector<int> decomp;
+  std::stringstream ss;
+  ss << precParams->get<std::string>("Strided Blocking");
+  while (not ss.eof()) {
+    int num = 0;
+    ss >> num;
+    TEUCHOS_ASSERT(num > 0);
+    decomp.push_back(num);
+  }
+  const int numBlocks = decomp.size();
+  const int numEqns = std::accumulate(decomp.begin(), decomp.end(), 0);
+
+  // Setup blockGIDs_
+  const auto numDofs = Albany::getLocalSubdim(disc->getVectorSpace());
+  TEUCHOS_ASSERT(numDofs % numEqns == 0);
+  const LO numDofsPerEqn = numDofs / numEqns;
+  blockGIDs_.resize(numBlocks);
+  for (int blk = 0; blk < numBlocks; ++blk) {
+    blockGIDs_[blk].resize(decomp[blk] * numDofsPerEqn);
+  }
+
+  // Fill blockGIDs_
+  const auto indexer = Albany::createGlobalLocalIndexer(disc->getVectorSpace());
+  int eqnStride = 0;
+  for (int blk = 0; blk < numBlocks; ++blk) {
+    int numEqnsPerBlock = decomp[blk];
+    for (LO blkLid = 0; blkLid < blockGIDs_[blk].size(); ++blkLid) {
+      const int eqn = (blkLid % numEqnsPerBlock) + eqnStride;
+      const LO lid = (blkLid / numEqnsPerBlock) * numEqns + eqn;
+      blockGIDs_[blk][blkLid] = indexer->getGlobalElement(lid);
+    }
+    eqnStride += numEqnsPerBlock;
+  }
+#else
+  TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
+      "Albany::Application::initializePreconditioner(): Teko is needed for a physics-based preconditioner");
+  return Teuchos::null;
+#endif
+}
+
 RCP<AbstractDiscretization>
 Application::getDiscretization() const
 {
@@ -839,12 +894,6 @@ RCP<Thyra_LinearOp>
 Application::createJacobianOp() const
 {
   return disc->createJacobianOp();
-}
-
-RCP<Thyra_LinearOp>
-Application::getPreconditioner()
-{
-  return Teuchos::null;
 }
 
 RCP<ParamLib>
@@ -1736,6 +1785,31 @@ Application::computeGlobalJacobian(
       countRes++;  // increment residual counter
     }
   }
+}
+
+void
+Application::computeGlobalPreconditioner(
+  const Teuchos::RCP<const Thyra_LinearOp> &jac_lop,
+  Teuchos::RCP<Thyra_Preconditioner> &prec)
+{
+  TEUCHOS_ASSERT(physicsBasedPreconditioner);
+  TEUCHOS_FUNC_TIME_MONITOR("Albany Fill: Preconditioner");
+#ifdef ALBANY_TEKO
+  // Create new BlockedTpetraOperator from Jacobian and rebuild preconditioner
+  TEUCHOS_ASSERT(!blockGIDs_.empty());
+  TEUCHOS_ASSERT(Teuchos::nonnull(invFactoryOp));
+  const auto jac_top = getConstTpetraOperator(jac_lop);
+  const auto jac_blocked_btop = Teuchos::rcp(new Teko::TpetraHelpers::BlockedTpetraOperator(blockGIDs_, jac_top));
+  const auto jac_blocked_top = Teuchos::rcp_dynamic_cast<Tpetra_Operator>(jac_blocked_btop);
+  invFactoryOp->rebuildInverseOperator(jac_blocked_top);
+  const auto invFactoryOpT = Teuchos::rcp_dynamic_cast<Tpetra_Operator>(invFactoryOp);
+  const auto precOp = Thyra::createLinearOp(invFactoryOpT);
+  const auto defaultPrec = Teuchos::rcp_dynamic_cast<Thyra::DefaultPreconditioner<ST>>(prec);
+  defaultPrec->initializeRight(precOp);
+#else
+  TEUCHOS_TEST_FOR_EXCEPTION(true, Teuchos::Exceptions::InvalidParameter,
+      "Albany::Application::computeGlobalPreconditioner(): Teko is needed for a physics-based preconditioner");
+#endif
 }
 
 void

--- a/src/Albany_Application.hpp
+++ b/src/Albany_Application.hpp
@@ -33,6 +33,10 @@
 #include "Teuchos_TimeMonitor.hpp"
 #include "Teuchos_VerboseObject.hpp"
 
+#ifdef ALBANY_TEKO
+#include "Teko_TpetraInverseFactoryOperator.hpp"
+#endif
+
 #include <set>
 
 namespace Albany {
@@ -74,6 +78,9 @@ public:
   void
   setDynamicLayoutSizes(Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>& in_fm) const;
 
+  void
+  initializePreconditioner();
+
   //! Get underlying abstract discretization
   Teuchos::RCP<Albany::AbstractDiscretization>
   getDiscretization() const;
@@ -93,10 +100,6 @@ public:
   //! Create Jacobian operator
   Teuchos::RCP<Thyra_LinearOp>
   createJacobianOp() const;
-
-  //! Get Preconditioner Operator
-  Teuchos::RCP<Thyra_LinearOp>
-  getPreconditioner();
 
   bool
   observeResponses() const
@@ -270,6 +273,10 @@ public:
   /*!
    * Set xdot to NULL for steady-state problems
    */
+  void computeGlobalPreconditioner(
+    const Teuchos::RCP<const Thyra_LinearOp> &jac,
+    Teuchos::RCP<Thyra_Preconditioner> &prec
+  );
 
   void
   computeGlobalTangent(
@@ -1195,9 +1202,11 @@ void
   Teuchos::Array<Teuchos::RCP<PHX::FieldManager<PHAL::AlbanyTraits>>> sfm;
 
   //! Data for Physics-Based Preconditioners
-  bool                                 physicsBasedPreconditioner;
-  Teuchos::RCP<Teuchos::ParameterList> precParams;
-  std::string                          precType;
+  bool physicsBasedPreconditioner;
+#ifdef ALBANY_TEKO
+  std::vector<std::vector<GO>> blockGIDs_;
+  Teuchos::RCP<Teko::TpetraHelpers::InverseFactoryOperator> invFactoryOp;
+#endif
 
   //! Type of solution method
   SolutionMethodType solMethod;

--- a/src/Albany_ModelEvaluator.hpp
+++ b/src/Albany_ModelEvaluator.hpp
@@ -127,7 +127,7 @@ public:
   //! Sacado parameter vector
   mutable Teuchos::Array<ParamVec> sacado_param_vec;
 
-  //! Allocated Jacobian for sending to user preconditioner
+  //! Jacobian for sending to user preconditioner
   mutable Teuchos::RCP<Thyra_LinearOp> Extra_W_op;
 
   //! Whether the problem supplies its own preconditioner

--- a/src/Albany_NullSpaceUtils.hpp
+++ b/src/Albany_NullSpaceUtils.hpp
@@ -30,6 +30,9 @@ public:
   //! Update the parameter list.
   void updatePL(const Teuchos::RCP<Teuchos::ParameterList>& precParams);
 
+  //! Is Teko used on this problem?
+  bool isTekoUsed() const { return tekoUsed; }
+
   //! Is MueLu used on this problem?
   bool isMueLuUsed() const { return mueLuUsed; }
 
@@ -50,20 +53,23 @@ public:
   //! Pass only the coordinates.
   void setCoordinates(const Teuchos::RCP<Thyra_MultiVector> &coordMV);
 
+  //! Get the preconditioner parameter list
+  Teuchos::RCP<Teuchos::ParameterList> getPL() const { return plist; }
+
 private:
   int numPDEs;
   bool computeConstantModes; //translations
   int physVectorDim;
   bool computeRotationModes;
   int nullSpaceDim;
-  bool mueLuUsed, froschUsed, setNonElastRBM;
+  bool tekoUsed, mueLuUsed, froschUsed, setNonElastRBM;
   bool areProbParametersSet, arePiroParametersSet;
 
   Teuchos::RCP<Teuchos::ParameterList> plist;
 
   Teuchos::RCP<Thyra_MultiVector> coordMV;
 
-  Teuchos::RCP<TraitsImplBase> nullSpaceTraits;
+  std::vector<Teuchos::RCP<TraitsImplBase>> nullSpaceTraits;
 };
 
 } // namespace Albany

--- a/src/Albany_ThyraTypes.hpp
+++ b/src/Albany_ThyraTypes.hpp
@@ -26,7 +26,6 @@
 #include "Thyra_BlockedLinearOpBase.hpp"
 #include "Thyra_PhysicallyBlockedLinearOpBase.hpp"
 #include "Thyra_BlockedLinearOpWithSolveBase.hpp"
-//#include "Thyra_BlockedLinearOpWithSolveFactoryBase.hpp"
 
 // Spmd Thyra types
 #include "Thyra_SpmdVectorSpaceBase.hpp"

--- a/src/disc/extruded/Albany_ExtrudedDiscretization.cpp
+++ b/src/disc/extruded/Albany_ExtrudedDiscretization.cpp
@@ -53,7 +53,7 @@ ExtrudedDiscretization::setupMLCoords()
 {
   TEUCHOS_FUNC_TIME_MONITOR("ExtrudedDiscretization: setupMLCoords");
   if (m_rigid_body_modes.is_null()) { return; }
-  if (!m_rigid_body_modes->isMueLuUsed() && !m_rigid_body_modes->isFROSchUsed()) { return; }
+  if (!m_rigid_body_modes->isTekoUsed() && !m_rigid_body_modes->isMueLuUsed() && !m_rigid_body_modes->isFROSchUsed()) { return; }
 
   const int numDim = getNumDim();
   auto coordMV = Thyra::createMembers(getNodeVectorSpace(), numDim);

--- a/src/disc/stk/Albany_STKDiscretization.cpp
+++ b/src/disc/stk/Albany_STKDiscretization.cpp
@@ -528,7 +528,7 @@ STKDiscretization::setupMLCoords()
 {
   TEUCHOS_FUNC_TIME_MONITOR("STKDiscretization: setupMLCoords");
   if (rigidBodyModes.is_null()) { return; }
-  if (!rigidBodyModes->isMueLuUsed() && !rigidBodyModes->isFROSchUsed()) { return; }
+  if (!rigidBodyModes->isTekoUsed() && !rigidBodyModes->isMueLuUsed() && !rigidBodyModes->isFROSchUsed()) { return; }
 
   const int                                   numDim = stkMeshStruct->numDim;
   AbstractSTKFieldContainer::STKFieldType* coordinates_field =
@@ -576,19 +576,10 @@ STKDiscretization::writeCoordsToMatrixMarket() const
 #else
   // if user wants to write the coordinates to matrix market file, write them to
   // matrix market file
-  if ((rigidBodyModes->isMueLuUsed() || rigidBodyModes->isFROSchUsed()) &&
+  if ((rigidBodyModes->isTekoUsed() || rigidBodyModes->isMueLuUsed() || rigidBodyModes->isFROSchUsed()) &&
       stkMeshStruct->writeCoordsToMMFile) {
-    if (comm->getRank() == 0) {
-      std::cout << "Writing mesh coordinates to Matrix Market file."
-                << std::endl;
-    }
-    writeMatrixMarket(coordMV->col(0), "xCoords");
-    if (coordMV->domain()->dim() > 1) {
-      writeMatrixMarket(coordMV->col(1), "yCoords");
-    }
-    if (coordMV->domain()->dim() > 2) {
-      writeMatrixMarket(coordMV->col(2), "zCoords");
-    }
+    *out << "Writing mesh coordinates to Matrix Market file." << std::endl;
+    writeMatrixMarket(coordMV, "coords");
   }
 #endif
 }

--- a/tests/landIce/FO_Thermo/CMakeLists.txt
+++ b/tests/landIce/FO_Thermo/CMakeLists.txt
@@ -104,8 +104,17 @@ if (ALBANY_FROSCH)
     set_tests_properties(${testNameRoot}_Humboldt_lubricated
       PROPERTIES FIXTURES_REQUIRED humboldtMeshSetup2d)
   endif()
+endif()
 
+if (ALBANY_MUELU AND ALBANY_TEKO)
+  # Copy input file from source to binary dir
+  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_FO_Thermo_wet_bed_test_teko.yaml
+                 ${CMAKE_CURRENT_BINARY_DIR}/input_FO_Thermo_wet_bed_test_teko.yaml)
 
+  # Create the tests
+  set (testName ${testNameRoot}_Wet_Bed_Teko)
+  add_test(${testName} ${Albany.exe} input_FO_Thermo_wet_bed_test_teko.yaml)
+  set_tests_properties(${testName} PROPERTIES LABELS "LandIce;Forward")
 endif()
 
 if(${PYTHON_TEST})

--- a/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_teko.yaml
+++ b/tests/landIce/FO_Thermo/input_FO_Thermo_wet_bed_test_teko.yaml
@@ -1,0 +1,517 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Debug Output:
+    Write Jacobian to MatrixMarket: -1
+  Problem:
+    Phalanx Graph Visualization Detail: 2
+    Solution Method: Steady
+    Compute Sensitivities: true
+    Name: LandIce Stokes FO Thermo Coupled 3D
+    Basal Side Name: basalside
+    Flat Bed Approximation: true
+    Cubature Degree: 4
+    Basal Cubature Degree: 4
+    Needs Dissipation: true
+    Needs Basal Friction: true
+    Dirichlet BCs:
+      DBC on NS top for DOF Enth prescribe Field: surface_enthalpy
+      DBC on NS bottom for DOF U1: 0.0
+      DBC on NS lateral for DOF U1: 0.0
+    LandIce BCs:
+      Number: 1
+      BC 0:
+        Type: Basal Friction
+        Side Set Name: basalside
+        Basal Friction Coefficient:
+          Type: Field
+          Beta Field Name: basal_friction
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Type: Scalar
+        Name: Glen's Law Homotopy Parameter
+    LandIce Viscosity:
+      Extract Strain Rate Sq: true
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.4e+00
+      Continuous Homotopy With Constant Initial Viscosity: true
+      Coefficient For Continuous Homotopy: 8.0
+      Glen's Law A: 2.400304414e-24     # [ Pa^-3 s^-1 ]
+      Glen's Law n: 3.0
+      Flow Rate Type: Temperature Based
+    LandIce Physical Parameters:
+      Conductivity of ice: 2.1
+      Diffusivity temperate ice: 1.1e-08
+      Heat capacity of ice: 2009.0
+      Water Density: 1000.0
+      Ice Density: 916.0
+      Gravity Acceleration: 9.8
+      Reference Temperature: 2.65e+02
+      Clausius-Clapeyron Coefficient: 7.9e-08
+      Ice Latent Heat Of Fusion: 3.34e+05
+      Permeability factor: 1.0e-12
+      Viscosity of water: 1.8e-03
+      Omega exponent alpha: 2.0e+00
+      Diffusivity homotopy exponent: -1.1e+00
+    LandIce Enthalpy:
+      Regularization:
+        Flux Regularization:
+          alpha: 1.0e-01
+          beta: 7.5
+        Basal Melting Regularization:
+          alpha: 2.0085537
+          beta: 4.0
+      Stabilization:
+        Type: Streamline Upwind
+        Parameter Delta: 2.0
+      Bed Lubrication:
+        Type: Wet
+    Body Force:
+      Type: FO INTERP SURF GRAD
+    Response Functions:
+      Number Of Responses: 1
+      Response 0:
+        Type: Scalar Response
+        Name: Solution Average
+    Use Physics-Based Preconditioner: true
+    LandIce Rigid Body Modes For Preconditioner:
+      Compute Constant Modes: true
+      Compute Rotation Modes: true
+  Discretization:
+    Workset Size: -1
+    Method: STKExtruded
+    Number Of Time Derivatives: 0
+    Exodus Output File Name: enth_coupled.exo
+    Columnwise Ordering: true
+    NumLayers: 10
+    Thickness Field Name: ice_thickness
+    Extrude Basal Node Fields: [ice_thickness, surface_height, basal_friction, surface_air_temperature]
+    Basal Node Fields Ranks: [1, 1, 1, 1, 1]
+    Use Glimmer Spacing: true
+    Required Fields Info:
+      Number Of Fields: 5
+      Field 0:
+        Field Name: ice_thickness
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 1:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 2:
+        Field Name: basal_friction
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 3:
+        Field Name: surface_air_temperature
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 4:
+        Field Name: surface_enthalpy
+        Field Type: Node Scalar
+        Field Usage: Output
+    Side Set Discretizations:
+      Side Sets: [basalside]
+      basalside:
+        Workset Size: -1
+        Method: Exodus
+        Number Of Time Derivatives: 0
+        Exodus Input File Name: ../ExoMeshes/slab_2d.exo
+        Use Serial Mesh: ${USE_SERIAL_MESH}
+        Required Fields Info:
+          Number Of Fields: 5
+          Field 0:
+            Field Name: basal_friction
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Enthalpy/Dome/basal_friction.ascii
+          Field 1:
+            Field Name: ice_thickness
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Enthalpy/Dome/thickness.ascii
+          Field 2:
+            Field Name: surface_height
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Enthalpy/Dome/surface_height.ascii
+          Field 3:
+            Field Name: surface_air_temperature
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Enthalpy/Dome/surface_air_temperature.ascii
+          Field 4:
+            Field Name: heat_flux
+            Field Type: Node Scalar
+            Field Origin: File
+            File Name: ../AsciiMeshes/Enthalpy/Dome/basal_heat_flux.ascii
+  Piro:
+    Sensitivity Method: Adjoint
+    Enable Explicit Matrix Transpose: true
+    LOCA:
+      Bifurcation: {}
+      Constraints: {}
+      Predictor:
+        Method: Constant
+      Stepper:
+        Initial Value: 0.0
+        Continuation Parameter: Glen's Law Homotopy Parameter
+        Continuation Method: Natural
+        Max Steps: 100
+        Max Value: 4.0e-01
+        Min Value: 0.0
+      Step Size:
+        Initial Step Size: 1.0e-01
+        Max Step Size: 1.0e-01
+    NOX:
+      Thyra Group Options:
+        Function Scaling: None
+        Update Row Sum Scaling: Before Each Nonlinear Solve
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: AND
+          Number of Tests: 1
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Scaled
+            Tolerance: 1.0e-08
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 100
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-7  # used for forward solves
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: {}
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Convergence Tolerance: 1.0e-7  # used for adjoint solve
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+                  VerboseObject:
+                    Verbosity Level: low
+              Preconditioner Type: Teko
+              Preconditioner Types:
+                Teko:
+                  Inverse Type: myBlocks
+                  Strided Blocking: "2 1 1"
+                  Inverse Factory Library:
+                    myBlocks:
+                      Type: Block Gauss-Seidel
+                      Use Upper Triangle: true
+                      Inverse Type 1: myMueLuUV
+                      Inverse Type 2: myMueLuT
+                      Inverse Type 3: myMueLuT
+                    myMueLuUV:
+                      Type: MueLu
+                      Matrix: 
+                        PDE equations: 2
+                      Factories: 
+                        myLineDetectionFact: 
+                          factory: LineDetectionFactory
+                          'linedetection: orientation': coordinates
+                        mySemiCoarsenPFact1: 
+                          factory: SemiCoarsenPFactory
+                          'semicoarsen: coarsen rate': 14
+                        UncoupledAggregationFact2: 
+                          factory: UncoupledAggregationFactory
+                          'aggregation: ordering': graph
+                          'aggregation: max selected neighbors': 0
+                          'aggregation: min agg size': 3
+                          'aggregation: phase3 avoid singletons': true
+                        MyCoarseMap2: 
+                          factory: CoarseMapFactory
+                          Aggregates: UncoupledAggregationFact2
+                        myTentativePFact2: 
+                          'tentative: calculate qr': true
+                          factory: TentativePFactory
+                          Aggregates: UncoupledAggregationFact2
+                          CoarseMap: MyCoarseMap2
+                        mySaPFact2: 
+                          'sa: eigenvalue estimate num iterations': 10
+                          'sa: damping factor': 1.33333
+                          factory: SaPFactory
+                          P: myTentativePFact2
+                        myTransferCoordinatesFact: 
+                          factory: CoordinatesTransferFactory
+                          CoarseMap: MyCoarseMap2
+                          Aggregates: UncoupledAggregationFact2
+                        myTogglePFact: 
+                          factory: TogglePFactory
+                          'semicoarsen: number of levels': 2
+                          TransferFactories: 
+                            P1: mySemiCoarsenPFact1
+                            P2: mySaPFact2
+                            Ptent1: mySemiCoarsenPFact1
+                            Ptent2: myTentativePFact2
+                            Nullspace1: mySemiCoarsenPFact1
+                            Nullspace2: myTentativePFact2
+                        myRestrictorFact: 
+                          factory: TransPFactory
+                          P: myTogglePFact
+                        myToggleTransferCoordinatesFact: 
+                          factory: ToggleCoordinatesTransferFactory
+                          Chosen P: myTogglePFact
+                          TransferFactories: 
+                            Coordinates1: mySemiCoarsenPFact1
+                            Coordinates2: myTransferCoordinatesFact
+                        myRAPFact: 
+                          factory: RAPFactory
+                          P: myTogglePFact
+                          R: myRestrictorFact
+                          TransferFactories: 
+                            For Coordinates: myToggleTransferCoordinatesFact
+                        myRepartitionHeuristicFact: 
+                          factory: RepartitionHeuristicFactory
+                          A: myRAPFact
+                          'repartition: min rows per proc': 3000
+                          'repartition: max imbalance': 1.327
+                          'repartition: start level': 3
+                        myZoltanInterface: 
+                          factory: ZoltanInterface
+                          A: myRAPFact
+                          Coordinates: myToggleTransferCoordinatesFact
+                          number of partitions: myRepartitionHeuristicFact
+                        myRepartitionFact: 
+                          factory: RepartitionFactory
+                          A: myRAPFact
+                          Partition: myZoltanInterface
+                          'repartition: remap parts': true
+                          number of partitions: myRepartitionHeuristicFact
+                        myRebalanceProlongatorFact: 
+                          factory: RebalanceTransferFactory
+                          type: Interpolation
+                          P: myTogglePFact
+                          Coordinates: myToggleTransferCoordinatesFact
+                          Nullspace: myTogglePFact
+                        myRebalanceRestrictionFact: 
+                          factory: RebalanceTransferFactory
+                          type: Restriction
+                          R: myRestrictorFact
+                        myRebalanceAFact: 
+                          factory: RebalanceAcFactory
+                          A: myRAPFact
+                          TransferFactories: { }
+                        mySmoother1:
+                          factory: TrilinosSmoother
+                          type: LINESMOOTHING_BANDEDRELAXATION
+                          'smoother: pre or post': both
+                          ParameterList:
+                            'relaxation: type': Gauss-Seidel
+                            'relaxation: sweeps': 1
+                            'relaxation: damping factor': 1.0
+                        mySmoother4:
+                          factory: TrilinosSmoother
+                          type: RELAXATION
+                          'smoother: pre or post': pre
+                          ParameterList:
+                            'relaxation: type': Gauss-Seidel
+                            'relaxation: sweeps': 4
+                            'relaxation: damping factor': 1.0
+                      Hierarchy:
+                        max levels: 7
+                        'coarse: max size': 200
+                        verbosity: medium
+                        Finest: 
+                          Smoother: mySmoother1
+                          CoarseSolver: mySmoother4
+                          P: myRebalanceProlongatorFact
+                          Nullspace: myRebalanceProlongatorFact
+                          CoarseNumZLayers: myLineDetectionFact
+                          LineDetection_Layers: myLineDetectionFact
+                          LineDetection_VertLineIds: myLineDetectionFact
+                          A: myRebalanceAFact
+                          Coordinates: myRebalanceProlongatorFact
+                          Importer: myRepartitionFact
+                        All: 
+                          startLevel: 1
+                          Smoother: mySmoother4
+                          CoarseSolver: mySmoother4
+                          P: myRebalanceProlongatorFact
+                          Nullspace: myRebalanceProlongatorFact
+                          CoarseNumZLayers: myLineDetectionFact
+                          LineDetection_Layers: myLineDetectionFact
+                          LineDetection_VertLineIds: myLineDetectionFact
+                          A: myRebalanceAFact
+                          Coordinates: myRebalanceProlongatorFact
+                          Importer: myRepartitionFact
+                    myMueLuT:
+                      Type: MueLu
+                      Matrix: 
+                        PDE equations: 1
+                      Factories: 
+                        myLineDetectionFact: 
+                          factory: LineDetectionFactory
+                          'linedetection: orientation': coordinates
+                        mySemiCoarsenPFact1: 
+                          factory: SemiCoarsenPFactory
+                          'semicoarsen: coarsen rate': 14
+                        UncoupledAggregationFact2: 
+                          factory: UncoupledAggregationFactory
+                          'aggregation: ordering': graph
+                          'aggregation: max selected neighbors': 0
+                          'aggregation: min agg size': 3
+                          'aggregation: phase3 avoid singletons': true
+                        MyCoarseMap2: 
+                          factory: CoarseMapFactory
+                          Aggregates: UncoupledAggregationFact2
+                        myTentativePFact2: 
+                          'tentative: calculate qr': true
+                          factory: TentativePFactory
+                          Aggregates: UncoupledAggregationFact2
+                          CoarseMap: MyCoarseMap2
+                        mySaPFact2: 
+                          'sa: eigenvalue estimate num iterations': 10
+                          'sa: damping factor': 1.33333
+                          factory: SaPFactory
+                          P: myTentativePFact2
+                        myTransferCoordinatesFact: 
+                          factory: CoordinatesTransferFactory
+                          CoarseMap: MyCoarseMap2
+                          Aggregates: UncoupledAggregationFact2
+                        myTogglePFact: 
+                          factory: TogglePFactory
+                          'semicoarsen: number of levels': 2
+                          TransferFactories: 
+                            P1: mySemiCoarsenPFact1
+                            P2: mySaPFact2
+                            Ptent1: mySemiCoarsenPFact1
+                            Ptent2: myTentativePFact2
+                            Nullspace1: mySemiCoarsenPFact1
+                            Nullspace2: myTentativePFact2
+                        myRestrictorFact: 
+                          factory: TransPFactory
+                          P: myTogglePFact
+                        myToggleTransferCoordinatesFact: 
+                          factory: ToggleCoordinatesTransferFactory
+                          Chosen P: myTogglePFact
+                          TransferFactories: 
+                            Coordinates1: mySemiCoarsenPFact1
+                            Coordinates2: myTransferCoordinatesFact
+                        myRAPFact: 
+                          factory: RAPFactory
+                          P: myTogglePFact
+                          R: myRestrictorFact
+                          TransferFactories: 
+                            For Coordinates: myToggleTransferCoordinatesFact
+                        myRepartitionHeuristicFact: 
+                          factory: RepartitionHeuristicFactory
+                          A: myRAPFact
+                          'repartition: min rows per proc': 3000
+                          'repartition: max imbalance': 1.327
+                          'repartition: start level': 3
+                        myZoltanInterface: 
+                          factory: ZoltanInterface
+                          A: myRAPFact
+                          Coordinates: myToggleTransferCoordinatesFact
+                          number of partitions: myRepartitionHeuristicFact
+                        myRepartitionFact: 
+                          factory: RepartitionFactory
+                          A: myRAPFact
+                          Partition: myZoltanInterface
+                          'repartition: remap parts': true
+                          number of partitions: myRepartitionHeuristicFact
+                        myRebalanceProlongatorFact: 
+                          factory: RebalanceTransferFactory
+                          type: Interpolation
+                          P: myTogglePFact
+                          Coordinates: myToggleTransferCoordinatesFact
+                          Nullspace: myTogglePFact
+                        myRebalanceRestrictionFact: 
+                          factory: RebalanceTransferFactory
+                          type: Restriction
+                          R: myRestrictorFact
+                        myRebalanceAFact: 
+                          factory: RebalanceAcFactory
+                          A: myRAPFact
+                          TransferFactories: { }
+                        mySmoother1:
+                          factory: TrilinosSmoother
+                          type: LINESMOOTHING_BANDEDRELAXATION
+                          'smoother: pre or post': both
+                          ParameterList:
+                            'relaxation: type': Gauss-Seidel
+                            'relaxation: sweeps': 1
+                            'relaxation: damping factor': 1.0
+                        mySmoother4:
+                          factory: TrilinosSmoother
+                          type: RELAXATION
+                          'smoother: pre or post': pre
+                          ParameterList:
+                            'relaxation: type': Gauss-Seidel
+                            'relaxation: sweeps': 4
+                            'relaxation: damping factor': 1.0
+                      Hierarchy:
+                        max levels: 7
+                        'coarse: max size': 200
+                        verbosity: medium
+                        Finest: 
+                          Smoother: mySmoother1
+                          CoarseSolver: mySmoother4
+                          P: myRebalanceProlongatorFact
+                          Nullspace: myRebalanceProlongatorFact
+                          CoarseNumZLayers: myLineDetectionFact
+                          LineDetection_Layers: myLineDetectionFact
+                          LineDetection_VertLineIds: myLineDetectionFact
+                          A: myRebalanceAFact
+                          Coordinates: myRebalanceProlongatorFact
+                          Importer: myRepartitionFact
+                        All: 
+                          startLevel: 1
+                          Smoother: mySmoother4
+                          CoarseSolver: mySmoother4
+                          P: myRebalanceProlongatorFact
+                          Nullspace: myRebalanceProlongatorFact
+                          CoarseNumZLayers: myLineDetectionFact
+                          LineDetection_Layers: myLineDetectionFact
+                          LineDetection_VertLineIds: myLineDetectionFact
+                          A: myRebalanceAFact
+                          Coordinates: myRebalanceProlongatorFact
+                          Importer: myRepartitionFact
+          Rescue Bad Newton Solve: true
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Full Step
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+      Solver Options:
+        Status Test Check Type: Minimal
+  Regression For Response 0:
+    Sensitivity For Parameter 0:
+      Test Value: -4.047527788959e-01
+    Test Value: 9.189270361965e-01
+    Relative Tolerance: 1.0e-02
+...


### PR DESCRIPTION
 - add creation of preconditioner inside app using Teko
 - add nullspace creation for Teko/muelu
 - remove some unused preconditioner code from previous implementations
 - add wet bed test
 
Currently this is hard-coded for the ALI FO Thermo coupled problem but it should be easily extensible to other problems. It's enabled with `Use Physics-Based Preconditioner: true` and Teko parameter list (see test problem). It will also add the rotation mode to the nullspace for the velocity block with:
```
    LandIce Rigid Body Modes For Preconditioner:
      Compute Constant Modes: true
      Compute Rotation Modes: true
```