### PR TITLE
Add support for landice tests using omegah for the basal mesh

### DIFF
--- a/cmake/GetOrInstallOmegah.cmake
+++ b/cmake/GetOrInstallOmegah.cmake
@@ -54,6 +54,7 @@ else ()
   string(REPLACE "include/kokkos" "" Kokkos_INSTALL_DIR ${Kokkos_INCLUDE_DIR})
   set(Kokkos_PREFIX ${Kokkos_INSTALL_DIR} PATH "Path to Kokkos install")
 
+  option (Omega_h_USE_SEACASExodus "Whether to use SEACASExodus" ON)
   option (Omega_h_USE_Kokkos "Use Kokkos as a backend" ON)
   option (Omega_h_USE_MPI "Use MPI for parallelism" ON)
   set (MPIEXEC_EXECUTABLE ${Albany_CXX_COMPILER})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,6 +103,42 @@ IF (ALBANY_SEACAS)
   MESSAGE("-- SEACAS_EXODIFF = ${SEACAS_EXODIFF}")
 ENDIF()
 
+# Find Omega_h tools if Omega_h is enabled
+if(ALBANY_OMEGAH)
+  if (Omega_h_FOUND)
+    # Get the bin directory from Omega_h installation
+    get_filename_component(Omega_h_BIN_DIR "${Omega_h_DIR}/../../../bin" ABSOLUTE)
+    find_program(
+         OMEGAH_EXO2OSH
+         NAMES exo2osh
+         PATHS ${Omega_h_BIN_DIR} ENV PATH
+    )
+    # Not sure if we need this, but might as well
+    find_program(
+         OMEGAH_OSH2EXO
+         NAMES osh2exo
+         PATHS ${Omega_h_BIN_DIR} ENV PATH
+    )
+    if(NOT OMEGAH_EXO2OSH OR NOT OMEGAH_OSH2EXO)
+      string(CONCAT msg
+        "Omega_h conversion tools (exo2osh or osh2exo) not found in Omega_h bin dir."
+        "Please, reinstall Omega_h with Omega_h_USE_SEACASExodus=ON\n"
+        "  Omega_h_BIN_DIR: ${Omega_h_BIN_DIR}")
+      message(FATAL_ERROR "${msg}")
+    endif()
+  else()
+    set(OMEGAH_EXO2OSH exo2osh)
+    set(OMEGAH_OSH2EXO osh2exo)
+    if (NOT TARGET ${OMEGAH_EXO2OSH} OR NOT TARGET ${OMEGAH_OSH2EXO})
+      string(CONCAT msg
+        "Omega_h conversion tools (exo2osh or osh2exo) not built by Omega_h project"
+        "Please, contact developers\n")
+      message(FATAL_ERROR "${msg}")
+    endif()
+  endif()
+  message("-- OMEGAH_EXO2OSH = ${OMEGAH_EXO2OSH}")
+  message("-- OMEGAH_OSH2EXO = ${OMEGAH_OSH2EXO}")
+endif()
 
 # Paths to the actual executables
 set(AlbanyPath                         ${Albany_BINARY_DIR}/src/Albany)

--- a/tests/landIce/FO_GIS/CMakeLists.txt
+++ b/tests/landIce/FO_GIS/CMakeLists.txt
@@ -130,6 +130,22 @@ if (ALBANY_IFPACK2)
                        FIXTURES_REQUIRED PopulateMesh2d
                        FIXTURES_SETUP ${testName}_extruded)
 
+  if (ALBANY_OMEGAH)
+    add_test (NAME ${testName}_CreateGisOsh
+          COMMAND ${OMEGAH_EXO2OSH} gis_unstruct_2d.exo gis_unstruct_2d.osh
+          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ExoMeshes)
+    set_tests_properties (${testName}_CreateGisOsh PROPERTIES FIXTURES_SETUP CreateGisOshMesh)
+
+    # Logically extruded mesh with omegah for the basal disc
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_unstruct_omegah.yaml
+                   ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_unstruct_omegah.yaml)
+    add_test(${testName}_Omega_h ${Albany.exe} input_fo_gis_unstruct_omegah.yaml)
+    set_tests_properties(${testName}_Omega_h
+                         PROPERTIES
+                         LABELS "LandIce;Forward;Omega_h"
+                         FIXTURES_REQUIRED CreateGisOshMesh)
+  endif()
+
   # Memoization run
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_unstruct_mem.yaml
                  ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_unstruct_mem.yaml)
@@ -162,7 +178,39 @@ if (ALBANY_IFPACK2)
   endif()
 endif()
 
-if (NOT ALBANY_PARALELL_EXODUS)
+#########################################################################
+###     Unstructured GIS with Omega_h for basal mesh (test)          ###
+#########################################################################
+
+if (ALBANY_OMEGAH AND ALBANY_IFPACK2)
+  # Find the exo2osh tool from the Omega_h installation
+  find_program(OMEGAH_EXO2OSH NAMES exo2osh
+    PATHS ${Omega_h_DIR}/bin ${Omega_h_DIR}/../bin NO_DEFAULT_PATH)
+
+  if (OMEGAH_EXO2OSH)
+    set (testName ${testNameRoot}_Unstructured_Omega_h)
+
+    # Fixture: convert the 2d exodus mesh to .osh format (run once)
+    add_test (NAME ${testName}_CreateGisOsh
+        COMMAND ${OMEGAH_EXO2OSH} gis_unstruct_2d.exo gis_unstruct_2d.osh
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ExoMeshes)
+    set_tests_properties (${testName}_CreateGisOsh
+        PROPERTIES FIXTURES_SETUP CreateGisOshMesh)
+
+    # Actual Albany test using Omega_h for the basal mesh
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/input_fo_gis_unstruct_omegah.yaml
+                   ${CMAKE_CURRENT_BINARY_DIR}/input_fo_gis_unstruct_omegah.yaml)
+    add_test(${testName} ${Albany.exe} input_fo_gis_unstruct_omegah.yaml
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/../ExoMeshes)
+    set_tests_properties(${testName}
+                         PROPERTIES
+                         LABELS "LandIce;Forward;Omega_h"
+                         FIXTURES_REQUIRED "CreateGisOshMesh;PopulateMesh2d")
+  else()
+    message(STATUS "exo2osh tool not found; skipping ${testNameRoot}_Unstructured_Omega_h test.")
+  endif()
+endif()
+
 	set (testNameHumboldtDecompMesh ${testNameRoot}_Humboldt_2d_decompMesh)
   add_test (NAME ${testNameHumboldtDecompMesh}
         COMMAND ${SerialSeacasDecomp.exe} -processors ${MPIMNP} humboldt_2d.exo

--- a/tests/landIce/FO_GIS/input_fo_gis_unstruct_omegah.yaml
+++ b/tests/landIce/FO_GIS/input_fo_gis_unstruct_omegah.yaml
@@ -1,0 +1,212 @@
+%YAML 1.1
+---
+ANONYMOUS:
+  Debug Output:
+    Write Solution to MatrixMarket: 0
+  Problem:
+    Phalanx Graph Visualization Detail: 0
+    Solution Method: Continuation
+    Name: LandIce Stokes First Order 3D
+    Compute Sensitivities: true
+    Basal Side Name: basalside
+    Surface Side Name: upperside
+    Flat Bed Approximation: true
+    Cubature Degrees (Horiz Vert): [4, 2]
+    Basal Cubature Degree: 3
+    Surface Cubature Degree: 3
+    Response Functions:
+      Number Of Responses: 1
+      Response 0:
+        Type: Scalar Response
+        Name: Surface Velocity Mismatch
+    Dirichlet BCs: {}
+    Neumann BCs: {}
+    LandIce BCs:
+      Number: 2
+      BC 0:
+        Type: Basal Friction
+        Side Set Name: basalside
+        Basal Friction Coefficient:
+          Type: Field
+          Beta Field Name: basal_friction
+      BC 1:
+        Type: Lateral
+        Cubature Degree: 3
+        Side Set Name: lateralside
+    Parameters:
+      Number Of Parameters: 1
+      Parameter 0:
+        Type: Scalar
+        Name: Glen's Law Homotopy Parameter
+    LandIce Physical Parameters:
+      Water Density: 1.028e+03
+      Ice Density: 9.10e+02
+      Gravity Acceleration: 9.8
+      Clausius-Clapeyron Coefficient: 0.0
+    LandIce Viscosity:
+      Type: Glen's Law
+      Glen's Law Homotopy Parameter: 0.1
+      Glen's Law A: 3.1709792e-24            # [Pa^-n s^-1]
+      Glen's Law n: 3.0
+      Flow Rate Type: Temperature Based
+    Body Force:
+      Type: FO INTERP SURF GRAD
+  Discretization:
+    Number Of Time Derivatives: 0
+    Method: Extruded
+    Columnwise Ordering: true
+    NumLayers: 5
+    Thickness Field Name: ice_thickness
+    Use Glimmer Spacing: true
+    Extrude Basal Fields: [ice_thickness, surface_height]
+    Interpolate Basal Layered Fields: [temperature]
+    Workset Size: -1
+    Required Fields Info:
+      Number Of Fields: 3
+      Field 0:
+        Field Name: temperature
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 1:
+        Field Name: ice_thickness
+        Field Type: Node Scalar
+        Field Origin: Mesh
+      Field 2:
+        Field Name: surface_height
+        Field Type: Node Scalar
+        Field Origin: Mesh
+    Side Set Discretizations:
+      Side Sets: [basalside, upperside]
+      basalside:
+        Method: Omegah
+        Mesh Creation Method: OshFile
+        Input Filename: ../ExoMeshes/gis_unstruct_2d.osh
+        Mark Parts: ['LateralSide']
+        Number Of Time Derivatives: 0
+        Required Fields Info:
+          Number Of Fields: 4
+          Field 0:
+            Field Name: ice_thickness
+            Field Origin: Mesh
+            Field Type: Node Scalar
+          Field 1:
+            Field Name: surface_height
+            Field Origin: Mesh
+            Field Type: Node Scalar
+          Field 2:
+            Field Name: temperature
+            Field Origin: Mesh
+            Field Type: Node Layered Scalar
+            Number Of Layers: 11
+          Field 3:
+            Field Name: basal_friction
+            Field Origin: Mesh
+            Field Type: Node Scalar
+      upperside:
+        Required Fields Info:
+          Number Of Fields: 2
+          Field 0:
+            Field Name: observed_surface_velocity
+            Field Type: Node Vector
+            Field Origin: Mesh
+          Field 1:
+            Field Name: observed_surface_velocity_RMS
+            Field Type: Node Vector
+            Field Origin: Mesh
+  Regression For Response 0:
+    Test Value: 1.109508809230e+08
+    Sensitivity For Parameter 0:
+      Test Value: 1.852225594771e+07
+    Relative Tolerance: 1.0e-06
+    Absolute Tolerance: 1.0e-06
+  Piro:
+    LOCA:
+      Bifurcation: { }
+      Constraints: { }
+      Predictor:
+        Method: Constant
+      Stepper:
+        Initial Value: 1.0e-01
+        Continuation Parameter: Glen's Law Homotopy Parameter
+        Continuation Method: Natural
+        Max Steps: 10
+        Max Value: 1.0
+        Min Value: 0.0
+      Step Size:
+        Initial Step Size: 2.0e-01
+    NOX:
+      Status Tests:
+        Test Type: Combo
+        Combo Type: OR
+        Number of Tests: 2
+        Test 0:
+          Test Type: Combo
+          Combo Type: OR
+          Number of Tests: 2
+          Test 0:
+            Test Type: NormF
+            Norm Type: Two Norm
+            Scale Type: Scaled
+            Tolerance: 1.0e-05
+          Test 1:
+            Test Type: NormWRMS
+            Absolute Tolerance: 1.0e-05
+            Relative Tolerance: 1.0e-03
+        Test 1:
+          Test Type: MaxIters
+          Maximum Iterations: 50
+      Direction:
+        Method: Newton
+        Newton:
+          Forcing Term Method: Constant
+          Linear Solver:
+            Write Linear System: false
+            Tolerance: 1.0e-4
+          Stratimikos Linear Solver:
+            NOX Stratimikos Options: { }
+            Stratimikos:
+              Linear Solver Type: Belos
+              Linear Solver Types:
+                Belos:
+                  VerboseObject:
+                    Verbosity Level: medium
+                  Solver Type: Block GMRES
+                  Solver Types:
+                    Block GMRES:
+                      Convergence Tolerance: 1.0e-06
+                      Output Frequency: 20
+                      Output Style: 1
+                      Verbosity: 33
+                      Maximum Iterations: 200
+                      Block Size: 1
+                      Num Blocks: 200
+                      Flexible Gmres: false
+              Preconditioner Type: Ifpack2
+              Preconditioner Types:
+                Ifpack2:
+                  Overlap: 0
+                  Prec Type: RILUK
+                  Ifpack2 Settings:
+                    'fact: iluk level-of-fill': 0
+          Rescue Bad Newton Solve: true
+      Line Search:
+        Full Step:
+          Full Step: 1.0
+        Method: Backtrack
+      Nonlinear Solver: Line Search Based
+      Printing:
+        Output Precision: 3
+        Output Processor: 0
+        Output Information:
+          Error: true
+          Warning: true
+          Outer Iteration: true
+          Parameters: false
+          Details: false
+          Linear Solver Details: false
+          Stepper Iteration: true
+          Stepper Details: true
+          Stepper Parameters: true
+      Solver Options:
+        Status Test Check Type: Minimal
+...


### PR DESCRIPTION
Most fixes are related to owned-vs-ghosted entities in omegah.

I still can't make the omegah and stk tests produce similar results. I know I can't expect bit-for-bit agreement, due to different ordering of entities inside the mesh, but the responses are wildly different, suggesting that there is still some areas of the code where things are not done correctly. I'll as a friend to take a look once the CI tests fail.