### PR TITLE
Replace libparmetis-dev with libscotchparmetis-dev

### DIFF
--- a/tools/containers/gcc-serial/Dockerfile
+++ b/tools/containers/gcc-serial/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update &&       \
         netcdf-bin          \
         libpnetcdf-dev      \
         libmetis-dev        \
-        libparmetis-dev
+        libscotchparmetis-dev
 
 # Create a bash goodies file, for users to load when manually running the container
 # Simply run 'source /opt/share/bash-goodies.sh' to get these


### PR DESCRIPTION
In late April, ubuntu:latest started to point to a new ubuntu distro "Resolute Raccoon" (it used to be "Questing Quokka"). According to Gemini:

> In newer Ubuntu releases, certain older libraries—especially those with restrictive licenses like ParMETIS—are often phased out in favor of open-source alternatives or integrated into other suites.

I don't think we're married to the original package, so I'm trying to just update to what apt is recommending in the podman build log:

> Package libparmetis-dev is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or is only available from another source
However the following packages replace it:
  libscotchparmetis-dev
