### PR TITLE
Restore libparmetis-dev package, but use login SHELL to enable multiverse repos

### DIFF
--- a/.github/workflows/build-containers.yml
+++ b/.github/workflows/build-containers.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Build image
         run: |
           cd albany/source/tools/containers/gcc-serial
-          podman build -f Dockerfile -t albany:gcc-12-serial
+          podman build --format docker -f Dockerfile -t albany:gcc-12-serial
       - name: Tag image
         run: |
           podman tag albany:gcc-12-serial ghcr.io/sandialabs/albany:gcc-12-serial

--- a/tools/containers/gcc-serial/Dockerfile
+++ b/tools/containers/gcc-serial/Dockerfile
@@ -4,6 +4,9 @@ LABEL maintainer="lbertag@sandia.gov"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Ensure all subsequent RUN commands use a login bash shell
+SHELL ["/bin/bash", "-l", "-c"]
+
 # Install basic utils
 RUN apt-get update &&   \
     apt-get install -y  \
@@ -43,7 +46,7 @@ RUN apt-get update &&       \
         netcdf-bin          \
         libpnetcdf-dev      \
         libmetis-dev        \
-        libscotchparmetis-dev
+        libparmetis-dev
 
 # Create a bash goodies file, for users to load when manually running the container
 # Simply run 'source /opt/share/bash-goodies.sh' to get these


### PR DESCRIPTION
Turns out the right thing to do for fixing the build-containers workflow was to ensure the multiverse repos were enabled.

I got puzzled when running the container manually i was able to install libparmetis-dev, while the podman build cmd couldn't. Turns out that it's b/c running manually we get a _login_ shell, where some apt setup cmd are run, enabling the multiverse repo, which is where libparmetis-dev has been moved (it wasn't removed completely).

I also switched our build cmd to use `--format docker`, so that it used docker metadata format rather than OCI; the latter does not recognize the SHELL cmd in the dockerfile, which allows to specify the type of shell to use during the build (in our case, login shell). I like setting SHELL b/c the result of the podman build should be _the same_ as you would get if you podman run the base image and manually run all the RUN cmd from inside the base image. With a non-login shell, the two can yield slightly different outcomes.

Once this is merged, I will run again the build-containers job. Once done, the gcc-12-serial image will be slightly different, as it will contain the SHELL metadata and will be have a docker-format manifesto. Anyone using it as base image (e.g., for the mali image) and building with podman will get the warning

```
WARN[0155] SHELL is not supported for OCI image format, [/bin/bash -l -c] will be ignored. Must use `docker` format 
```

To get rid of it, simply add `--format docker` to the podman build line. Anyone using Docker to build (instead of podman) will not get the warning in the first place...

Edit: I have manually triggered a build-containers [job](https://github.com/sandialabs/Albany/actions/runs/25685753681/job/75408914120) on this branch, so we can merge only if it indeed fixes the workflow...