### PR TITLE
Misc fixes to omegah related classes

### DIFF
--- a/cmake/GetOrInstallOmegah.cmake
+++ b/cmake/GetOrInstallOmegah.cmake
@@ -1,7 +1,7 @@
 set (tmpStr "Looking for valid Omega_h installation ...")
 message (STATUS ${tmpStr})
 
-find_package(Omega_h 11.0 CONFIG QUIET
+find_package(Omega_h 11.0.2 CONFIG QUIET
   # Avoid all defaults. Only check env/CMake var Omega_h_ROOT
   NO_CMAKE_PATH
   NO_CMAKE_ENVIRONMENT_PATH

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -356,6 +356,14 @@ computeSideSets ()
   const auto& ssNames = getMeshStruct()->meshSpecs[0]->ssNames;
   if (ssNames.empty()) return;
 
+  // Ensure every workset has an entry for every sideset name, even when this
+  // rank/workset owns no sides for that sideset. Downstream code may rely on
+  // getSideSets(ws).at(ssName) being valid and yielding an empty vector.
+  for (int ws=0; ws<num_ws; ++ws) {
+    for (const auto& ssn : ssNames) {
+      m_sideSets[ws][ssn] = {};
+    }
+  }
   auto& mesh = *m_mesh_struct->getOmegahMesh();
   const int side_dim = mesh.dim()-1;
   const int num_loc_sides = Omega_h::element_degree(mesh.family(), mesh.dim(), side_dim);

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -168,6 +168,30 @@ updateMesh ()
   m_dof_managers[nodes_dof_name()][""]     = node_dof_mgr;
   m_node_dof_managers[""]     = node_dof_mgr;
 
+  // Create DOF managers for nodal parameter states (setFieldData should have been called already)
+  TEUCHOS_TEST_FOR_EXCEPTION (m_solution_mfa.is_null(), std::runtime_error,
+      "[OmegahDiscretization] Error! Solution MFA is null, but setFieldData should have created it...\n");
+
+  for (auto st : m_solution_mfa->getNodalParameterSIS()) {
+    int numComps;
+    switch (st->dim.size()) {
+      case 2: numComps = 1; break;
+      case 3: numComps = st->dim[2]; break;
+      default:
+        throw std::runtime_error(
+            "[OmegahDiscretization::updateMesh] Error! Unsupported nodal state rank.\n"
+            "  - state name: " + st->name + "\n"
+            "  - input dims: (" + util::join(st->dim,",") + ")\n");
+    }
+    auto dof_mgr = create_dof_mgr (st->meshPart,FE_Type::HGRAD,1,numComps);
+    m_dof_managers[st->name][st->meshPart] = dof_mgr;
+
+    if (m_node_dof_managers.find(st->meshPart)==m_node_dof_managers.end()) {
+      auto node_dof_mgr_part = create_dof_mgr (st->meshPart,FE_Type::HGRAD,1,1);
+      m_node_dof_managers[st->meshPart] = node_dof_mgr_part;
+    }
+  }
+
   // Compute workset information
   const auto& ms = m_mesh_struct->meshSpecs[0];
   const auto& mesh = *m_mesh_struct->getOmegahMesh();
@@ -202,6 +226,7 @@ updateMesh ()
   }
 
   m_mesh_struct->get_field_accessor()->createStateArrays(m_workset_sizes);
+  m_mesh_struct->get_field_accessor()->transferNodeStatesToElemStates();
 
   auto node_gids = hostRead(OmegahGhost::getEntGidsInClosureOfOwnedElms(mesh,Omega_h::VERT));
   auto node_indexer = getOverlapNodeGlobalLocalIndexer();
@@ -456,26 +481,6 @@ void OmegahDiscretization::setFieldData()
     }
   }
   m_solution_mfa = solution_mfa;
-  for (auto st : m_solution_mfa->getNodalParameterSIS()) {
-    // TODO: get mesh part from st, create dof mgr on that part for st.name dof
-    int numComps;
-    switch (st->dim.size()) {
-      case 2: numComps = 1; break;
-      case 3: numComps = st->dim[2]; break;
-      default:
-        throw std::runtime_error(
-            "[OmegahDiscretization::setFieldData] Error! Unsupported nodal state rank.\n"
-            "  - state name: " + st->name + "\n"
-            "  - input dims: (" + util::join(st->dim,",") + ")\n");
-    }
-    auto dof_mgr = create_dof_mgr (st->meshPart,FE_Type::HGRAD,1,numComps);
-    m_dof_managers[st->name][st->meshPart] = dof_mgr;
-
-    if (m_node_dof_managers.find(st->meshPart)==m_node_dof_managers.end()) {
-      auto node_dof_mgr = create_dof_mgr (st->meshPart,FE_Type::HGRAD,1,1);
-      m_node_dof_managers[st->meshPart] = node_dof_mgr;
-    }
-  }
 
   // Proceed to set the solution field data in the side meshes as well (if any)
   for (auto& it : sideSetDiscretizations) {

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -250,12 +250,7 @@ updateMesh ()
     elms_in_prior_worksets += m_workset_sizes[ws];
   }
 
-  m_sideSets.resize(num_ws);
-  for (int ws=0; ws<num_ws; ++ws) {
-    m_sideSetViews[ws] = {};
-    m_wsLocalDOFViews[ws] = {};
-  }
-
+  computeSideSets ();
   computeNodeSets ();
   computeGraphs ();
 
@@ -267,7 +262,6 @@ void OmegahDiscretization::
 computeNodeSets ()
 {
   const auto& nsNames = getMeshStruct()->meshSpecs[0]->nsNames;
-  using Omega_h::I32;
   using Omega_h::I8;
 
   auto& mesh = *m_mesh_struct->getOmegahMesh();
@@ -318,6 +312,100 @@ computeNodeSets ()
           " - node lid (osh): " << i << "\n");
     }
   }
+}
+
+void OmegahDiscretization::
+computeSideSets ()
+{
+  // Reset sideset-related arrays
+  int num_ws = getNumWorksets();
+  m_sideSets.resize(num_ws);
+  m_sideSetViews.resize(num_ws);
+  m_wsLocalDOFViews.resize(num_ws);
+  for (int ws=0; ws<num_ws; ++ws) {
+    m_sideSets[ws] = {};
+    m_sideSetViews[ws] = {};
+    m_wsLocalDOFViews[ws] = {};
+  }
+
+  const auto& ssNames = getMeshStruct()->meshSpecs[0]->ssNames;
+  if (ssNames.empty()) return;
+
+  auto& mesh = *m_mesh_struct->getOmegahMesh();
+  const int side_dim = mesh.dim()-1;
+  const int num_loc_sides = Omega_h::element_degree(mesh.family(), mesh.dim(), side_dim);
+
+  // Build s2e: for each side (owned+ghost), the list of OWNED adjacent elements.
+  // This ensures each side is processed exactly once (by the process owning its element).
+  auto s2e = OmegahGhost::getUpAdjacentEntsInClosureOfOwnedElms(mesh, side_dim);
+  auto s2e_a2ab = hostRead(s2e.a2ab);
+  auto s2e_ab2b = hostRead(s2e.ab2b);
+
+  // Down-adjacency: element -> sides (all elements, owned+ghost)
+  auto e2s = mesh.ask_down(mesh.dim(), side_dim);
+  auto e2s_ab2b = hostRead(e2s.ab2b);
+
+  // Owned element GIDs and side GIDs (for lookup by omega_h LID)
+  auto elem_gids = hostRead(mesh.globals(mesh.dim()));
+  auto side_gids = hostRead(mesh.globals(side_dim));
+
+  // cell_indexer maps element GIDs to Albany LIDs (0..N_owned-1)
+  auto cell_indexer = getCellsGlobalLocalIndexer();
+
+  // Determine local position of a side within an element
+  auto determine_side_pos = [&](int elem_lid, int side_lid) {
+    int offset = elem_lid*num_loc_sides;
+    for (int pos=0; pos<num_loc_sides; ++pos) {
+      if (e2s_ab2b[offset+pos]==side_lid)
+        return pos;
+    }
+    return -1;
+  };
+
+  Teuchos::Array<GO> side_GIDs;
+  for (const auto& ssn : ssNames) {
+    auto is_on_ss_host = hostRead(mesh.get_array<Omega_h::I8>(side_dim,ssn));
+
+    for (int i=0; i<is_on_ss_host.size(); ++i) {
+      if (not is_on_ss_host[i]) continue;
+
+      // For each owned element adjacent to side i, add a side set entry
+      for (int adjIdx=s2e_a2ab[i]; adjIdx<s2e_a2ab[i+1]; adjIdx++) {
+        auto ielem = s2e_ab2b[adjIdx];  // omega_h LID of owned element
+        GO  elem_GID = elem_gids[ielem];
+        int elem_LID = cell_indexer->getLocalElement(elem_GID);
+
+        TEUCHOS_TEST_FOR_EXCEPTION (elem_LID < 0 or elem_LID >= static_cast<int>(m_elem_ws_idx.size()),
+            std::runtime_error,
+            "Error! Element LID out of range in computeSideSets.\n"
+            "  - side id: " << i << "\n"
+            "  - elem omega_h LID: " << ielem << "\n"
+            "  - elem GID: " << elem_GID << "\n"
+            "  - elem Albany LID: " << elem_LID << "\n");
+
+        int ws  = m_elem_ws_idx[elem_LID].ws;
+        int idx = m_elem_ws_idx[elem_LID].idx;
+
+        int side_pos = determine_side_pos(ielem, i);
+        TEUCHOS_TEST_FOR_EXCEPTION (side_pos < 0, std::runtime_error,
+            "Error! Could not locate side " << i << " within element " << ielem << ".\n");
+
+        auto& sStruct = m_sideSets[ws][ssn].emplace_back();
+        sStruct.elem_GID      = elem_GID;
+        sStruct.elem_ebIndex = m_mesh_struct->meshSpecs[0]->ebNameToIndex[m_wsEBNames[ws]];
+        sStruct.side_pos      = side_pos;
+        sStruct.ws_elem_idx   = idx;
+        sStruct.side_GID      = side_gids[i];
+
+        side_GIDs.push_back(side_gids[i]);
+      }
+    }
+  }
+
+  auto vs = createVectorSpace(m_comm,side_GIDs);
+  m_sides_indexer = createGlobalLocalIndexer(vs);
+
+  buildSideSetsViews();
 }
 
 void OmegahDiscretization::

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -345,8 +345,8 @@ computeSideSets ()
   // Reset sideset-related arrays
   int num_ws = getNumWorksets();
   m_sideSets.resize(num_ws);
-  m_sideSetViews.resize(num_ws);
-  m_wsLocalDOFViews.resize(num_ws);
+  m_sideSetViews.clear();
+  m_wsLocalDOFViews.clear();
   for (int ws=0; ws<num_ws; ++ws) {
     m_sideSets[ws] = {};
     m_sideSetViews[ws] = {};

--- a/src/disc/omegah/Albany_OmegahDiscretization.cpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.cpp
@@ -203,32 +203,43 @@ updateMesh ()
 
   m_mesh_struct->get_field_accessor()->createStateArrays(m_workset_sizes);
 
-  m_ws_elem_coords.resize(num_ws);
-  auto coords_h  = m_mesh_struct->coords_host();
   auto node_gids = hostRead(OmegahGhost::getEntGidsInClosureOfOwnedElms(mesh,Omega_h::VERT));
   auto node_indexer = getOverlapNodeGlobalLocalIndexer();
   auto nverts = node_gids.size();
-  m_node_lid_to_omegah_pos.resize(nverts);
+
+  // Maps an Albany node LID to a position in the coords_host() array.
+  std::vector<int> albany_lid_to_omegah_pos(nverts);
   for (int i=0; i<nverts; ++i) {
     auto gid = node_gids[i];
     auto lid = node_indexer->getLocalElement(gid);
-    m_node_lid_to_omegah_pos[lid] = i;
+    albany_lid_to_omegah_pos[lid] = i;
   }
 
   int num_elem_nodes = node_dof_mgr->get_topology().getNodeCount();
   const auto& node_elem_dof_lids = node_dof_mgr->elem_dof_lids().host();
 
+  // Build elem_LID -> workset index map (needed by computeSideSets and others)
+  m_elem_ws_idx.clear();
+  m_elem_ws_idx.resize(nelems);
+
   const int mdim = mesh.dim();
+  auto coords_h  = m_mesh_struct->coords_host();
   m_nodes_coordinates.resize(mdim * getLocalSubdim(getOverlapNodeVectorSpace()));
+  m_ws_elem_coords.resize(num_ws);
   int elms_in_prior_worksets = 0;
   for (int ws=0; ws<num_ws; ++ws) {
     m_ws_elem_coords[ws].resize(m_workset_sizes[ws]);
     for (int ielem=0; ielem<m_workset_sizes[ws]; ++ielem) {
       m_ws_elem_coords[ws][ielem].resize(num_elem_nodes);
+      const auto elmIdx = ielem + elms_in_prior_worksets;
+
+      // Save a map from element Albany-LID to workset on this PE
+      m_elem_ws_idx[elmIdx].ws  = ws;
+      m_elem_ws_idx[elmIdx].idx = ielem;
+
       for (int inode=0; inode<num_elem_nodes; ++inode) {
-        const auto elmIdx = ielem + elms_in_prior_worksets;
         LO node_lid = node_elem_dof_lids(elmIdx,inode);
-        int omh_pos = m_node_lid_to_omegah_pos[node_lid];
+        int omh_pos = albany_lid_to_omegah_pos[node_lid];
         m_ws_elem_coords[ws][ielem][inode] = &coords_h[omh_pos*mdim];
         auto coords = &m_nodes_coordinates[node_lid*mdim];
         for (int idim=0; idim<mdim; ++idim) {

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -144,6 +144,7 @@ protected:
                   const int order,
                   const int dof_dim);
 
+  void computeSideSets ();
   void computeNodeSets ();
   void computeGraphs ();
 

--- a/src/disc/omegah/Albany_OmegahDiscretization.hpp
+++ b/src/disc/omegah/Albany_OmegahDiscretization.hpp
@@ -153,9 +153,6 @@ protected:
 
   Teuchos::RCP<OmegahGenericMesh> m_mesh_struct;
 
-  // Maps a Tpetra LID to the pos of a node in the omegah arrays
-  std::vector<int>  m_node_lid_to_omegah_pos;
-
   // TODO: move stuff below in base class?
   Teuchos::RCP<const Teuchos_Comm> m_comm;
 

--- a/src/disc/omegah/Albany_OmegahGenericMesh.cpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.cpp
@@ -3,15 +3,15 @@
 #include "Albany_Omegah.hpp"
 #include "OmegahGhost.hpp"
 
+#include "Albany_CombineAndScatterManager.hpp"
+#include "Albany_ThyraUtils.hpp"
+#include "Albany_Gather.hpp"
+
 #include <Omega_h_for.hpp>        // for Omega_h::parallel_for
 #include <Omega_h_build.hpp>      // for Omega_h::build_box
 #include <Omega_h_file.hpp>       // for Omega_h::binary::read
 #include <Omega_h_mark.hpp>       // for Omega_h::mark_by_class
 #include <Omega_h_array_ops.hpp>  // for Omega_h::land_each
-
-#include "Albany_CombineAndScatterManager.hpp"
-#include "Albany_ThyraUtils.hpp"
-#include "Albany_Gather.hpp"
 
 #include <regex>
 
@@ -32,6 +32,10 @@ OmegahGenericMesh (const Teuchos::RCP<Teuchos::ParameterList>& params)
     // Digits have CONSECUTIVE char values. So '1' = '0'+1, etc.
     int dim = method[3] - '0';
     buildBox(dim);
+  } else {
+    throw std::runtime_error("Invalid choice for 'Mesh Creation Method'.\n"
+                             " - provided choice: " + method + "\n"
+                             " - valid choices: OshFile, Box1D, Box2D, Box3D\n");
   }
 
   m_field_accessor = Teuchos::rcp(new OmegahMeshFieldAccessor(m_mesh));
@@ -299,7 +303,8 @@ loadOmegahMesh ()
   // Omega_h does not know what worksets are, so all elements are in one workset
   this->meshSpecs.resize(1);
   int ws_size_max = m_params->get<int>("Workset Size", -1);
-  int ws_size = computeWorksetSize(ws_size_max,m_mesh->nelems());
+  int numOwnedElems = OmegahGhost::getNumOwnedElms(*m_mesh);
+  int ws_size = computeWorksetSize(ws_size_max,numOwnedElems);
   this->meshSpecs[0] = Teuchos::rcp(
       new MeshSpecsStruct(MeshType::Unstructured, *ctd, m_mesh->dim(),
                           nsNames, ssNames, ws_size, ebName,
@@ -462,7 +467,8 @@ OmegahGenericMesh::createSideSets()
   return ssNames;
 }
 
-void OmegahGenericMesh::setCoordinates() {
+void OmegahGenericMesh::setCoordinates()
+{
   auto ownedCoords_d = OmegahGhost::getVtxCoordsInClosureOfOwnedElms(*m_mesh);
   m_coords_d = ownedCoords_d.view();
   m_coords_h = Kokkos::create_mirror_view(m_coords_d);
@@ -618,7 +624,8 @@ buildBox (const int dim)
 
   this->meshSpecs.resize(1);
   int ws_size_max = m_params->get<int>("Workset Size", -1);
-  int ws_size = computeWorksetSize(ws_size_max,m_mesh->nelems());
+  int numOwnedElems = OmegahGhost::getNumOwnedElms(*m_mesh);
+  int ws_size = computeWorksetSize(ws_size_max,numOwnedElems);
   this->meshSpecs[0] = Teuchos::rcp(
       new MeshSpecsStruct(MeshType::Structured, *ctd, dim,
                           nsNames, ssNames, ws_size, ebName,

--- a/src/disc/omegah/Albany_OmegahGenericMesh.cpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.cpp
@@ -242,21 +242,48 @@ loadOmegahMesh ()
   // A dimension and id uniquely defines a geometric model entity.
   const auto& parts_names = m_params->get<Teuchos::Array<std::string>>("Mark Parts",{});
   for (const auto& pn : parts_names) {
-          auto& pl = m_params->sublist(pn);
-    const auto topo_str = pl.get<std::string>("Topo");
-    const auto topo = str2topo(pl.get<std::string>("Topo"));
-    const int dim = topo_dim(topo);
-    const int id  = pl.get<int>("Id");
-    const bool markDownward = pl.get<int>("Mark Downward",true); // Is default=true ok?
-    auto is_in_part = Omega_h::mark_by_class(m_mesh.get(), dim, dim, id);
-    //ghosted entities cannot be owned so we don't need to check the closure of owned elements
-    auto owned = m_mesh->owned(dim); 
-    auto is_in_part_and_owned = Omega_h::land_each(is_in_part, owned);
-    this->declare_part(pn,topo,is_in_part_and_owned,markDownward);
+    TEUCHOS_TEST_FOR_EXCEPTION(m_mesh->class_sets.count(pn)==0, std::runtime_error,
+        "Error! Part '" + pn + "' was not found in the mesh class_sets. "
+        "Marked parts must exist in mesh->class_sets.\n");
 
-    if (dim==0) {
+    const auto& class_pairs = m_mesh->class_sets.at(pn);
+    TEUCHOS_TEST_FOR_EXCEPTION(class_pairs.empty(), std::runtime_error,
+        "Error! Class set '" + pn + "' is empty in the mesh file.\n");
+
+    // Determine the mesh entity dimension from the first class pair's model dimension.
+    // For sidesets created by exo2osh, class pairs have model_dim = mesh.dim()-1.
+    const int ent_dim = class_pairs[0].dim;
+
+    // Build a union mark for all geometric entities in this class set
+    auto is_in_part = Omega_h::Read<Omega_h::I8>(m_mesh->nents(ent_dim), 0);
+    for (const auto& cp : class_pairs) {
+      TEUCHOS_TEST_FOR_EXCEPTION(cp.dim != ent_dim, std::runtime_error,
+          "Error! Class set '" + pn + "' has pairs with mixed entity dimensions.\n");
+      auto mark = Omega_h::mark_by_class(m_mesh.get(), ent_dim, cp.dim, cp.id);
+      is_in_part = Omega_h::lor_each(is_in_part, mark);
+    }
+
+    // Infer the Topo_type from (mesh_family, ent_dim)
+    Topo_type topo;
+    const bool isSimplex = (m_mesh->family()==OMEGA_H_SIMPLEX);
+    bool mark_downward = true;
+    if (ent_dim==0) {
+      topo = Topo_type::vertex;
+      mark_downward = false;
+    } else if (ent_dim==1) {
+      topo = Topo_type::edge;
+    } else if (ent_dim==2) {
+      topo = isSimplex ? Topo_type::triangle : Topo_type::quadrilateral;
+    } else {
+      TEUCHOS_TEST_FOR_EXCEPTION(true, std::runtime_error,
+          "Error! Class set part with entity dimension " + std::to_string(ent_dim) + " not supported.\n");
+    }
+
+    this->declare_part(pn, topo, is_in_part, mark_downward);
+
+    if (ent_dim==0) {
       nsNames.push_back(pn);
-    } else if (dim==m_mesh->dim()-1) {
+    } else if (ent_dim==m_mesh->dim()-1) {
       ssNames.push_back(pn);
     }
   }
@@ -799,10 +826,8 @@ loadRequiredInputFields (const Teuchos::RCP<const Teuchos_Comm>& comm,
     auto serial_vs = cas_manager->getOwnedVectorSpace();
     auto vs = cas_manager->getOverlappedVectorSpace();  // It is not overlapped, it is just distributed.
 
-    std::vector<double> norm_layers_coords;
-    if (layered) {
-      norm_layers_coords = m_field_accessor->getMeshVectorStates()[fname + "_NLC"];
-    }
+    std::vector<double> dummy;
+    auto& norm_layers_coords = layered ? m_field_accessor->getMeshVectorStates()[fname + "_NLC"] : dummy;
     Teuchos::RCP<Thyra_MultiVector> field_mv;
     if (load_ascii) {
       field_mv = loadField (fname, fparams, *cas_manager, comm, nodal, scalar, layered, out, norm_layers_coords);

--- a/src/disc/omegah/Albany_OmegahGenericMesh.hpp
+++ b/src/disc/omegah/Albany_OmegahGenericMesh.hpp
@@ -39,8 +39,8 @@ public:
 
   bool hasRestartSolution () const { return m_has_restart_solution; }
 
-  DeviceView1d<const double>                   coords_dev  () const { return m_coords_d; }
-  DeviceView1d<      double>::host_mirror_type coords_host () const { return m_coords_h; }
+  auto coords_dev  () const { return m_coords_d; }
+  auto coords_host () const { return m_coords_h; }
 
   int part_dim (const std::string& part_name) const;
 
@@ -86,10 +86,10 @@ protected:
   // Given a part name, returns its topology (in the form of an Omega_h enum
   std::map<std::string,Topo_type>  m_part_topo;
 
-  Teuchos::RCP<OmegahMeshFieldAccessor>    m_field_accessor;
+  Teuchos::RCP<OmegahMeshFieldAccessor>     m_field_accessor;
 
-  DeviceView1d<const double>                m_coords_d;
-  DeviceView1d<      double>::host_mirror_type    m_coords_h;
+  Kokkos::View<const double*,PHX::Device>                      m_coords_d;
+  Kokkos::View<const double*,PHX::Device>::host_mirror_type    m_coords_h;
 
   mutable GO m_max_node_gid = -1; //set when get_max_node_gid() called
   mutable GO m_max_elem_gid = -1; //set when get_max_elem_gid() called

--- a/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
+++ b/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
@@ -17,9 +17,30 @@ addFieldOnMesh (const std::string& name,
                 const int entityDim,
                 const int numComps)
 {
-  TEUCHOS_TEST_FOR_EXCEPTION (m_mesh->has_tag(entityDim,name), std::logic_error,
-      "Error! Tag '" + name + "' is already defined on the mesh.\n");
   Omega_h::Write<ST> f(m_mesh->nents(entityDim)*numComps,name);
+  if (m_mesh->has_tag(entityDim,name)) {
+    auto tag = m_mesh->get_tag<ST>(entityDim,name);
+    TEUCHOS_TEST_FOR_EXCEPTION (tag->ncomps()!=numComps, std::logic_error,
+        "Error! Attempt to re-define tag with different number of components.\n"
+        " - tag name: " + name + "\n"
+        " - tag ncomps: " + std::to_string(tag->ncomps()) + "\n"
+        " - new ncomps: " + std::to_string(numComps) + "\n");
+
+    auto const old_size = tag->array().size();
+    auto const new_size = f.size();
+    TEUCHOS_TEST_FOR_EXCEPTION (old_size != new_size, std::logic_error,
+        "Error! Attempt to re-define tag with incompatible storage size.\n"
+        "The mesh entity count appears to have changed since the tag was created.\n"
+        " - tag name: " + name + "\n"
+        " - entity dimension: " + std::to_string(entityDim) + "\n"
+        " - tag array size: " + std::to_string(old_size) + "\n"
+        " - expected array size: " + std::to_string(new_size) + "\n"
+        " - tag ncomps: " + std::to_string(tag->ncomps()) + "\n"
+        " - current numComps: " + std::to_string(numComps) + "\n");
+    // Copy existing data, then remove so we can re-add with OUR (writable) array
+    Omega_h::copy_into(tag->array(),f);
+    m_mesh->remove_tag(entityDim,name);
+  }
   m_mesh->add_tag<ST>(entityDim,name,numComps,f,false);
   m_tags[name].array = f;
   m_tags[name].ncomps = numComps;
@@ -41,22 +62,33 @@ setFieldOnMesh (const std::string& name,
   // Create 1d view of input MV
   auto dev_mv = getDeviceData(mv);
   int ncmps = dev_mv.extent(1);
-  int nents = dev_mv.extent(0);
+  int mv_nents = dev_mv.extent(0);
   int tag_nents = Omega_h::divide_no_remainder(tag->array().size(), tag->ncomps());
 
-  TEUCHOS_TEST_FOR_EXCEPTION (tag_nents != nents, std::logic_error,
-      "Error! Cannot copy MV on mesh tag, as the number of entities differ.\n"
+  TEUCHOS_TEST_FOR_EXCEPTION (tag_nents != m_mesh->nents(entityDim), std::runtime_error,
+      "Error! Something is amiss with the registered tag size.\n"
       "  - tag name: " + name + "\n"
+      "  - entity dim: " << entityDim << "\n"
       "  - tag num ents: " << tag_nents << "\n"
-      "  - MV num ents: " << nents << "\n");
+      "  - mesh num ents: " << m_mesh->nents(entityDim) << "\n");
+
+  // The MV may contain only owned entities (fewer than total owned+ghosted).
+  // Omega_h places owned entities first, so we write to positions [0, mv_nents).
+  // The caller is responsible for syncing ghost data afterwards if needed.
+  TEUCHOS_TEST_FOR_EXCEPTION (mv_nents > tag_nents, std::logic_error,
+      "Error! Unexpected number of entities in input MV.\n"
+      "  - tag name: " + name + "\n"
+      "  - entity dim: " << entityDim << "\n"
+      "  - num owned+ghosted ents: " << tag_nents << "\n"
+      "  - MV num ents: " << mv_nents << "\n");
 
   // Copy into tag. WARNING: tags have entity id striding slower, while the input mv makes
   // entity id stride faster (it's a 2d view with layout left)
-  Kokkos::RangePolicy<> policy(0,nents*ncmps);
+  Kokkos::RangePolicy<> policy(0,mv_nents*ncmps);
   auto tag_view = m_tags.at(name).array.view();
   auto lambda = KOKKOS_LAMBDA(int idx) {
-    int ient = idx % nents;
-    int icmp = idx / nents;
+    int ient = idx % mv_nents;
+    int icmp = idx / mv_nents;
     tag_view (ient*ncmps + icmp) = dev_mv(ient,icmp);
   };
   Kokkos::parallel_for(policy,lambda);
@@ -94,11 +126,9 @@ addStateStruct(const Teuchos::RCP<StateStruct>& st)
   switch(st->entity) {
     case StateStruct::NodalDistParameter:
       nodal_parameter_sis.push_back(st);
-      nodal_sis.push_back(st);
-      break;
+      [[fallthrough]];
     case StateStruct::NodalDataToElemNode:
       nodal_sis.push_back(st);
-      elem_sis.push_back(st);
       break;
     case StateStruct::ElemData:   [[fallthrough]];
     case StateStruct::ElemNode:   [[fallthrough]];
@@ -138,8 +168,8 @@ void OmegahMeshFieldAccessor::createStateArrays (const WorksetArray<int>& workse
     auto data = m_tags.at(st->name).array.data();
     auto dim = st->dim;
     int stride = 1;
+    dim[0] = 1; // We don't use the extent of the elem tag to compute stride
     for (auto d : dim) stride *= d;
-    stride /= dim[0];
 
     for (int ws=0; ws<num_ws; ++ws) {
       int num_elems = worksets_sizes[ws];
@@ -211,13 +241,12 @@ void OmegahMeshFieldAccessor::createStateArrays (const WorksetArray<int>& workse
 
 void OmegahMeshFieldAccessor::transferNodeStatesToElemStates ()
 {
-  int num_elems = m_mesh->nelems();
-  auto elem_nodes = m_mesh->ask_elem_verts();
-  auto elem_nodes_h = hostRead(elem_nodes);
-  int num_elem_nodes = elem_nodes.size() / num_elems;
+  int num_elems = OmegahGhost::getNumOwnedElms(*m_mesh);
+  auto elem_nodes_h = hostRead(OmegahGhost::getDownAdjacentEntsInClosureOfOwnedElms(*m_mesh, Omega_h::VERT));
+  int num_elem_nodes = Omega_h::element_degree(m_mesh->family(), m_mesh->dim(), 0);
 
   for (const auto& st : nodal_sis) {
-    if (st->entity!=StateStruct::NodalDataToElemNode)
+    if (st->entity==StateStruct::NodalData)
       continue;
     const auto& dim = st->dim;
     const auto rank = st->dim.size();
@@ -237,22 +266,30 @@ void OmegahMeshFieldAccessor::transferNodeStatesToElemStates ()
 
     auto& elem_state_h = elem_state.host();
     auto  node_state_h = hostRead(node_state);
+    
+    TEUCHOS_TEST_FOR_EXCEPTION (dim[1] != static_cast<size_t>(num_elem_nodes), std::runtime_error,
+        "Error! State struct dim[1] does not match actual num_elem_nodes.\n"
+        "  - state name: " + st->name + "\n"
+        "  - dim[1]: " << dim[1] << "\n"
+        "  - num_elem_nodes: " << num_elem_nodes << "\n");
+    
     for (int i=0; i<num_elems; ++i) {
       for (int j=0; j<num_elem_nodes; ++j) {
+        // elem_nodes_h uses omega_h LIDs; node_state_h is indexed by omega_h LID.
+        // Ghost node data is valid because sync_tag was called after loading fields.
+        auto node_lid = elem_nodes_h[i*num_elem_nodes+j];
         switch(rank) {
           case 2:
-            elem_state_h(i, j) = node_state_h[elem_nodes_h[i*num_elem_nodes+j]];
+            elem_state_h(i, j) = node_state_h[node_lid];
             break;
           case 3:
             for (size_t k=0; k<dim[2]; ++k) {
-              auto offset = i*num_elem_nodes*dim[2]+j*dim[2]+k;
-              elem_state_h(i, j, k) = node_state_h[elem_nodes_h[offset]];
+              elem_state_h(i, j, k) = node_state_h[node_lid*dim[2]+k];
             } break;
           case 4:
             for (size_t k=0; k<dim[2]; ++k) {
               for (size_t l=0; l<dim[3]; ++l) {
-                auto offset = i*num_elem_nodes*dim[2]*dim[3]+j*dim[2]*dim[3]+k*dim[3]+l;
-                elem_state_h(i, j, k, l) = node_state_h[elem_nodes_h[offset]];
+                elem_state_h(i, j, k, l) = node_state_h[node_lid*dim[2]*dim[3]+k*dim[3]+l];
               }
             } break;
         }

--- a/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
+++ b/src/disc/omegah/Albany_OmegahMeshFieldAccessor.cpp
@@ -241,9 +241,9 @@ void OmegahMeshFieldAccessor::createStateArrays (const WorksetArray<int>& workse
 
 void OmegahMeshFieldAccessor::transferNodeStatesToElemStates ()
 {
-  int num_elems = OmegahGhost::getNumOwnedElms(*m_mesh);
   auto elem_nodes_h = hostRead(OmegahGhost::getDownAdjacentEntsInClosureOfOwnedElms(*m_mesh, Omega_h::VERT));
   int num_elem_nodes = Omega_h::element_degree(m_mesh->family(), m_mesh->dim(), 0);
+  int num_ws = elemStateArrays.size();
 
   for (const auto& st : nodal_sis) {
     if (st->entity==StateStruct::NodalData)
@@ -251,51 +251,47 @@ void OmegahMeshFieldAccessor::transferNodeStatesToElemStates ()
     const auto& dim = st->dim;
     const auto rank = st->dim.size();
 
-    const auto& node_state = m_mesh->get_tag<ST>(0,st->name)->array();
-          auto& elem_state = elemStateArrays[0][st->name];
-    switch (rank) {
-      case 2:
-        elem_state.resize(st->name,num_elems,dim[1]); break;
-      case 3:
-        elem_state.resize(st->name,num_elems,dim[1],dim[2]); break;
-      case 4:
-        elem_state.resize(st->name,num_elems,dim[1],dim[2],dim[3]); break;
-      default:
-        throw std::runtime_error("Error! Unsupported rank for node state '" + st->name + "'.\n");
-    }
-
-    auto& elem_state_h = elem_state.host();
-    auto  node_state_h = hostRead(node_state);
-    
     TEUCHOS_TEST_FOR_EXCEPTION (dim[1] != static_cast<size_t>(num_elem_nodes), std::runtime_error,
         "Error! State struct dim[1] does not match actual num_elem_nodes.\n"
         "  - state name: " + st->name + "\n"
         "  - dim[1]: " << dim[1] << "\n"
         "  - num_elem_nodes: " << num_elem_nodes << "\n");
-    
-    for (int i=0; i<num_elems; ++i) {
-      for (int j=0; j<num_elem_nodes; ++j) {
-        // elem_nodes_h uses omega_h LIDs; node_state_h is indexed by omega_h LID.
-        // Ghost node data is valid because sync_tag was called after loading fields.
-        auto node_lid = elem_nodes_h[i*num_elem_nodes+j];
-        switch(rank) {
-          case 2:
-            elem_state_h(i, j) = node_state_h[node_lid];
-            break;
-          case 3:
-            for (size_t k=0; k<dim[2]; ++k) {
-              elem_state_h(i, j, k) = node_state_h[node_lid*dim[2]+k];
-            } break;
-          case 4:
-            for (size_t k=0; k<dim[2]; ++k) {
-              for (size_t l=0; l<dim[3]; ++l) {
-                elem_state_h(i, j, k, l) = node_state_h[node_lid*dim[2]*dim[3]+k*dim[3]+l];
-              }
-            } break;
+
+    const auto& node_state = m_mesh->get_tag<ST>(0,st->name)->array();
+    auto  node_state_h = hostRead(node_state);
+
+    int elem_offset = 0;
+    for (int ws=0; ws<num_ws; ++ws) {
+      auto& elem_state = elemStateArrays[ws][st->name];
+      auto& elem_state_h = elem_state.host();
+      int ws_num_elems = elem_state_h.extent(0);
+
+      for (int i=0; i<ws_num_elems; ++i) {
+        int global_elem_idx = elem_offset + i;
+        for (int j=0; j<num_elem_nodes; ++j) {
+          // elem_nodes_h uses omega_h LIDs; node_state_h is indexed by omega_h LID.
+          // Ghost node data is valid because sync_tag was called after loading fields.
+          auto node_lid = elem_nodes_h[global_elem_idx*num_elem_nodes+j];
+          switch(rank) {
+            case 2:
+              elem_state_h(i, j) = node_state_h[node_lid];
+              break;
+            case 3:
+              for (size_t k=0; k<dim[2]; ++k) {
+                elem_state_h(i, j, k) = node_state_h[node_lid*dim[2]+k];
+              } break;
+            case 4:
+              for (size_t k=0; k<dim[2]; ++k) {
+                for (size_t l=0; l<dim[3]; ++l) {
+                  elem_state_h(i, j, k, l) = node_state_h[node_lid*dim[2]*dim[3]+k*dim[3]+l];
+                }
+              } break;
+          }
         }
       }
+      elem_state.sync_to_dev();
+      elem_offset += ws_num_elems;
     }
-    elem_state.sync_to_dev();
   }
 }
 

--- a/src/disc/omegah/OmegahConnManager.cpp
+++ b/src/disc/omegah/OmegahConnManager.cpp
@@ -234,7 +234,7 @@ void setElementToEntDofConnectivityMask(const OmegahGenericMesh& albanyMesh, con
         for(int k=0; k<dofsPerEnt; k++) {
           const auto shardsAdjEntIdx = perm[j]; //use the omega_h to shards permutation to convert the omegah j index to shards
           const auto elmPartIdx = partEntIdx[elm];
-          const auto connIdx = (elmPartIdx*dofsPerElm)+(dofOffset+shardsAdjEntIdx+k);
+          const auto connIdx = (elmPartIdx*dofsPerElm)+(dofOffset+shardsAdjEntIdx*dofsPerEnt+k);
           assert(elm2dof.size() > connIdx and connIdx >= 0);
           elm2dof[connIdx] = maskArray[adjEnt];
         }
@@ -272,7 +272,7 @@ void setElementToEntDofConnectivity(OmegahGenericMesh& albanyMesh, const std::st
         for(int k=0; k<dofsPerEnt; k++) {
           const auto shardsAdjEntIdx = perm[j]; //use the omega_h to shards permutation to convert the omegah j index to shards
           const auto elmPartIdx = partEntIdx[elm];
-          const auto connIdx = (elmPartIdx*dofsPerElm)+(dofOffset+shardsAdjEntIdx+k);
+          const auto connIdx = (elmPartIdx*dofsPerElm)+(dofOffset+shardsAdjEntIdx*dofsPerEnt+k);
           assert(elm2dof.size() > connIdx and connIdx >= 0);
           const auto dofIndex = adjEnt*dofsPerEnt+k;
           const auto dofGlobalId = globalDofNumbering[dofIndex];

--- a/tests/unit/disc/omegah/OmegahDiscretization.cpp
+++ b/tests/unit/disc/omegah/OmegahDiscretization.cpp
@@ -63,6 +63,9 @@ TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_updateMesh_DOFManagers)
   auto mesh = createOmegahBoxMesh(teuchosComm);
   auto disc = createOmegahDiscretization(mesh, teuchosComm);
 
+  // Create solution MFA
+  disc->setFieldData();
+
   // Call updateMesh
   disc->updateMesh();
 
@@ -87,6 +90,9 @@ TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_updateMesh_Worksets)
 
   auto mesh = createOmegahBoxMesh(teuchosComm);
   auto disc = createOmegahDiscretization(mesh, teuchosComm);
+
+  // Create solution MFA
+  disc->setFieldData();
 
   // Call updateMesh
   disc->updateMesh();
@@ -122,6 +128,9 @@ TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_updateMesh_Coordinates)
   auto mesh = createOmegahBoxMesh(teuchosComm);
   auto disc = createOmegahDiscretization(mesh, teuchosComm);
 
+  // Create solution MFA
+  disc->setFieldData();
+
   // Call updateMesh
   disc->updateMesh();
 
@@ -148,9 +157,11 @@ TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_updateMesh_1D)
   auto mesh = createOmegahBoxMesh<1>(teuchosComm);
   auto disc = createOmegahDiscretization(mesh, teuchosComm);
 
+  // Create solution MFA
+  disc->setFieldData();
+
   // Call updateMesh
-  disc->updateMesh(); //FIXME hangs in parallel, see screenshot from totalview
-  // ~/develop/albanyOmegahAdaptHooks/throwingExceptionInUpdateMesh1d.png
+  disc->updateMesh();
 
   // Verify DOF managers were created
   auto sol_dof_mgr = disc->getDOFManager();

--- a/tests/unit/disc/omegah/OmegahDiscretization.cpp
+++ b/tests/unit/disc/omegah/OmegahDiscretization.cpp
@@ -20,16 +20,21 @@
 #include <Omega_h_for.hpp>
 #include <Omega_h_array_ops.hpp>
 
+#include <algorithm>
+
 #define REQUIRE(cond) \
   TEUCHOS_TEST_FOR_EXCEPTION (!(cond),std::runtime_error, \
       "Condition failed: " << #cond << "\n");
 
 template <size_t Dim = 2>
 Teuchos::RCP<Albany::OmegahGenericMesh>
-createOmegahBoxMesh(const Teuchos::RCP<const Teuchos_Comm>& comm) {
+createOmegahBoxMesh(const Teuchos::RCP<const Teuchos_Comm>& comm,
+                    const int worksetSize = -1) {
   auto pl = Teuchos::rcp(new Teuchos::ParameterList());
   pl->set("Mesh Creation Method","Box" + std::to_string(Dim) + "D");
   pl->set("Number of Elements",Teuchos::Array<int>(Dim,2));
+  if (worksetSize > 0)
+    pl->set("Workset Size", worksetSize);
   auto p = Teuchos::rcp(new Albany::OmegahGenericMesh(pl));
   return p;
 }
@@ -174,5 +179,137 @@ TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_updateMesh_1D)
   REQUIRE(1 == disc->getNumDim());
 
   out << "Testing OmegahDiscretization::updateMesh() for 1D mesh\n";
+  success = true;
+}
+
+// Helper: sum the number of side structs over all worksets for a given sideset name
+static int countSideSetEntries(const Albany::OmegahDiscretization& disc,
+                               const std::string& sideSetName)
+{
+  int total = 0;
+  int num_ws = disc.getNumWorksets();
+  for (int ws = 0; ws < num_ws; ++ws) {
+    const auto& ssl = disc.getSideSets(ws);
+    auto it = ssl.find(sideSetName);
+    if (it != ssl.end())
+      total += static_cast<int>(it->second.size());
+  }
+  return total;
+}
+
+// For the 2D box mesh, there are 4 boundary sidesets (one per side of the unit square).
+// Each sideset name matches one of SideSet0..SideSet3.
+static const std::vector<std::string> kExpected2DBoxSSNames = {
+  "SideSet0", "SideSet1", "SideSet2", "SideSet3"
+};
+// A 2x2 box mesh has 2 boundary edges per side of the unit square.
+static constexpr int kEdgesPerBoundarySide = 2;
+
+TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_computeSideSets_basic)
+{
+  auto teuchosComm = Albany::getDefaultComm();
+
+  // A 2D 2x2 box mesh has SideSet0..SideSet3 (one per boundary edge group).
+  auto mesh = createOmegahBoxMesh<2>(teuchosComm);
+  auto disc = createOmegahDiscretization(mesh, teuchosComm);
+
+  disc->setFieldData();
+  disc->updateMesh();  // internally calls computeSideSets()
+
+  const auto& ssNames = mesh->meshSpecs[0]->ssNames;
+  REQUIRE(ssNames.size() == kExpected2DBoxSSNames.size());
+
+  // Verify the expected sideset names are all present.
+  for (const auto& expected : kExpected2DBoxSSNames) {
+    auto it = std::find(ssNames.begin(), ssNames.end(), expected);
+    REQUIRE(it != ssNames.end());
+  }
+
+  int num_ws = disc->getNumWorksets();
+  REQUIRE(num_ws >= 1);
+
+  // Every workset must have an entry for every sideset name (possibly empty).
+  for (int ws = 0; ws < num_ws; ++ws) {
+    const auto& ssl = disc->getSideSets(ws);
+    for (const auto& ssn : ssNames) {
+      REQUIRE(ssl.count(ssn) == 1);
+    }
+  }
+
+  // For a 2D 2x2 simplex box (8 triangles), each of the 4 boundary edges
+  // belongs to exactly one SideSet. Count them per-sideset (globally summed).
+  // The boundary has 2 edges per side, so each sideset should have 2 entries.
+  // When running on multiple MPI ranks the owned-edge sets are disjoint but sum to 2.
+  int totalSides = 0;
+  for (const auto& ssn : ssNames) {
+    int localCount  = countSideSetEntries(*disc, ssn);
+    int globalCount = 0;
+    Teuchos::reduceAll(*teuchosComm, Teuchos::REDUCE_SUM, 1, &localCount, &globalCount);
+
+    // Each side of the 2x2 box has exactly 2 boundary edges.
+    REQUIRE(globalCount == kEdgesPerBoundarySide);
+    totalSides += globalCount;
+  }
+  // 4 sides x 2 edges each = 8 total boundary edges
+  REQUIRE(totalSides == static_cast<int>(kExpected2DBoxSSNames.size()) * kEdgesPerBoundarySide);
+
+  // Verify SideStruct fields are in valid ranges for every entry.
+  // A triangle has 3 sides, so side_pos must be in [0,2].
+  const int num_loc_sides = 3;  // triangle
+  for (int ws = 0; ws < num_ws; ++ws) {
+    const auto& ssl = disc->getSideSets(ws);
+    for (const auto& ssn : ssNames) {
+      for (const auto& s : ssl.at(ssn)) {
+        REQUIRE(s.elem_GID >= 0);
+        REQUIRE(s.side_GID >= 0);
+        REQUIRE(s.ws_elem_idx >= 0);
+        REQUIRE(s.side_pos  >= 0);
+        REQUIRE(s.side_pos   < num_loc_sides);
+        REQUIRE(s.elem_ebIndex == 0);
+      }
+    }
+  }
+
+  out << "Testing OmegahDiscretization::computeSideSets() basic correctness\n";
+  success = true;
+}
+
+TEUCHOS_UNIT_TEST(OmegahDiscTests, Discretization_computeSideSets_multiWorkset)
+{
+  auto teuchosComm = Albany::getDefaultComm();
+
+  // Force multiple worksets by setting workset size to 1.
+  // A 2x2 simplex box mesh has 8 triangles total (globally).
+  auto mesh = createOmegahBoxMesh<2>(teuchosComm, 1);
+  auto disc = createOmegahDiscretization(mesh, teuchosComm);
+
+  disc->setFieldData();
+  disc->updateMesh();
+
+  const auto& ssNames = mesh->meshSpecs[0]->ssNames;
+  REQUIRE(ssNames.size() == kExpected2DBoxSSNames.size());
+
+  int num_ws = disc->getNumWorksets();
+
+  // Every workset must contain an entry for every sideset name.
+  for (int ws = 0; ws < num_ws; ++ws) {
+    const auto& ssl = disc->getSideSets(ws);
+    for (const auto& ssn : ssNames) {
+      REQUIRE(ssl.count(ssn) == 1);
+    }
+  }
+
+  // The global side counts should be the same as in the single-workset case.
+  int totalSides = 0;
+  for (const auto& ssn : ssNames) {
+    int localCount  = countSideSetEntries(*disc, ssn);
+    int globalCount = 0;
+    Teuchos::reduceAll(*teuchosComm, Teuchos::REDUCE_SUM, 1, &localCount, &globalCount);
+    REQUIRE(globalCount == kEdgesPerBoundarySide);
+    totalSides += globalCount;
+  }
+  REQUIRE(totalSides == static_cast<int>(kExpected2DBoxSSNames.size()) * kEdgesPerBoundarySide);
+
+  out << "Testing OmegahDiscretization::computeSideSets() with multiple worksets\n";
   success = true;
 }


### PR DESCRIPTION
`transferNodeStatesToElemStates` wrote all element data into `elemStateArrays[0]` and incorrectly resized it to hold all owned elements, leaving worksets 1+ uninitialized. Add unit tests for `computeSideSets` which previously had no coverage.

## Changes

- **`Albany_OmegahMeshFieldAccessor.cpp`** — Fix `transferNodeStatesToElemStates`:
  - Remove incorrect per-state `resize` calls (`createStateArrays` already sizes each workset correctly)
  - Iterate over all worksets with a cumulative element offset, writing to `elemStateArrays[ws][st->name]` for each workset

  ```cpp
  // Before: only workset 0, wrong size
  auto& elem_state = elemStateArrays[0][st->name];
  elem_state.resize(st->name, num_elems, dim[1]);  // num_elems = ALL owned elems

  // After: all worksets, correct per-workset range
  int elem_offset = 0;
  for (int ws = 0; ws < num_ws; ++ws) {
    auto& elem_state = elemStateArrays[ws][st->name];
    int ws_num_elems = elem_state.host().extent(0);
    for (int i = 0; i < ws_num_elems; ++i) {
      int global_elem_idx = elem_offset + i;
      // ... fill from elem_nodes_h[global_elem_idx * ...]
    }
    elem_state.sync_to_dev();
    elem_offset += ws_num_elems;
  }
  ```

- **`tests/unit/disc/omegah/OmegahDiscretization.cpp`** — Add two `computeSideSets` tests using the 2D box mesh (which auto-creates `SideSet0`–`SideSet3`):
  - `Discretization_computeSideSets_basic`: verifies all 4 sideset names present, every workset has an entry per sideset, global side counts correct (2 boundary edges per sideset / 8 total), and all `SideStruct` fields in valid ranges
  - `Discretization_computeSideSets_multiWorkset`: same checks with workset size forced to 1 to exercise the multi-workset path