### PR TITLE
Bump omegah required version

### DIFF
--- a/cmake/GetOrInstallOmegah.cmake
+++ b/cmake/GetOrInstallOmegah.cmake
@@ -1,7 +1,7 @@
 set (tmpStr "Looking for valid Omega_h installation ...")
 message (STATUS ${tmpStr})
 
-find_package(Omega_h 10.8 CONFIG QUIET
+find_package(Omega_h 11.0 CONFIG QUIET
   # Avoid all defaults. Only check env/CMake var Omega_h_ROOT
   NO_CMAKE_PATH
   NO_CMAKE_ENVIRONMENT_PATH


### PR DESCRIPTION
CMake kept rejecting my installation of omegah, until I realized that version 11.X is not compatible with 10.Y (as stated in the generated Omega_hConfigVersion.cmake file).
