### PR TITLE
Promote computeField to a generic disc util

### DIFF
--- a/src/disc/Albany_DiscretizationUtils.cpp
+++ b/src/disc/Albany_DiscretizationUtils.cpp
@@ -20,6 +20,11 @@
 #include "Intrepid2_HGRAD_WEDGE_C1_FEM.hpp"
 #include "Intrepid2_HGRAD_WEDGE_C2_FEM.hpp"
 
+// Expression reading
+#ifdef ALBANY_PANZER_EXPR_EVAL
+#include <Panzer_ExprEval_impl.hpp>
+#endif
+
 namespace Albany {
 
 int computeWorksetSize(const int worksetSizeMax,
@@ -346,7 +351,7 @@ loadField (const std::string& field_name,
 
   *out << "  - Reading " << field_type << " field '" << field_name << "' from file '" << fname << "' ... ";
   out->getOStream()->flush();
-  // Read the input file and stuff it in the Tpetra multivector
+  // Read the input file and stuff it in the Thyra multivector
 
   if (scalar) {
     if (layered) {
@@ -411,7 +416,6 @@ fillField (const std::string& field_name,
            const Teuchos::RCP<Teuchos::FancyOStream> out,
            std::vector<double>& norm_layers_coords)
 {
-  std::string temp_str;
   std::string field_type = (nodal ? "Node" : "Elem");
   field_type += (layered ? " Layered" : "");
   field_type += (scalar ? " Scalar" : " Vector");
@@ -504,6 +508,96 @@ fillField (const std::string& field_name,
       field_mv->col(iv)->assign(values[iv]);
     }
   }
+
+  return field_mv;
+}
+
+Teuchos::RCP<Thyra_MultiVector>
+computeField (const std::string& field_name,
+              const Teuchos::ParameterList& field_params,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& x,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& y,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& z,
+              const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
+              bool nodal, bool scalar, bool layered,
+              const Teuchos::RCP<Teuchos::FancyOStream>& out)
+{
+#ifdef ALBANY_PANZER_EXPR_EVAL
+  // Only nodal fields allowed, no layered fields
+  TEUCHOS_TEST_FOR_EXCEPTION(!nodal, std::logic_error, "Error! Only nodal fields can be computed from a mathematical expression.\n");
+  TEUCHOS_TEST_FOR_EXCEPTION(layered, std::logic_error, "Error! Layered fields cannot be computed from a mathematical expression.\n");
+
+  int field_dim = 1;
+  if (!scalar) {
+    TEUCHOS_TEST_FOR_EXCEPTION(!field_params.isParameter("Vector Dim"), std::logic_error,
+                               "Error! In order to compute the vector field '" << field_name << "' "
+                               "from a mathematical expression, you must provide the parameter 'Vector Dim'.\n");
+    field_dim = field_params.get<int>("Vector Dim");
+  }
+
+  // Get the expressions out of the parameter list.
+  Teuchos::Array<std::string> expressions = field_params.get<Teuchos::Array<std::string>>("Field Expression");
+
+  // NOTE: we need expressions to be of length AT LEAST equal to the field dimension.
+  //       If the length L is larger than the field dimension M, then the first L-M
+  //       strings are assumed to be coefficients needed for the field formula.
+  //       E.g.: if we have a field of dimension 2, one could write
+  //         <Parameter name="Field Expression" type="Array(string)" value="{a=1.5;b=-1;c=2;a*x^2+b*x+c;a*x+b*x+c}"/>
+
+  int num_expr = expressions.size();
+  std::string field_type = (nodal ? "Node" : "Elem");
+  field_type += (layered ? " Layered" : "");
+  field_type += (scalar ? " Scalar" : " Vector");
+  TEUCHOS_TEST_FOR_EXCEPTION(num_expr<field_dim, Teuchos::Exceptions::InvalidParameter,
+                             "Error! Input array for 'Field Expression' is too short. "
+                             "Expected length >=" << field_dim << ". Got " << num_expr << " instead.\n");
+
+  *out << "  - Computing " << field_type << " field '" << field_name << "' from mathematical expression(s):";
+  int num_expr_params = num_expr - field_dim;
+  for (int idim=num_expr_params; idim<num_expr; ++idim) {
+    *out << " " << expressions[idim] << (idim==num_expr-1 ? "" : ";");
+  }
+  if (num_expr_params>0) {
+    *out << " (with";
+    for (int idim=0; idim<num_expr_params; ++idim) {
+      *out << " " << expressions[idim] << (idim==num_expr_params-1 ? "" : ";");
+    }
+    *out << ")";
+  }
+  *out << ".\n";
+
+  // Extract coordinates of all nodes
+  auto field_mv = Thyra::createMembers(entities_vs,field_dim);
+
+  using exec_space = PHX::Device::execution_space;
+  using layout = typename Kokkos::View<double**,DeviceView1d<double>::memory_space>::traits::array_layout;
+
+  // Set up the expression parser
+  panzer::Expr::Eval<double**,layout,exec_space> eval;
+  using const_view_type = decltype(eval)::const_view_type;
+  set_cmath_functions(eval);
+  eval.set("x",x);
+  if (y.data()!=nullptr)
+    eval.set("y",y);
+  if (z.data()!=nullptr)
+    eval.set("z",z);
+
+  // Start by reading the parameters used in the field expression(s)
+  Teuchos::any result;
+  for (int iparam=0; iparam<num_expr_params; ++iparam) {
+    eval.read_string(result,expressions[iparam]+";","params");
+  }
+
+  // Parse and evaluate all the expressions
+  for (int idim=0; idim<field_dim; ++idim) {
+    eval.read_string(result,expressions[num_expr_params+idim],"field expression");
+    auto result_view = Teuchos::any_cast<const_view_type>(result);
+    auto result_view_1d = DeviceView1d<const double>(result_view.data(),result_view.extent_int(0));
+    Kokkos::deep_copy(getNonconstDeviceData(field_mv->col(idim)),result_view_1d);
+  }
+#else
+  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Error! Cannot read the field from a mathematical expression, since PanzerExprEval package was not found in Trilinos.\n");
+#endif
 
   return field_mv;
 }

--- a/src/disc/Albany_DiscretizationUtils.hpp
+++ b/src/disc/Albany_DiscretizationUtils.hpp
@@ -215,6 +215,16 @@ fillField (const std::string& field_name,
            const Teuchos::RCP<Teuchos::FancyOStream> out,
            std::vector<double>& norm_layers_coords);
 
+Teuchos::RCP<Thyra_MultiVector>
+computeField (const std::string& field_name,
+              const Teuchos::ParameterList& field_params,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& x,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& y,
+              const Kokkos::View<double**,typename DeviceView1d<double>::memory_space>& z,
+              const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
+              bool nodal, bool scalar, bool layered,
+              const Teuchos::RCP<Teuchos::FancyOStream>& out);
+
 }  // namespace Albany
 
 #endif  // ALBANY_DISCRETIZATION_UTILS_HPP

--- a/src/disc/omegah/Albany_OmegahGenericMesh.cpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.cpp
@@ -802,9 +802,11 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     } else if (load_value) {
       field_mv = fillField (fname, fparams, vs, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_math_expr) {
+      TEUCHOS_TEST_FOR_EXCEPTION(!nodal, std::logic_error, "Error! Only nodal fields can be computed from a mathematical expression.\n");
+      TEUCHOS_TEST_FOR_EXCEPTION(layered, std::logic_error, "Error! Layered fields cannot be computed from a mathematical expression.\n");
+
       using exec_space = PHX::Device::execution_space;
       using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
-      using layout = view_type::traits::array_layout;
 
       int num_ents = getLocalSubdim(vs);
       view_type x("x",num_ents,1);

--- a/src/disc/omegah/Albany_OmegahGenericMesh.cpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.cpp
@@ -638,14 +638,16 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
   int num_fields = req_fields_info.get<int>("Number Of Fields",0);
 
   // Check for early return
-  if (num_fields==0)
+  if (num_fields==0) {
+    *out << "[OmegahGenericMesh] Processing field requirements...done! (no requirements)\n";
     return;
+  }
 
-  // Get nodes/elems global ids
-  auto node_gids = m_mesh->globals(0);
-  auto elem_gids = m_mesh->globals(m_mesh->dim());
-  auto node_gids_h = hostRead(node_gids);
-  auto elem_gids_h = hostRead(elem_gids);
+  // Get owned-only nodes/elems global ids.
+  // Using ALL nodes (including ghost copies on multiple ranks) would create a Tpetra Map
+  // with duplicate GIDs across ranks, which has undefined behavior. We must use owned-only.
+  auto node_gids_h = OmegahGhost::getOwnedEntityGids(*m_mesh, 0);
+  auto elem_gids_h = OmegahGhost::getOwnedEntityGids(*m_mesh, m_mesh->dim());
 
   // NOTE: the reinterpret_cast is safe, since both Albany and Omegah use 64bit int for Global ids
   Teuchos::ArrayView<const GO> node_gids_av(reinterpret_cast<const GO*>(node_gids_h.data()),node_gids_h.size());
@@ -776,8 +778,10 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     bool load_value = fparams.isParameter("Field Value") || fparams.isParameter("Random Value");
     TEUCHOS_TEST_FOR_EXCEPTION ( load_ascii && load_value, std::logic_error,
         "Error! You cannot specify both 'File Name' and 'Field Value' (or 'Random Value') for loading a field.\n");
-    TEUCHOS_TEST_FOR_EXCEPTION ( load_math_expr, std::logic_error,
-        "Error! 'Field Expression' not supported by Omegah meshes (yet).\n");
+    TEUCHOS_TEST_FOR_EXCEPTION ( load_ascii && load_math_expr, std::logic_error,
+        "Error! You cannot specify both 'File Name' and 'Field Expression' for loading a field.\n");
+    TEUCHOS_TEST_FOR_EXCEPTION ( load_math_expr && load_value, std::logic_error,
+        "Error! You cannot specify both 'Field Expression' and 'Field Value' (or 'Random Value') for loading a field.\n");
 
     // Depending on the input field type, we need to use different pointers/importers/vectors
     bool nodal = std::regex_search(ftype,nodal_r);
@@ -797,13 +801,47 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
       field_mv = loadField (fname, fparams, *cas_manager, comm, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_value) {
       field_mv = fillField (fname, fparams, vs, nodal, scalar, layered, out, norm_layers_coords);
+    } else if (load_math_expr) {
+      using exec_space = PHX::Device::execution_space;
+      using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
+      using layout = view_type::traits::array_layout;
+
+      int num_ents = getLocalSubdim(vs);
+      view_type x("x",num_ents,1);
+      view_type y,z;
+      int mdim = m_mesh->dim();
+      if (mdim>1) {
+        y = view_type ("y",num_ents,1);
+        if (mdim>2) {
+          z = view_type ("z",num_ents,1);
+        }
+      }
+      auto copy_coords = KOKKOS_LAMBDA(int i) {
+        x(i,0) = m_coords_d(mdim*i);
+        if (mdim>1) {
+          y(i,0) = m_coords_d(mdim*i+1);
+          if (mdim>2) {
+            z(i,0) = m_coords_d(mdim*i+2);
+          }
+        }
+      };
+      Kokkos::parallel_for(Kokkos::RangePolicy<exec_space>(0,num_ents),copy_coords);
+
+      field_mv = computeField (fname, fparams, x, y, z, vs, nodal, scalar, layered, out);
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error,
           "Error! No means were specified for loading field '" + fname + "'.\n");
     }
 
     m_field_accessor->setFieldOnMesh (fname,nodal ? 0 : m_mesh->dim(), field_mv.getConst());
+
+    // Sync owned entity data to ghost copies so that subsequent operations
+    // (e.g., transferNodeStatesToElemStates) can safely read ghost node values.
+    // This is necessary because setFieldOnMesh only writes owned entity data
+    // (positions 0..N_owned-1 in Omega_h's owned-first ordering).
+    m_mesh->sync_tag(nodal ? 0 : m_mesh->dim(), fname);
   }
+  *out << "[OmegahGenericMesh] Processing field requirements...done!\n";
 }
 
 } // namespace Albany

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -26,11 +26,6 @@
 #include <stk_mesh/base/CreateAdjacentEntities.hpp>
 #include <stk_mesh/base/MeshBuilder.hpp>
 
-// Expression reading
-#ifdef ALBANY_PANZER_EXPR_EVAL
-#include <Panzer_ExprEval_impl.hpp>
-#endif
-
 // Rebalance
 #ifdef ALBANY_ZOLTAN
 #include <percept/stk_rebalance/Rebalance.hpp>
@@ -701,54 +696,34 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
 
     // Depending on the input field type, we need to use different pointers/importers/vectors
     bool nodal, scalar, layered;
-    Teuchos::RCP<CombineAndScatterManager> cas_manager;
-    std::vector<stk::mesh::Entity>* entities;
     if (ftype == "Node Scalar") {
       nodal = true; scalar = true; layered = false;
-      cas_manager = cas_manager_node;
-      entities = &nodes;
     } else if (ftype == "Elem Scalar") {
       nodal = false; scalar = true; layered = false;
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else if (ftype == "QuadPoint Scalar") {
       nodal = false; scalar = false; layered = false; //saved as vector, numQuadPoints == Vector Dim
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else if (ftype == "Node Vector") {
       nodal = true; scalar = false; layered = false;
-      cas_manager = cas_manager_node;
-      entities = &nodes;
     } else if (ftype == "Elem Vector") {
       nodal = false; scalar = false; layered = false;
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else if (ftype == "Node Layered Scalar") {
       nodal = true; scalar = true; layered = true;
-      cas_manager = cas_manager_node;
-      entities = &nodes;
     } else if (ftype == "Elem Layered Scalar") {
       nodal = false; scalar = true; layered = true;
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else if (ftype == "QuadPoint Layered Scalar") {
       nodal = false; scalar = false; layered = true; //saved as vector, numQuadPoints == Vector Dim
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else if (ftype == "Node Layered Vector") {
       nodal = true; scalar = false; layered = true;
-      cas_manager = cas_manager_node;
-      entities = &nodes;
     } else if (ftype == "Elem Layered Vector") {
       nodal = false; scalar = false; layered = true;
-      cas_manager = cas_manager_elem;
-      entities = &elems;
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION (true, Teuchos::Exceptions::InvalidParameterValue,
                                   "Error! Field '" << fname << "' has type '" << ftype << "'.\n" <<
                                   "Unfortunately, the only supported field types so fare are 'Node/Elem Scalar/Vector' and 'Node/Elem Layered Scalar/Vector'.\n");
     }
 
+    auto& entities = nodal ? nodes : elems;
+    auto cas_manager = nodal ? cas_manager_node : cas_manager_elem;
     auto serial_vs = cas_manager->getOwnedVectorSpace();
     auto vs = cas_manager->getOverlappedVectorSpace();  // It is not overlapped, it is just distributed.
     Teuchos::RCP<Thyra_MultiVector> field_mv;
@@ -760,7 +735,26 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     } else if (load_value) {
       field_mv = fillField (fname, fparams, vs, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_math_expr) {
-      field_mv = computeField (fname, fparams, vs, *entities, nodal, scalar, layered, out);
+      using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
+
+      view_type x("x",entities.size(),1), y("y",entities.size(),1), z("z",entities.size(),1);
+      view_type::host_mirror_type x_h = Kokkos::create_mirror_view(x);
+      view_type::host_mirror_type y_h = Kokkos::create_mirror_view(y);
+      view_type::host_mirror_type z_h = Kokkos::create_mirror_view(z);
+      const auto& coordinates = *this->getCoordinatesField3d();
+      double* xyz;
+      for (unsigned int i=0; i<entities.size(); ++i) {
+        xyz = stk::mesh::field_data(coordinates, entities[i]);
+
+        x_h(i,0) = xyz[0];
+        y_h(i,0) = xyz[1];
+        z_h(i,0) = xyz[2];
+      }
+      Kokkos::deep_copy(x,x_h);
+      Kokkos::deep_copy(y,y_h);
+      Kokkos::deep_copy(z,z_h);
+
+      field_mv = computeField (fname, fparams, x, y, z, vs, nodal, scalar, layered, out);
     } else {
       TEUCHOS_TEST_FOR_EXCEPTION (true, std::logic_error, "Error! No means were specified for loading field '" + fname + "'.\n");
     }
@@ -777,121 +771,16 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     stk::mesh::EntityId gid;
     LO lid;
     auto indexer = createGlobalLocalIndexer(vs);
-    for (unsigned int i(0); i<entities->size(); ++i) {
-      double* values = stk::mesh::field_data(*stk_field, (*entities)[i]);
+    for (unsigned int i(0); i<entities.size(); ++i) {
+      double* values = stk::mesh::field_data(*stk_field, entities[i]);
 
-      gid = bulkData->identifier((*entities)[i]) - 1;
+      gid = bulkData->identifier(entities[i]) - 1;
       lid = indexer->getLocalElement(GO(gid));
       for (int iDim(0); iDim<field_mv_view.size(); ++iDim) {
         values[iDim] = field_mv_view[iDim][lid];
       }
     }
   }
-}
-
-Teuchos::RCP<Thyra_MultiVector>
-GenericSTKMeshStruct::
-computeField (const std::string& field_name,
-              const Teuchos::ParameterList& field_params,
-              const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
-              const std::vector<stk::mesh::Entity>& entities,
-              bool nodal, bool scalar, bool layered,
-              const Teuchos::RCP<Teuchos::FancyOStream> out)
-{
-#ifdef ALBANY_PANZER_EXPR_EVAL
-  // Only nodal fields allowed, no layered fields
-  TEUCHOS_TEST_FOR_EXCEPTION(!nodal, std::logic_error, "Error! Only nodal fields can be computed from a mathematical expression.\n");
-  TEUCHOS_TEST_FOR_EXCEPTION(layered, std::logic_error, "Error! Layered fields cannot be computed from a mathematical expression.\n");
-
-  int field_dim = 1;
-  if (!scalar) {
-    TEUCHOS_TEST_FOR_EXCEPTION(!field_params.isParameter("Vector Dim"), std::logic_error,
-                               "Error! In order to compute the vector field '" << field_name << "' "
-                               "from a mathematical expression, you must provide the parameter 'Vector Dim'.\n");
-    field_dim = field_params.get<int>("Vector Dim");
-  }
-
-  // Get the expressions out of the parameter list.
-  Teuchos::Array<std::string> expressions = field_params.get<Teuchos::Array<std::string>>("Field Expression");
-
-  // NOTE: we need expressions to be of length AT LEAST equal to the field dimension.
-  //       If the length L is larger than the field dimension M, then the first L-M
-  //       strings are assumed to be coefficients needed for the field formula.
-  //       E.g.: if we have a field of dimension 2, one could write
-  //         <Parameter name="Field Expression" type="Array(string)" value="{a=1.5;b=-1;c=2;a*x^2+b*x+c;a*x+b*x+c}"/>
-
-  int num_expr = expressions.size();
-  std::string temp_str;
-  std::string field_type = (nodal ? "Node" : "Elem");
-  field_type += (layered ? " Layered" : "");
-  field_type += (scalar ? " Scalar" : " Vector");
-  TEUCHOS_TEST_FOR_EXCEPTION(num_expr<field_dim, Teuchos::Exceptions::InvalidParameter,
-                             "Error! Input array for 'Field Expression' is too short. "
-                             "Expected length >=" << field_dim << ". Got " << num_expr << " instead.\n");
-
-  *out << "  - Computing " << field_type << " field '" << field_name << "' from mathematical expression(s):";
-  int num_expr_params = num_expr - field_dim;
-  for (int idim=num_expr_params; idim<num_expr; ++idim) {
-    *out << " " << expressions[idim] << (idim==num_expr-1 ? "" : ";");
-  }
-  if (num_expr_params>0) {
-    *out << " (with";
-    for (int idim=0; idim<num_expr_params; ++idim) {
-      *out << " " << expressions[idim] << (idim==num_expr_params-1 ? "" : ";");
-    }
-    *out << ")";
-  }
-  *out << ".\n";
-
-  // Extract coordinates of all nodes
-  auto field_mv = Thyra::createMembers(entities_vs,field_dim);
-  using exec_space = Tpetra_MultiVector::execution_space;
-  using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
-  using layout = view_type::traits::array_layout;
-
-  view_type x("x",entities.size(),1), y("y",entities.size(),1), z("z",entities.size(),1);
-  view_type::host_mirror_type x_h = Kokkos::create_mirror_view(x);
-  view_type::host_mirror_type y_h = Kokkos::create_mirror_view(y);
-  view_type::host_mirror_type z_h = Kokkos::create_mirror_view(z);
-  const auto& coordinates = *this->getCoordinatesField3d();
-  double* xyz;
-  for (unsigned int i=0; i<entities.size(); ++i) {
-    xyz = stk::mesh::field_data(coordinates, entities[i]);
-
-    x_h(i,0) = xyz[0];
-    y_h(i,0) = xyz[1];
-    z_h(i,0) = xyz[2];
-  }
-  Kokkos::deep_copy(x,x_h);
-  Kokkos::deep_copy(y,y_h);
-  Kokkos::deep_copy(z,z_h);
-
-  // Set up the expression parser
-  panzer::Expr::Eval<double**,layout,exec_space> eval;
-  using const_view_type = decltype(eval)::const_view_type;
-  set_cmath_functions(eval);
-  eval.set("x",x);
-  eval.set("y",y);
-  eval.set("z",z);
-
-  // Start by reading the parameters used in the field expression(s)
-  Teuchos::any result;
-  for (int iparam=0; iparam<num_expr_params; ++iparam) {
-    eval.read_string(result,expressions[iparam]+";","params");
-  }
-
-  // Parse and evaluate all the expressions
-  for (int idim=0; idim<field_dim; ++idim) {
-    eval.read_string(result,expressions[num_expr_params+idim],"field expression");
-    auto result_view = Teuchos::any_cast<const_view_type>(result);
-    auto result_view_1d = DeviceView1d<const double>(result_view.data(),result_view.extent_int(0));
-    Kokkos::deep_copy(getNonconstDeviceData(field_mv->col(idim)),result_view_1d);
-  }
-#else
-  TEUCHOS_TEST_FOR_EXCEPTION(true, std::logic_error, "Error! Cannot read the field from a mathematical expression, since PanzerExprEval package was not found in Trilinos.\n");
-#endif
-
-  return field_mv;
 }
 
 void GenericSTKMeshStruct::checkFieldIsInMesh (const std::string& fname, const std::string& ftype) const
@@ -916,7 +805,7 @@ void GenericSTKMeshStruct::checkFieldIsInMesh (const std::string& fname, const s
 Teuchos::RCP<Teuchos::ParameterList>
 GenericSTKMeshStruct::getValidGenericSTKParameters(std::string listname) const
 {
-  Teuchos::RCP<Teuchos::ParameterList> validPL = rcp(new Teuchos::ParameterList(listname));;
+  Teuchos::RCP<Teuchos::ParameterList> validPL = rcp(new Teuchos::ParameterList(listname));
   validPL->set<std::string>("Cell Topology", "Quad" , "Quad or Tri Cell Topology");
   validPL->set<int>("Number Of Time Derivatives", 1, "Number of time derivatives in use in the problem");
   validPL->set<std::string>("Exodus Output File Name", "",

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.cpp
@@ -735,6 +735,9 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     } else if (load_value) {
       field_mv = fillField (fname, fparams, vs, nodal, scalar, layered, out, norm_layers_coords);
     } else if (load_math_expr) {
+      TEUCHOS_TEST_FOR_EXCEPTION(!nodal, std::logic_error, "Error! Only nodal fields can be computed from a mathematical expression.\n");
+      TEUCHOS_TEST_FOR_EXCEPTION(layered, std::logic_error, "Error! Layered fields cannot be computed from a mathematical expression.\n");
+
       using view_type = Kokkos::View<double**,DeviceView1d<double>::memory_space>;
 
       view_type x("x",entities.size(),1), y("y",entities.size(),1), z("z",entities.size(),1);

--- a/src/disc/stk/Albany_GenericSTKMeshStruct.hpp
+++ b/src/disc/stk/Albany_GenericSTKMeshStruct.hpp
@@ -68,15 +68,6 @@ public:
   void loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
                                 Teuchos::ParameterList& req_fields_info) override;
 
-  // Compute a field from a string expression
-  Teuchos::RCP<Thyra_MultiVector>
-  computeField (const std::string& field_name,
-                const Teuchos::ParameterList& params,
-                const Teuchos::RCP<const Thyra_VectorSpace>& entities_vs,
-                const std::vector<stk::mesh::Entity>& entities,
-                bool node, bool scalar, bool layered,
-                const Teuchos::RCP<Teuchos::FancyOStream> out);
-
   void checkFieldIsInMesh (const std::string& fname, const std::string& ftype) const;
 
   void setDefaultCoordinates3d ();


### PR DESCRIPTION
`computeField` already rejects non-nodal and layered fields, but both the STK and Omegah `load_math_expr` branches extracted/allocated coordinates before reaching that check — causing a segfault (STK) or out-of-bounds access (Omegah) for those unsupported cases.

## Changes

- **STK (`Albany_GenericSTKMeshStruct.cpp`)**: Add early `TEUCHOS_TEST_FOR_EXCEPTION` guards for `!nodal` and `layered` before the `stk::mesh::field_data` coordinate extraction loop, preventing a null-dereference when entities are elements.
- **Omegah (`Albany_OmegahGenericMesh.cpp`)**: Add the same guards before coordinate view allocation/copy, preventing out-of-bounds indexing into `m_coords_d` when `num_ents` would be an element count rather than a node count.
- **Omegah**: Remove unused `layout` type alias in the same branch.