### PR TITLE
Start working on gh CI build for PR testing

### DIFF
--- a/.github/workflows/ghci-gcc-serial.yml
+++ b/.github/workflows/ghci-gcc-serial.yml
@@ -45,16 +45,16 @@ jobs:
         run: |
           mkdir -p ${GITHUB_WORKSPACE}/albany/build && cd ${GITHUB_WORKSPACE}/albany/build
           cmake \
-            -D CMAKE_BUILD_TYPE:STRING=RELEASE                              \
-            -D CMAKE_INSTALL_PREFIX:PATH=${GITHUB_WORKSPACE}/albany/install \
+            -D CMAKE_BUILD_TYPE:STRING=RELEASE                                \
+            -D CMAKE_INSTALL_PREFIX:PATH=${GITHUB_WORKSPACE}/albany/install   \
             \
-            -D ALBANY_TRILINOS_DIR:PATH=${TRILINOS_ROOT}                    \
-            -D ALBANY_MPI_EXEC_MAX_NUMPROCS:STRING=2                        \
-            -D ALBANY_MPI_EXEC_TRAILING_OPTIONS:STRING="--bind-to core"     \
+            -D ALBANY_TRILINOS_DIR:PATH=${TRILINOS_ROOT}                      \
+            -D ALBANY_MPI_EXEC_MAX_NUMPROCS:STRING=4                          \
+            -D ALBANY_MPI_EXEC_TRAILING_OPTIONS:STRING="--bind-to hwthread"   \
             \
-            -D ENABLE_OMEGAH:BOOL=ON                                        \
-            -D ENABLE_DEMO_PDES:BOOL=ON                                     \
-            -D ENABLE_LANDICE:BOOL=ON                                       \
+            -D ENABLE_OMEGAH:BOOL=ON                                          \
+            -D ENABLE_DEMO_PDES:BOOL=ON                                       \
+            -D ENABLE_LANDICE:BOOL=ON                                         \
             \
             -S ${GITHUB_WORKSPACE}/albany/source
       - name: Build Albany


### PR DESCRIPTION
Implement a workflow for testing PRs on GitHub free runners.

Looking at the workflow run, it appears testing took ~45min, which seems like a reasonable amount. Perhaps we can make it a tad faster if we allow 4 MPI ranks in the test phase (I had it set to 2), although the bulk of the time was spent in the build phase...

The CI uses the [albany:gcc-12-serial](https://github.com/orgs/sandialabs/packages/container/package/albany) container, which I built from a recipe in [this](https://github.com/bartgol/albany-containers) repo. I can later move the recipes repo into the sandialabs org.