### PR TITLE
Revert changes to periodic BCs implementation in PR #1127 and related PR #1145

### DIFF
--- a/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
+++ b/src/disc/stk/Albany_TmplSTKMeshStruct_Def.hpp
@@ -544,6 +544,7 @@ TmplSTKMeshStruct<1>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& comm)
   AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[0] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[0] = true;
       this->PBCStruct.scale[0] = scale[0];
   }
@@ -645,10 +646,12 @@ TmplSTKMeshStruct<2>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& /* comm 
   AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[0] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[0] = true;
       this->PBCStruct.scale[0] = scale[0];
   }
   if (periodic_y) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[1] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[1] = true;
       this->PBCStruct.scale[1] = scale[1];
   }
@@ -887,14 +890,17 @@ TmplSTKMeshStruct<3>::buildMesh(const Teuchos::RCP<const Teuchos_Comm>& comm)
   AbstractSTKFieldContainer::STKFieldType* coordinates_field = fieldContainer->getCoordinatesField();
 
   if (periodic_x) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[0] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[0] = true;
       this->PBCStruct.scale[0] = scale[0];
   }
   if (periodic_y) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[1] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[1] = true;
       this->PBCStruct.scale[1] = scale[1];
   }
   if (periodic_z) {
+      TEUCHOS_TEST_FOR_EXCEPTION(nelem[2] < 3, std::runtime_error, "Error! Implementation of periodic conditions requires at least 3 elements.\n");
       this->PBCStruct.periodic[2] = true;
       this->PBCStruct.scale[2] = scale[2];
   }

--- a/tests/demoPDEs/Advection1D/input_scalar_param_adjoint_sens_explicit.yaml
+++ b/tests/demoPDEs/Advection1D/input_scalar_param_adjoint_sens_explicit.yaml
@@ -102,12 +102,14 @@ ALBANY:
               'fact: ilut level-of-fill': 1.00000000000000000e+00
   Regression For Response 0:
     Absolute Tolerance: 1.00000000000000008e-05
-    Test Value: 2.373564034129
+    Test Value: -9.730072575842e-05
     Sensitivity For Parameter 0:
-      Test Value: 8.448731516750
+      Test Value: 0.0
     Relative Tolerance: 1.00000000000000002e-03
   Regression For Response 1:
     Absolute Tolerance: 1.00000000000000008e-05
-    Test Value: 1.221269731774e+01
+    Test Value: 3.571064945950e+00
+      #Sensitivity For Parameter 0:
+      #Test Value: -1.82404989716553993e-02
     Relative Tolerance: 1.00000000000000002e-03
 ...

--- a/tests/demoPDEs/Advection1D/input_scalar_param_fwd_sens_implicit.yaml
+++ b/tests/demoPDEs/Advection1D/input_scalar_param_fwd_sens_implicit.yaml
@@ -129,14 +129,14 @@ ALBANY:
               'fact: ilut level-of-fill': 1.00000000000000000e+00
   Regression For Response 0:
     Absolute Tolerance: 1.00000000000000008e-05
-    Test Value: 1.221269731774
+    Test Value: 0.0
     Sensitivity For Parameter 0:
-      Test Value: 3.487477458518e-01
+      Test Value: 0.0
     Relative Tolerance: 1.00000000000000002e-03
   Regression For Response 1:
     Absolute Tolerance: 1.00000000000000008e-05
-    Test Value: 3.487477458518e+01
+    Test Value: 3.363119799958e+00
     Sensitivity For Parameter 0:
-      Test Value: 1.768365207875
+      Test Value: -3.362633334361e-02
     Relative Tolerance: 1.00000000000000002e-03
 ...

--- a/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testA.yaml
+++ b/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testA.yaml
@@ -144,12 +144,12 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:  
-    Test Value: 2.154535716628e+01
+    Test Value: 1.50291698407e+01
     Relative Tolerance: 1.0e-04
   Regression For Response 1:
-    Test Value: 1.058705195819e+00
+    Test Value: 1.37379728154e+00
     Relative Tolerance: 1.0e-04
   Regression For Response 2:
-    Test Value: 6.968434466185e+00
+    Test Value: 5.11690906222e+00
     Relative Tolerance: 1.0e-04
 ...

--- a/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testB.yaml
+++ b/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testB.yaml
@@ -142,15 +142,15 @@ ANONYMOUS:
   Regression For Response 0:
     Relative Tolerance: 1.0e-06
     Absolute Tolerance: 1.0e-06
-    Test Value: 1.618727420764e+01
+    Test Value: 1.067962127873e+01
   Regression For Response 1:
     Relative Tolerance: 1.0e-06
     Absolute Tolerance: 1.0e-10
-    Test Value: 2.372857585175e+00
+    Test Value: 0.0
   Regression For Response 2:
     Relative Tolerance: 1.0e-06
     Absolute Tolerance: 1.0e-010
-    Test Value: 4.862116055279e+00
+    Test Value: 3.649614402659e+00
     Sensitivity For Parameter 0:
-      Test Value: -1.155031746880e-05
+      Test Value: -6.431392908894e-05
 ...

--- a/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testC.yaml
+++ b/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testC.yaml
@@ -164,12 +164,12 @@ ANONYMOUS:
       Solver Options:
         Status Test Check Type: Minimal
   Regression For Response 0:  
-    Test Value: 1.712912537154e+01
+    Test Value: 1.59711319233e+01
     Relative Tolerance: 1.0e-04
   Regression For Response 1:
-    Test Value: 1.860418180231e-01
+    Test Value: 6.62994775897e-02
     Relative Tolerance: 1.0e-04
   Regression For Response 2:
-    Test Value: 8.060920597102e+00
+    Test Value: 7.944496494e+00
     Relative Tolerance: 1.0e-04
 ...

--- a/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testD.yaml
+++ b/tests/landIce/FO_ISMIP/input_fo_ismip-hom_testD.yaml
@@ -168,14 +168,14 @@ ANONYMOUS:
         Status Test Check Type: Minimal
   Regression For Response 0:
     Relative Tolerance: 1.0e-06
-    Test Value: 1.727805447634e+01
+    Test Value: 1.624337758025e+01
   Regression For Response 1:
     Absolute Tolerance: 1.0e-10
-    Test Value: 4.285191599946e-01
+    Test Value: 0.0
     Relative Tolerance: 1.0e-06
   Regression For Response 2:
     Relative Tolerance: 1.0e-06
-    Test Value: 8.276731681373e+00
+    Test Value: 8.064113480430e+00
     Sensitivity For Parameter 0:
-      Test Value: -6.689022448775e-02
+      Test Value: -5.681178032868e-02
 ...

--- a/tests/landIce/FO_MMS/input_fo_sincosz.yaml
+++ b/tests/landIce/FO_MMS/input_fo_sincosz.yaml
@@ -36,10 +36,10 @@ ANONYMOUS:
     Method: STK3D
     Exodus Output File Name: felix_stokes_fo_sincosz_out.exo
   Regression For Response 0: 
-    Test Value: 6.026269474671e-01
+    Test Value: 9.86721213035e-02
     Relative Tolerance: 1.0e-04
   Regression For Response 1: 
-    Test Value: 2.034560457726e-01
+    Test Value: 9.86721213035e-02
     Relative Tolerance: 1.0e-04
   Regression For Response 2: 
     Test Value: 0.0

--- a/tests/landIce/SHMIP/input_hewitt.yaml
+++ b/tests/landIce/SHMIP/input_hewitt.yaml
@@ -126,7 +126,7 @@ ANONYMOUS:
         Field Usage: Output
   Regression For Response 0:
     Absolute Tolerance: 1.0e-04
-    Test Value: 2.51058239583
+    Test Value: 1.624674816941e+02
     Relative Tolerance: 1.0e-04
   Piro: 
     LOCA: 


### PR DESCRIPTION
This PR reverts changes to periodic BCs implementation performed in PR #1127 and related PR #1145
- Slightly modified original implementation and added comments and checks.
- Reset original regression values for affected tests. 

Note, the 2d AdvDiff core test has been modified in PR #1150 and no longer uses periodic BCs